### PR TITLE
Add polynomial substitution & Scale redesign

### DIFF
--- a/src/ZkFold/Base/Algebra/Basic/Class.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Class.hs
@@ -83,13 +83,13 @@ instance FromConstant a a where
     fromConstant = id
 
 -- Note: numbers should convert to Little-endian bit representation.
-class Semiring a => ToBits a where
-    toBits :: a -> [a]
+class Semiring a => BinaryExpansion a where
+    binaryExpansion :: a -> [a]
 
-class Semiring a => FromBits a where
-    fromBits :: [a] -> a
+    fromBinary :: [a] -> a
+    fromBinary = foldr (\x y -> x + y + y) zero
 
-padBits :: forall a . ToBits a => Integer -> [a] -> [a]
+padBits :: forall a . BinaryExpansion a => Integer -> [a] -> [a]
 padBits n xs = xs ++ replicate (n - length xs) zero
 
 castBits :: (Semiring a, Eq a, Semiring b) => [a] -> [b]
@@ -99,13 +99,21 @@ castBits (x:xs)
     | x == one  = one  : castBits xs
     | otherwise = error "castBits: impossible bit value"
 
-class (AdditiveMonoid a, Semiring b) => Scale a b where
+class (AdditiveMonoid a, Semiring b) => Scale a b | a -> b where
     scale :: b -> a -> a
 
 type Algebra a b = (Ring a, Scale a b)
 
 class (MultiplicativeMonoid a, Semiring b) => Exponent a b where
     (^) :: a -> b -> a
+
+instance (MultiplicativeMonoid a, Eq b, BinaryExpansion b) => Exponent a b where
+    a ^ n = product $ zipWith f (binaryExpansion n) (iterate (\x -> x * x) a)
+      where
+        f x y
+          | x == zero = one
+          | x == one  = y
+          | otherwise = error "^: This should never happen."
 
 multiExp :: (Exponent a b, Foldable t) => a -> t b -> a
 multiExp a = foldl (\x y -> x * (a ^ y)) one
@@ -143,28 +151,11 @@ instance MultiplicativeSemigroup Integer where
 instance MultiplicativeMonoid Integer where
     one = 1
 
-instance ToBits Integer where
-    toBits 0 = []
-    toBits x
-        | x > 0     = (x `mod` 2) : toBits (x `div` 2)
+instance BinaryExpansion Integer where
+    binaryExpansion 0 = []
+    binaryExpansion x
+        | x > 0     = (x `mod` 2) : binaryExpansion (x `div` 2)
         | otherwise = error "toBits: Not defined for negative integers!"
-
-instance FromBits Integer where
-    fromBits = foldl (\x y -> x * 2 + y) 0 . reverse
-
-instance AdditiveMonoid a => Scale a Integer where
-    scale n a = sum $ zipWith f (toBits n) (iterate (\x -> x + x) a)
-      where
-        f 0 _ = zero
-        f 1 y = y
-        f _ _ = error "scale: This should never happen."
-
-instance MultiplicativeMonoid a => Exponent a Integer where
-    a ^ n = product $ zipWith f (toBits n) (iterate (\x -> x * x) a)
-      where
-        f 0 _ = one
-        f 1 y = y
-        f _ _ = error "^: This should never happen."
 
 --------------------------------------------------------------------------------
 

--- a/src/ZkFold/Base/Algebra/Basic/Field.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Field.hs
@@ -67,17 +67,8 @@ instance Prime p => MultiplicativeGroup (Zp p) where
 instance Finite p => FromConstant Integer (Zp p) where
     fromConstant = toZp @p
 
-instance Finite p => ToBits (Zp p) where
-    toBits (Zp a) = map Zp $ toBits a
-
-instance Finite p => FromBits (Zp p) where
-    fromBits = toZp . fromBits . map fromZp
-
-instance (AdditiveMonoid a, Finite p) => Scale a (Zp p) where
-    scale (Zp n) = scale n
-
-instance (MultiplicativeMonoid a, Finite p) => Exponent a (Zp p) where
-    a ^ Zp n = a ^ n
+instance Prime p => BinaryExpansion (Zp p) where
+    binaryExpansion (Zp a) = map Zp $ binaryExpansion a
 
 instance Finite p => Haskell.Num (Zp p) where
     fromInteger = toZp @p
