### PR TITLE
fixed ToBits & optimized Ord

### DIFF
--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
@@ -1,12 +1,17 @@
 module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (
     isZeroC,
     invertC,
+    mappendC,
+    plusMultC,
 ) where
 
 import           Control.Monad.State                                 (State, execState)
 import           Data.Bool                                           (bool)
-import           Data.Map                                            (fromListWith, singleton)
+import           Data.List                                           (nub)
+import           Data.Map                                            (fromListWith, singleton, union)
 import           Prelude                                             hiding (negate, (+), (*))
+import qualified Prelude                                             as Haskell
+import           System.Random                                       (mkStdGen, uniform)
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Polynomials.Multivariate        (monomial, polynomial)
@@ -40,3 +45,32 @@ runInvert r = do
         constraint $ con' z
         assignment (invert $ eval r)
       )
+
+mappendC :: ArithmeticCircuit a -> ArithmeticCircuit a -> ArithmeticCircuit a
+mappendC r1 r2 = ArithmeticCircuit
+    {
+        acSystem   = acSystem r1 `union` acSystem r2,
+        -- NOTE: is it possible that we get a wrong argument order when doing `apply` because of this concatenation?
+        -- We need a way to ensure the correct order no matter how `(<>)` is used.
+        acInput    = nub $ acInput r1 ++ acInput r2,
+        acWitness  = \w -> acWitness r1 w `union` acWitness r2 w,
+        acOutput   = max (acOutput r1) (acOutput r2),
+        acVarOrder = acVarOrder r1 `union` acVarOrder r2,
+        acRNG      = mkStdGen $ fst (uniform (acRNG r1)) Haskell.* fst (uniform (acRNG r2))
+    }
+
+plusMultC :: (FiniteField a, Eq a, ToBits a) => ArithmeticCircuit a -> ArithmeticCircuit a -> ArithmeticCircuit a -> ArithmeticCircuit a
+-- ^ @plusMult a b c@ computes @a + b * c@ in one PLONK constraint.
+plusMultC a b c = flip execState (a `mappendC` b `mappendC` c) $ do
+    let x     = acOutput a
+        y     = acOutput b
+        z     = acOutput c
+        con w = polynomial [
+                    monomial one (singleton x one),
+                    monomial one (fromListWith (+) [(y, one), (z, one)]),
+                    monomial (negate one) (singleton w one)
+                ]
+    w <- newVariableFromConstraint con
+    addVariable w
+    constraint (con w)
+    assignment (eval a + eval b * eval c)

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -137,7 +137,7 @@ instance (FiniteField a, Eq a, ToBits a) => ToBits (ArithmeticCircuit a) where
                              monomial (negate one) (singleton b one)
                          ]
             (bits, x') = flip runState x . for [0 .. numberOfBits @a - 1] $ \i -> do
-                b <- newVariable
+                b <- newVariableWithSource [acOutput x] boolCon
                 addVariable b
                 assignment ((!! i) . repr)
                 constraint (boolCon b)

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -5,9 +5,11 @@
 
 module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Instance where
 
-import           Control.Monad.State                                    (MonadState (..), evalState, execState)
+import           Control.Monad.State                                    (MonadState (..), execState, runState)
 import           Data.Aeson
-import           Data.Map                                               hiding (drop,foldl,foldr, map, null, splitAt, take)
+import           Data.List                                              (foldl')
+import           Data.Map                                               hiding (drop, foldl, foldl', foldr, map, null, splitAt, take)
+import           Data.Traversable                                       (for)
 import           Prelude                                                hiding (Num (..), drop, length, product, splitAt, sum, take, (!!), (^))
 import           System.Random                                          (mkStdGen)
 import           Test.QuickCheck                                        (Arbitrary (..))
@@ -16,7 +18,7 @@ import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Polynomials.Multivariate           (monomial, polynomial)
 import           ZkFold.Prelude                                         ((!!))
 
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (invertC, mappendC)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (invertC, mappendC, plusMultC)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal
 import           ZkFold.Symbolic.Compiler.Arithmetizable                (Arithmetizable (..))
 
@@ -129,20 +131,28 @@ instance (FiniteField a, Eq a, ToBits a, FromConstant b a) => FromConstant b (Ar
 
 instance (FiniteField a, Eq a, ToBits a) => ToBits (ArithmeticCircuit a) where
     toBits x =
-        let two = one + one
-            ps  = map (two ^) [0.. numberOfBits @a - 1]
-            f z = flip evalState z $ mapM (\i -> do
-                    x' <- newVariable
-                    addVariable x'
-                    assignment ((!! i) . padBits (numberOfBits @a) . toBits . eval x)
-                    constraint $ polynomial [monomial one (singleton x' (one + one)), monomial (negate one) (singleton x' one)]
-                    get
-                ) [0.. numberOfBits @a - 1]
-            v z = z - sum (zipWith (*) (f z) ps)
-            y   = x { acRNG = acRNG (v x) }
-            bs  = map acOutput $ f y
-            r   = execState forceZero $ v y
-        in map (\x'' -> r { acOutput = x'' } ) bs
+        let repr       = padBits (numberOfBits @a) . toBits . eval x
+            boolCon b  = polynomial [
+                             monomial one (singleton b (one + one)),
+                             monomial (negate one) (singleton b one)
+                         ]
+            (bits, x') = flip runState x . for [0 .. numberOfBits @a - 1] $ \i -> do
+                b <- newVariable
+                addVariable b
+                assignment ((!! i) . repr)
+                constraint (boolCon b)
+                return b
+         in case bits of
+            []       -> []
+            (b : bs) -> let two         = one + one
+                            f (y, p) b' = (plusMultC y (x' { acOutput = b' }) p, p * two)
+                            (x'', _)    = foldl' f (x' { acOutput = b }, two) bs
+                            constrained = flip execState x'' $ constraint
+                                $ polynomial [
+                                      monomial one (singleton (acOutput x) one),
+                                      monomial (negate one) (singleton (acOutput x'') one)
+                                  ]
+                         in [ constrained { acOutput = b' } | b' <- b : bs ]
 
 -- TODO: make a proper implementation of Arbitrary
 instance (FiniteField a, Eq a, ToBits a) => Arbitrary (ArithmeticCircuit a) where

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -7,35 +7,23 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Instance where
 
 import           Control.Monad.State                                    (MonadState (..), evalState, execState)
 import           Data.Aeson
-import           Data.List                                              (nub)
 import           Data.Map                                               hiding (drop,foldl,foldr, map, null, splitAt, take)
 import           Prelude                                                hiding (Num (..), drop, length, product, splitAt, sum, take, (!!), (^))
-import qualified Prelude                                                as Haskell
-import           System.Random                                          (mkStdGen, uniform)
+import           System.Random                                          (mkStdGen)
 import           Test.QuickCheck                                        (Arbitrary (..))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Polynomials.Multivariate           (monomial, polynomial)
 import           ZkFold.Prelude                                         ((!!))
 
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (invertC)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (invertC, mappendC)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal
 import           ZkFold.Symbolic.Compiler.Arithmetizable                (Arithmetizable (..))
 
 ------------------------------------- Instances -------------------------------------
 
 instance Eq a => Semigroup (ArithmeticCircuit a) where
-    r1 <> r2 = ArithmeticCircuit
-        {
-            acSystem   = acSystem r1 `union` acSystem r2,
-            -- NOTE: is it possible that we get a wrong argument order when doing `apply` because of this concatenation?
-            -- We need a way to ensure the correct order no matter how `(<>)` is used.
-            acInput    = nub $ acInput r1 ++ acInput r2,
-            acWitness  = \w -> acWitness r1 w `union` acWitness r2 w,
-            acOutput   = max (acOutput r1) (acOutput r2),
-            acVarOrder = acVarOrder r1 `union` acVarOrder r2,
-            acRNG      = mkStdGen $ fst (uniform (acRNG r1)) Haskell.* fst (uniform (acRNG r2))
-        }
+    (<>) = mappendC
 
 instance (FiniteField a, Eq a) => Monoid (ArithmeticCircuit a) where
     mempty = ArithmeticCircuit

--- a/src/ZkFold/Symbolic/Data/Ord.hs
+++ b/src/ZkFold/Symbolic/Data/Ord.hs
@@ -54,9 +54,9 @@ instance (Prime p, Haskell.Ord x) => Ord (Bool (Zp p)) x where
 
     x >  y = Bool $ Haskell.bool zero one (x Haskell.>  y)
 
-    max x y = Haskell.bool y x $ x <= y
+    max x y = Haskell.bool x y $ x <= y
 
-    min x y = Haskell.bool y x $ x >= y
+    min x y = Haskell.bool x y $ x >= y
 
 -- | Every @Arithmetizable@ type can be compared lexicographically.
 instance Arithmetizable a x => Ord (Bool (ArithmeticCircuit a)) x where
@@ -68,9 +68,9 @@ instance Arithmetizable a x => Ord (Bool (ArithmeticCircuit a)) x where
 
     x >  y = bitCheckGT dorAnd $ zipWith (-) (getBitsBE @a x) (getBitsBE y)
 
-    max x y = bool @(Bool (ArithmeticCircuit a)) y x $ x < y
+    max x y = bool @(Bool (ArithmeticCircuit a)) x y $ x < y
 
-    min x y = bool @(Bool (ArithmeticCircuit a)) y x $ x > y
+    min x y = bool @(Bool (ArithmeticCircuit a)) x y $ x > y
 
 getBitsBE :: Arithmetizable a x => x -> [ArithmeticCircuit a]
 -- ^ @getBitsBE x@ returns a list of circuits computing bits of @x@, eldest to


### PR DESCRIPTION
* fixed `ToBits` circuit instance to properly generate bits
* introduced new `plusMult` combinator and impoved `checkBits` operation to optimize Ord circuit size
* fixed a bug in min/max definitions