### PR TITLE
Remove newSourced

### DIFF
--- a/src/ZkFold/Base/Algebra/Basic/Scale.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Scale.hs
@@ -19,7 +19,9 @@ instance (AdditiveMonoid a, Eq b, BinaryExpansion b) => Scale (BinScale b a) b w
 
 newtype Self a = Self { getSelf :: a }
     deriving (Eq)
-    deriving newtype (AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, MultiplicativeSemigroup, MultiplicativeMonoid)
+    deriving newtype (AdditiveSemigroup, AdditiveMonoid, AdditiveGroup,
+                      MultiplicativeSemigroup, MultiplicativeMonoid, MultiplicativeGroup,
+                      BinaryExpansion, Finite)
 
 instance Ring a => Scale (Self a) a where
     scale a (Self b) = Self (a * b)

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeApplications #-}
+
 module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (
     boolCheckC,
     isZeroC,
@@ -5,13 +7,15 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (
     plusMultC,
 ) where
 
-import           Data.Bool                                                 (bool)
-import           Prelude                                                   hiding (negate, (*), (+), (-))
+import           Prelude                                                   hiding (Bool, Eq (..), negate, (*), (+), (-))
 
 import           ZkFold.Base.Algebra.Basic.Class
 
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       (Arithmetic, ArithmeticCircuit)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint
+import           ZkFold.Symbolic.Data.Eq                                   (Eq(..))
+import           ZkFold.Symbolic.Data.Conditional                          (Conditional(..))
+import           ZkFold.Symbolic.Data.Bool                                 (Bool)
 
 boolCheckC :: Arithmetic a => ArithmeticCircuit a -> ArithmeticCircuit a
 -- ^ @boolCheckC r@ computes @r (r - 1)@ in one PLONK constraint.
@@ -25,12 +29,15 @@ isZeroC r = circuit $ fst <$> runInvert r
 invertC :: Arithmetic a => ArithmeticCircuit a -> ArithmeticCircuit a
 invertC r = circuit $ snd <$> runInvert r
 
-runInvert :: (Arithmetic a, MonadBlueprint i a m) => ArithmeticCircuit a -> m (i, i)
+runInvert :: MonadBlueprint i a m => ArithmeticCircuit a -> m (i, i)
 runInvert r = do
     i <- runCircuit r
-    j <- newConstrained (\x j -> x i * x j) (bool zero one . (== zero) . ($ i))
+    j <- newConstrained (\x j -> x i * x j) (isZero . ($ i))
     k <- newConstrained (\x k -> x i * x k + x j - one) (invert . ($ i))
     return (j, k)
+    where
+      isZero :: forall a b . WitnessField a b => a -> a
+      isZero x = bool @(Bool a) zero one (x == zero)
 
 plusMultC :: Arithmetic a => ArithmeticCircuit a -> ArithmeticCircuit a -> ArithmeticCircuit a -> ArithmeticCircuit a
 -- ^ @plusMult a b c@ computes @a + b * c@ in one PLONK constraint.

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -5,21 +5,26 @@
 
 module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Instance where
 
-import           Data.Aeson
-import           Data.Foldable                                             (foldl')
+import           Data.Aeson                                                hiding (Bool)
+import           Data.Foldable                                             (foldl', null)
 import           Data.Map                                                  hiding (drop, foldl, foldl', foldr, map, null, splitAt, take)
 import           Data.Traversable                                          (for)
-import           Prelude                                                   hiding (Num (..), drop, length, product, splitAt, sum, take, (!!), (^))
+import           Prelude                                                   (const, error, map, mempty, pure, return, reverse, show, zipWith, ($), (++), (.), (<$>), (<*>))
+import qualified Prelude                                                   as Haskell
 import           System.Random                                             (mkStdGen)
 import           Test.QuickCheck                                           (Arbitrary (..))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Prelude                                            ((!!))
 
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (invertC)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (invertC, isZeroC)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       hiding (constraint)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint(..), circuit, circuits)
 import           ZkFold.Symbolic.Compiler.Arithmetizable                   (Arithmetizable (..))
+import           ZkFold.Symbolic.Data.Bool
+import           ZkFold.Symbolic.Data.Conditional
+import           ZkFold.Symbolic.Data.DiscreteField
+import           ZkFold.Symbolic.Data.Eq
 
 ------------------------------------- Instances -------------------------------------
 
@@ -69,7 +74,7 @@ instance (Arithmetic a, FromConstant b a) => FromConstant b (ArithmeticCircuit a
     fromConstant c = circuit $ newAssigned $ const (fromConstant @b @a c `scale` one)
 
 instance Arithmetic a => BinaryExpansion (ArithmeticCircuit a) where
-    binaryExpansion r = if numberOfBits @a == 0 then [] else circuits $ do
+    binaryExpansion r = if numberOfBits @a Haskell.== 0 then [] else circuits $ do
         k <- runCircuit r
         let repr = padBits (numberOfBits @a) . binaryExpansion . ($ k)
         bits <- for [0 .. numberOfBits @a - 1] $ \j -> do
@@ -88,6 +93,42 @@ instance Arithmetic a => BinaryExpansion (ArithmeticCircuit a) where
                 j <- runCircuit b
                 newAssigned (\x -> x i + x i + x j)
 
+instance Arithmetic a => Arithmetizable a (Bool (ArithmeticCircuit a)) where
+    arithmetize (Bool b) = arithmetize b
+
+    restore [r] = Bool $ restore [r]
+    restore _   = error "SymbolicBool: invalid number of values"
+
+    typeSize = 1
+
+instance (Arithmetizable a x, Field x) => DiscreteField (Bool (ArithmeticCircuit a)) x where
+    isZero x = case circuits (arithmetize x) of
+      [] -> true
+      xs -> Bool $ product1 (map isZeroC xs)
+
+instance Arithmetizable a x => Eq (Bool (ArithmeticCircuit a)) x where
+    x == y =
+        let x' = circuits (arithmetize x)
+            y' = circuits (arithmetize y)
+            zs = zipWith (-) x' y'
+        in if null zs
+            then true
+            else all1 (isZero @(Bool (ArithmeticCircuit a)) @(ArithmeticCircuit a)) zs
+
+    x /= y =
+        let x' = circuits (arithmetize x)
+            y' = circuits (arithmetize y)
+            zs = zipWith (-) x' y'
+        in if null zs
+            then false
+            else not $ all1 (isZero @(Bool (ArithmeticCircuit a)) @(ArithmeticCircuit a)) zs
+
+instance Arithmetizable a x => Conditional (Bool (ArithmeticCircuit a)) x where
+    bool brFalse brTrue (Bool b) =
+        let f' = circuits (arithmetize brFalse)
+            t' = circuits (arithmetize brTrue)
+        in restore $ zipWith (\f t -> b * t + (one - b) * f) f' t'
+
 -- TODO: make a proper implementation of Arbitrary
 instance Arithmetic a => Arbitrary (ArithmeticCircuit a) where
     arbitrary = do
@@ -95,7 +136,7 @@ instance Arithmetic a => Arbitrary (ArithmeticCircuit a) where
         return ac
 
 -- TODO: make it more readable
-instance (FiniteField a, Eq a, Show a) => Show (ArithmeticCircuit a) where
+instance (FiniteField a, Haskell.Eq a, Haskell.Show a) => Haskell.Show (ArithmeticCircuit a) where
     show r = "ArithmeticCircuit { acSystem = " ++ show (acSystem r) ++ ", acInput = "
         ++ show (acInput r) ++ ", acOutput = " ++ show (acOutput r) ++ ", acVarOrder = " ++ show (acVarOrder r) ++ " }"
 

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE TypeApplications   #-}
 
 {-# OPTIONS_GHC -Wno-orphans    #-}
 
@@ -15,12 +16,15 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (
 import           Control.Monad.State                                    (State, gets, modify, runState)
 import           Data.Functor                                           (($>))
 import           Data.Map                                               (singleton, (!))
-import           Prelude                                                hiding (Bool (..), Eq (..), (*), (-))
+import           Data.Set                                               (Set)
+import qualified Data.Set                                               as Set
+import           Prelude                                                hiding (Bool (..), Eq (..), replicate, (*), (-))
 import qualified Prelude                                                as Haskell
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Scale                        (Self (..))
 import           ZkFold.Base.Algebra.Polynomials.Multivariate           (monomial, polynomial)
+import           ZkFold.Prelude                                         (replicate)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal    hiding (Constraint, constraint)
 import qualified ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal    as I
 import           ZkFold.Symbolic.Data.Bool                              (Bool (..), BoolType (..))
@@ -43,12 +47,9 @@ class (Ring a, Monad m) => MonadBlueprint i a m | m -> i, m -> a where
 
     runCircuit :: ArithmeticCircuit a -> m i
 
-    newSourced :: [i] -> NewConstraint i a -> Witness i a -> m i
+    newConstrained :: NewConstraint i a -> Witness i a -> m i
 
     constraint :: ClosedPoly i a -> m ()
-
-    newConstrained :: NewConstraint i a -> Witness i a -> m i
-    newConstrained = newSourced []
 
     newAssigned :: ClosedPoly i a -> m i
     newAssigned p = newConstrained (\x i -> p x - x i) p
@@ -60,14 +61,24 @@ instance Arithmetic a => MonadBlueprint Integer a (State (ArithmeticCircuit a)) 
 
     runCircuit r = modify (<> r) $> acOutput r
 
-    newSourced s c e = do
-        i <- newVariableWithSource s (c var)
+    newConstrained c e = do
+        let s = sources e `Set.difference` sources (`c` (-1))
+        i <- newVariableWithSource (Set.toList s) (c var)
         addVariable i
         constraint (`c` i)
         assignment (\m -> getSelf $ e (Self . (m !)))
         return i
 
     constraint p = I.constraint (p var)
+
+circuit :: Arithmetic a => (forall i m . MonadBlueprint i a m => m i) -> ArithmeticCircuit a
+circuit b = let (o, r) = runState b mempty in r { acOutput = o }
+
+circuits :: Arithmetic a => (forall i m . MonadBlueprint i a m => m [i]) -> [ArithmeticCircuit a]
+circuits b = let (os, r) = runState b mempty in [ r { acOutput = o } | o <- os ]
+
+var :: Arithmetic a => Integer -> I.Constraint a
+var x = polynomial [(one, monomial (singleton x one))]
 
 instance (FiniteField a, Haskell.Eq a) => Eq (Bool (Self a)) (Self a) where
     Self x == Self y = Bool . Self $ bool zero one (x Haskell.== y)
@@ -79,11 +90,44 @@ instance (FiniteField a, Haskell.Eq a) => Conditional (Bool (Self a)) (Self a) w
 instance (FiniteField a, Haskell.Eq a) => Conditional (Bool (Self a)) (Bool (Self a)) where
     bool x y b = if b Haskell.== true then y else x
 
-var :: Arithmetic a => Integer -> I.Constraint a
-var x = polynomial [(one, monomial (singleton x one))]
+sources :: forall i a . (FiniteField a, Ord i) => Witness i a -> Set i
+sources = runSources . ($ Sources @a . Set.singleton)
 
-circuit :: Arithmetic a => (forall i m . MonadBlueprint i a m => m i) -> ArithmeticCircuit a
-circuit b = let (o, r) = runState b mempty in r { acOutput = o }
+newtype Sources a i = Sources { runSources :: Set i } deriving newtype (Semigroup, Monoid)
 
-circuits :: Arithmetic a => (forall i m . MonadBlueprint i a m => m [i]) -> [ArithmeticCircuit a]
-circuits b = let (os, r) = runState b mempty in [ r { acOutput = o } | o <- os ]
+instance Ord i => AdditiveSemigroup (Sources a i) where
+  (+) = (<>)
+
+instance Ord i => AdditiveMonoid (Sources a i) where
+  zero = mempty
+
+instance Ord i => AdditiveGroup (Sources a i) where
+  negate = id
+
+instance (Semiring a, Ord i) => Scale (Sources a i) a where
+  scale = const id
+
+instance Finite a => Finite (Sources a i) where
+  order = order @a
+
+instance Ord i => MultiplicativeSemigroup (Sources a i) where
+  (*) = (<>)
+
+instance Ord i => MultiplicativeMonoid (Sources a i) where
+  one = mempty
+
+instance Ord i => MultiplicativeGroup (Sources a i) where
+  invert = id
+
+instance (Finite a, Ord i) => BinaryExpansion (Sources a i) where
+  binaryExpansion = replicate (numberOfBits @a)
+
+instance (Finite a, Ord i) => Eq (Bool (Sources a i)) (Sources a i) where
+  x == y = Bool (x <> y)
+  x /= y = Bool (x <> y)
+
+instance (Finite a, Ord i) => Conditional (Bool (Sources a i)) (Sources a i) where
+  bool x y (Bool b) = x <> y <> b
+
+instance (Finite a, Ord i) => Conditional (Bool (Sources a i)) (Bool (Sources a i)) where
+  bool (Bool x) (Bool y) (Bool b) = Bool (x <> y <> b)

--- a/src/ZkFold/Symbolic/Data/Bool.hs
+++ b/src/ZkFold/Symbolic/Data/Bool.hs
@@ -10,7 +10,6 @@ import           Prelude                         hiding (Num(..), Bool, (/), (&&
 import qualified Prelude                         as Haskell
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Symbolic.Compiler
 
 class BoolType b where
     true  :: b
@@ -59,11 +58,3 @@ all1 f = foldr1 (&&) . map f
 
 any :: BoolType b => (x -> b) -> [x] -> b
 any f = foldr ((||) . f) false
-
-instance Arithmetic a => Arithmetizable a (Bool (ArithmeticCircuit a)) where
-    arithmetize (Bool b) = arithmetize b
-
-    restore [r] = Bool $ restore [r]
-    restore _   = error "SymbolicBool: invalid number of values"
-
-    typeSize = 1

--- a/src/ZkFold/Symbolic/Data/Conditional.hs
+++ b/src/ZkFold/Symbolic/Data/Conditional.hs
@@ -7,7 +7,6 @@ import qualified Prelude                         as Haskell
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field (Zp)
-import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Data.Bool       (BoolType (..), Bool (..))
 
 class BoolType b => Conditional b a where
@@ -24,9 +23,3 @@ instance Conditional Haskell.Bool a where
 
 instance Prime p => Conditional (Bool (Zp p)) x where
     bool f t b = if b == true then t else f
-
-instance Arithmetizable a x => Conditional (Bool (ArithmeticCircuit a)) x where
-    bool brFalse brTrue (Bool b) =
-        let f' = circuits (arithmetize brFalse)
-            t' = circuits (arithmetize brTrue)
-        in restore $ zipWith (\f t -> b * t + (one - b) * f) f' t'

--- a/src/ZkFold/Symbolic/Data/DiscreteField.hs
+++ b/src/ZkFold/Symbolic/Data/DiscreteField.hs
@@ -6,8 +6,6 @@ import qualified Prelude                                                as Haske
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field                        (Zp)
-import           ZkFold.Symbolic.Compiler
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (isZeroC)
 import           ZkFold.Symbolic.Data.Bool                              (Bool (..), BoolType (..))
 
 class (BoolType b, Field a) => DiscreteField b a where
@@ -18,8 +16,3 @@ instance (Field a, Eq a) => DiscreteField Haskell.Bool a where
 
 instance (Prime p, Field x, Eq x) => DiscreteField (Bool (Zp p)) x where
     isZero = Bool . bool zero one . (== zero)
-
-instance (Arithmetizable a x, Field x) => DiscreteField (Bool (ArithmeticCircuit a)) x where
-    isZero x = case circuits (arithmetize x) of
-      [] -> true
-      xs -> Bool $ product1 (map isZeroC xs)

--- a/src/ZkFold/Symbolic/Data/Eq.hs
+++ b/src/ZkFold/Symbolic/Data/Eq.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
-
 module ZkFold.Symbolic.Data.Eq (
     Eq(..),
     elem
@@ -11,9 +9,7 @@ import qualified Prelude                                                as Haske
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field                        (Zp)
-import           ZkFold.Symbolic.Compiler
-import           ZkFold.Symbolic.Data.Bool                              (Bool (..), BoolType (..), all1, any)
-import           ZkFold.Symbolic.Data.DiscreteField
+import           ZkFold.Symbolic.Data.Bool                              (Bool (..), BoolType (..), any)
 
 class BoolType b => Eq b a where
     (==) :: a -> a -> b
@@ -27,23 +23,6 @@ instance Haskell.Eq a => Eq Haskell.Bool a where
 instance (Prime p, Haskell.Eq x) => Eq (Bool (Zp p)) x where
     x == y = Bool $ bool zero one (x Haskell.== y)
     x /= y = Bool $ bool zero one (x Haskell./= y)
-
-instance Arithmetizable a x => Eq (Bool (ArithmeticCircuit a)) x where
-    x == y =
-        let x' = circuits (arithmetize x)
-            y' = circuits (arithmetize y)
-            zs = zipWith (-) x' y'
-        in case zs of
-            [] -> true
-            _  -> all1 (isZero @(Bool (ArithmeticCircuit a)) @(ArithmeticCircuit a)) zs
-
-    x /= y =
-        let x' = circuits (arithmetize x)
-            y' = circuits (arithmetize y)
-            zs = zipWith (-) x' y'
-        in case zs of
-            [] -> false
-            _  -> not $ all1 (isZero @(Bool (ArithmeticCircuit a)) @(ArithmeticCircuit a)) zs
 
 elem :: Eq b a => a -> [a] -> b
 elem x = any (== x)


### PR DESCRIPTION
* pulled instances of internalized typeclasses to `ArithmeticCircuit/Instance.hs`
* created a new `WitnessField` constraint (which is a prime field, an algebra over some basic ring and which also supports internalized equality checks)
* witness arguments in `MonadBlueprint` are now expressions in an arbitrary `WitnessField`
* `newConstrained` in a `MonadBlueprint` instance now tracks sources of new variable thanks to witness being an expression
* removed `newSourced` in favor of `newConstrained`