@@ -152,9 +143,6 @@ instance (Field f, Eq f, IrreduciblePoly f e) => MultiplicativeGroup (Ext2 f e) 
 instance (FromConstant f f', Field f') => FromConstant f (Ext2 f' e) where
     fromConstant e = Ext2 (fromConstant e) zero
 
-instance (Field f, ToBits f, Eq f, IrreduciblePoly f e) => ToBits (Ext2 f e) where
-    toBits (Ext2 a b) = map (`Ext2` zero) $ toBits a ++ toBits b
-
 instance ToByteString f => ToByteString (Ext2 f e) where
     toByteString (Ext2 a b) = toByteString a <> toByteString b
 
@@ -198,9 +186,6 @@ instance (Field f, Eq f, IrreduciblePoly f e) => MultiplicativeGroup (Ext3 f e) 
 
 instance (FromConstant f f', Field f') => FromConstant f (Ext3 f' ip) where
     fromConstant e = Ext3 (fromConstant e) zero zero
-
-instance (Field f, ToBits f, Eq f, IrreduciblePoly f e) => ToBits (Ext3 f e) where
-    toBits (Ext3 a b c) = map (\x -> Ext3 x zero zero) $ toBits a ++ toBits b ++ toBits c
 
 instance ToByteString f => ToByteString (Ext3 f e) where
     toByteString (Ext3 a b c) = toByteString a <> toByteString b <> toByteString c

--- a/src/ZkFold/Base/Algebra/Basic/Scale.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Scale.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DerivingStrategies #-}
+
+module ZkFold.Base.Algebra.Basic.Scale where
+
+import           Prelude                         hiding (sum, (*), (+))
+
+import           ZkFold.Base.Algebra.Basic.Class
+
+newtype BinScale b a = BinScale { runBinScale :: a }
+    deriving newtype (AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, MultiplicativeSemigroup, MultiplicativeMonoid)
+
+instance (AdditiveMonoid a, Eq b, BinaryExpansion b) => Scale (BinScale b a) b where
+    scale n a = sum $ zipWith f (binaryExpansion n) (iterate (\x -> x + x) a)
+      where
+        f x y
+          | x == zero = zero
+          | x == one  = y
+          | otherwise = error "scale: This should never happen."
+
+newtype Self a = Self { getSelf :: a }
+    deriving (Eq)
+    deriving newtype (AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, MultiplicativeSemigroup, MultiplicativeMonoid)
+
+instance Ring a => Scale (Self a) a where
+    scale a (Self b) = Self (a * b)

--- a/src/ZkFold/Base/Algebra/Polynomials/Multivariate.hs
+++ b/src/ZkFold/Base/Algebra/Polynomials/Multivariate.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators    #-}
+
 module ZkFold.Base.Algebra.Polynomials.Multivariate (
     module ZkFold.Base.Algebra.Polynomials.Multivariate.Polynomial,
     module ZkFold.Base.Algebra.Polynomials.Multivariate.Monomial,
@@ -8,6 +10,7 @@ module ZkFold.Base.Algebra.Polynomials.Multivariate (
     monomial,
     polynomial,
     evalPolynomial,
+    substitutePolynomial,
     variables
     ) where
 
@@ -17,7 +20,6 @@ import           Data.Maybe                      (fromJust)
 import           Prelude                         hiding (sum, (^), product, Num(..), (!!), length, replicate)
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Prelude                  ((!))
 
 import           ZkFold.Base.Algebra.Polynomials.Multivariate.Polynomial
 import           ZkFold.Base.Algebra.Polynomials.Multivariate.Monomial
@@ -37,12 +39,16 @@ monomial = M . fromJust . toMonomial
 polynomial :: Polynomial c i j => [(c, M i j (Map i j))] -> P c i j (Map i j) [(c, M i j (Map i j))]
 polynomial = sum . map (\m -> P [m]) . fromJust . toPolynomial
 
-evalMonomial :: forall i j m b . (FromMonomial i j m, Exponent b j) => M i j m -> Map i b -> b
-evalMonomial (M m) xs = product (map (\(i, j) -> (xs ! i)^j) (toList $ fromMonomial @i @j m))
+evalMonomial :: forall i j m b . (FromMonomial i j m, Exponent b j) => (i -> b) -> M i j m -> b
+evalMonomial f (M m) = product (map (\(i, j) -> f i ^ j) (toList $ fromMonomial @i @j m))
 
 evalPolynomial :: forall c i j m p b . (FromMonomial i j m, FromPolynomial c i j m p, Algebra b c, Exponent b j)
-    => P c i j m p -> Map i b -> b
-evalPolynomial (P p) xs = sum $ map (\(c, m) -> scale c (evalMonomial m xs)) (fromPolynomial @c @i @j @m @p p)
+    => (i -> b) -> P c i j m p -> b
+evalPolynomial f (P p) = sum $ map (\(c, m) -> scale c (evalMonomial f m)) (fromPolynomial @c @i @j @m @p p)
+
+substitutePolynomial :: forall c i i' j j' m m' p p' . (BinaryExpansion j, FromMonomial i j m, FromPolynomial c i j m p, FromPolynomial c i' j' m' p', m' ~ Map i' j', p' ~ [(c, M i' j' m')])
+    => (i -> P c i' j' m' p') -> P c i j m p -> P c i' j' m' p'
+substitutePolynomial = evalPolynomial
 
 variables :: forall c i j m p . (FromMonomial i j m, FromPolynomial c i j m p) => P c i j m p -> [i]
 variables (P p) = nubOrd $ concatMap (\(_, M m) -> keys (fromMonomial @i @j @m m)) $ fromPolynomial @c @i @j @m @p p

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
@@ -15,15 +15,10 @@ import           Data.Map                                               (singlet
 import           Prelude                                                hiding ((*), (-))
 
 import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Base.Algebra.Basic.Scale                        (Self(..))
 import           ZkFold.Base.Algebra.Polynomials.Multivariate           (monomial, polynomial)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal    hiding (Constraint, constraint)
 import qualified ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal    as I
-
-newtype Self a = Self { getSelf :: a }
-    deriving newtype (AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, MultiplicativeSemigroup, MultiplicativeMonoid)
-
-instance Ring a => Scale (Self a) a where
-    scale a (Self b) = Self (a * b)
 
 type Eval i a = (i -> a) -> a
 

--- a/src/ZkFold/Symbolic/Data/Ord.hs
+++ b/src/ZkFold/Symbolic/Data/Ord.hs
@@ -74,7 +74,7 @@ instance Arithmetizable a x => Ord (Bool (ArithmeticCircuit a)) x where
 getBitsBE :: Arithmetizable a x => x -> [ArithmeticCircuit a]
 -- ^ @getBitsBE x@ returns a list of circuits computing bits of @x@, eldest to
 -- youngest.
-getBitsBE x = concatMap (reverse . toBits) $ circuits $ arithmetize x
+getBitsBE x = concatMap (reverse . binaryExpansion) $ circuits $ arithmetize x
 
 dorAnd ::
   Arithmetic a =>

--- a/src/ZkFold/Symbolic/Types.hs
+++ b/src/ZkFold/Symbolic/Types.hs
@@ -2,12 +2,12 @@ module ZkFold.Symbolic.Types (Symbolic, I) where
 
 import           Prelude                          (Integer)
 
-import           ZkFold.Base.Algebra.Basic.Class  (FiniteField, FromConstant, ToBits)
+import           ZkFold.Base.Algebra.Basic.Class  (FiniteField, FromConstant, BinaryExpansion)
 import           ZkFold.Symbolic.Data.Bool        (Bool)
 import           ZkFold.Symbolic.Data.Conditional (Conditional)
 import           ZkFold.Symbolic.Data.Eq          (Eq)
 import           ZkFold.Symbolic.Data.Ord         (Ord)
 
-type Symbolic a = (FromConstant I a, FiniteField a, ToBits a, Eq (Bool a) a, Ord (Bool a) a, Conditional (Bool a) a)
+type Symbolic a = (FromConstant I a, FiniteField a, BinaryExpansion a, Eq (Bool a) a, Ord (Bool a) a, Conditional (Bool a) a)
 
 type I = Integer

--- a/tests/Tests/Plonk.hs
+++ b/tests/Tests/Plonk.hs
@@ -14,7 +14,8 @@ import           Tests.NonInteractiveProof                    (NonInteractivePro
 
 import           ZkFold.Base.Algebra.Basic.Class              (AdditiveSemigroup (..), AdditiveGroup (..), MultiplicativeSemigroup (..), Finite (..), zero, negate)
 import           ZkFold.Base.Algebra.Basic.Field              (fromZp)
-import           ZkFold.Base.Algebra.Polynomials.Multivariate 
+import           ZkFold.Base.Algebra.Basic.Scale              (Self(..))
+import           ZkFold.Base.Algebra.Polynomials.Multivariate
 import           ZkFold.Base.Algebra.Polynomials.Univariate   (toPolyVec, polyVecInLagrangeBasis, fromPolyVec, polyVecZero, polyVecLinear, evalPolyVec)
 import           ZkFold.Base.Protocol.ARK.Plonk
 import           ZkFold.Base.Protocol.ARK.Plonk.Internal      (fromPlonkConstraint, toPlonkConstaint, toPlonkArithmetization)
@@ -25,11 +26,11 @@ propPlonkConstraintConversion :: (F, F, F, F, F, F, F, F) -> (F, F, F) -> Bool
 propPlonkConstraintConversion x (x1, x2, x3) =
     let p   = fromPlonkConstraint x
         xs  = nubOrd $ variables p
-        v   = fromList [(head xs, x1), (xs !! 1, x2), (xs !! 2, x3)]
+        v   = Self . (fromList [(head xs, x1), (xs !! 1, x2), (xs !! 2, x3)] !)
         p'  = fromPlonkConstraint $ toPlonkConstaint p
         xs' = nubOrd $ variables p'
-        v'  = fromList [(head xs', x1), (xs' !! 1, x2), (xs' !! 2, x3)]
-    in p `evalPolynomial` v == p' `evalPolynomial` v'
+        v'  = Self . (fromList [(head xs', x1), (xs' !! 1, x2), (xs' !! 2, x3)] !)
+    in v `evalPolynomial` p == v' `evalPolynomial` p'
 
 propPlonkConstraintSatisfaction :: ParamsPlonk -> NonInteractiveProofTestData PlonkBS -> Bool
 propPlonkConstraintSatisfaction (ParamsPlonk _ _ _ inputs ac) (TestData _ _ w) =
@@ -42,7 +43,7 @@ propPlonkConstraintSatisfaction (ParamsPlonk _ _ _ inputs ac) (TestData _ _ w) =
         w2'     = map ((wmap wInput !) . fromZp) (fromPolyVec b)
         w3'     = map ((wmap wInput !) . fromZp) (fromPolyVec c)
         wPub    = take l (map negate $ elems inputs) ++ replicate (order @PlonkBS - l) zero
-        
+
         ql' = fromPolyVec ql
         qr' = fromPolyVec qr
         qo' = fromPolyVec qo

--- a/zkfold-base.cabal
+++ b/zkfold-base.cabal
@@ -66,6 +66,7 @@ library
       ZkFold.Base.Algebra.Basic.Field
       ZkFold.Base.Algebra.Basic.Number
       ZkFold.Base.Algebra.Basic.Permutations
+      ZkFold.Base.Algebra.Basic.Scale
       ZkFold.Base.Algebra.EllipticCurve.BLS12_381
       ZkFold.Base.Algebra.EllipticCurve.Class
       ZkFold.Base.Algebra.Polynomials.Multivariate


### PR DESCRIPTION
* `ToBits` and `FromBits` are now `BinaryExpansion`
* `Scale` has a fundep from `a` to `b`
* binary scaling and self scaling are now newtypes
* `Exponent` has a default instance for `BinaryExpansion` degrees
* added `substitutePolynomial`
* removed unlawful `BinaryExpansion` instances for field extensions
* added `BinaryExpansion` instance for `Arithmetizable`