### PR TITLE
UInt on multiple registers (draft)

### DIFF
--- a/src/ZkFold/Symbolic/Cardano/Types/Value.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/Value.hs
@@ -6,10 +6,10 @@ import           Prelude                         (Eq (..), ($), error, otherwise
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Symbolic.Compiler
-import           ZkFold.Symbolic.Data.UInt       (UInt32)
+import           ZkFold.Symbolic.Data.UInt       (UInt)
 import           ZkFold.Prelude                  (length, take, drop)
 
-newtype Value size x = Value [(x, x, UInt32 x)]
+newtype Value size x = Value [(x, x, UInt 32 x)]
 
 instance (Arithmetizable a x, Finite size) => Arithmetizable a (Value size x) where
     arithmetize (Value value) = do

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
@@ -5,7 +5,7 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (
     embed,
     expansion,
     splitExpansion,
-    gorner,
+    horner,
     isZeroC,
     invertC,
     plusMultC,
@@ -30,43 +30,55 @@ boolCheckC r = circuit $ do
     newAssigned (\x -> x i * (x i - one))
 
 embed :: Arithmetic a => a -> ArithmeticCircuit a
+-- ^ @embed c@ creates a new circuit with output forced to equal @c@.
 embed x = circuit $ newAssigned $ const (x `scale` one)
 
 expansion :: MonadBlueprint i a m => Integer -> i -> m [i]
+-- ^ @expansion n k@ computes a binary expansion of @k@ if it fits in @n@ bits.
 expansion n k = do
     bits <- bitsOf n k
-    k' <- gorner bits
+    k' <- horner bits
     constraint (\x -> x k - x k')
     return bits
 
 splitExpansion :: MonadBlueprint i a m => Integer -> Integer -> i -> m (i, i)
+-- ^ @splitExpansion n1 n2 k@ computes two values @(l, h)@ such that
+-- @k = 2^n1 h + l@, @l@ fits in @n1@ bits and @h@ fits in n2 bits (if such
+-- values exist).
 splitExpansion n1 n2 k = do
     bits <- bitsOf (n1 + n2) k
     let (lo, hi) = splitAt n1 bits
-    l <- gorner lo
-    h <- gorner hi
+    l <- horner lo
+    h <- horner hi
     constraint (\x -> x k - x l - scale ((one + one) ^ n1) (x h))
     return (l, h)
 
 bitsOf :: MonadBlueprint i a m => Integer -> i -> m [i]
+-- ^ @bitsOf n k@ creates @n@ bits and sets their witnesses equal to @n@ smaller
+-- bits of @k@.
 bitsOf n k = for [0 .. n - 1] $ \j ->
     newConstrained (\x i -> x i * (x i - one)) ((!! j) . repr . ($ k))
     where
         repr :: forall b . (BinaryExpansion b, Finite b) => b -> [b]
         repr = padBits (numberOfBits @b) . binaryExpansion
 
-gorner :: MonadBlueprint i a m => [i] -> m i
-gorner bits = case reverse bits of
+horner :: MonadBlueprint i a m => [i] -> m i
+-- ^ @horner [b0,...,bn]@ computes the sum @b0 + 2 b1 + ... + 2^n bn@ using
+-- Horner's scheme.
+horner bits = case reverse bits of
     []       -> newAssigned zero
     (b : bs) -> foldlM (\i j -> newAssigned (\x -> x i + x i + x j)) b bs
 
 isZeroC :: Arithmetic a => ArithmeticCircuit a -> ArithmeticCircuit a
+-- ^ Tests if output variable is zero.
 isZeroC r = circuit $ fst <$> runInvert r
 
 invertC :: Arithmetic a => ArithmeticCircuit a -> ArithmeticCircuit a
+-- ^ @invertC r@ Computes an inverse of @r@.
 invertC r = circuit $ snd <$> runInvert r
 
 runInvert :: MonadBlueprint i a m => ArithmeticCircuit a -> m (i, i)
+-- ^ @runInvert r@ computes both equal-to-zero bit and inverse value of r.
 runInvert r = do
     i <- runCircuit r
     j <- newConstrained (\x j -> x i * x j) (isZero . ($ i))

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
@@ -3,20 +3,25 @@
 module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (
     boolCheckC,
     embed,
+    expansion,
+    splitExpansion,
+    gorner,
     isZeroC,
     invertC,
     plusMultC,
 ) where
 
-import           Prelude                                                   hiding (Bool, Eq (..), negate, (*), (+), (-))
+import           Data.Foldable                                             (foldlM)
+import           Data.Traversable                                          (for)
+import           Prelude                                                   hiding (Bool, Eq (..), negate, splitAt, (!!), (*), (+), (-), (^))
 
 import           ZkFold.Base.Algebra.Basic.Class
-
+import           ZkFold.Prelude                                            (splitAt, (!!))
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       (Arithmetic, ArithmeticCircuit)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint
-import           ZkFold.Symbolic.Data.Eq                                   (Eq(..))
-import           ZkFold.Symbolic.Data.Conditional                          (Conditional(..))
 import           ZkFold.Symbolic.Data.Bool                                 (Bool)
+import           ZkFold.Symbolic.Data.Conditional                          (Conditional (..))
+import           ZkFold.Symbolic.Data.Eq                                   (Eq (..))
 
 boolCheckC :: Arithmetic a => ArithmeticCircuit a -> ArithmeticCircuit a
 -- ^ @boolCheckC r@ computes @r (r - 1)@ in one PLONK constraint.
@@ -26,6 +31,34 @@ boolCheckC r = circuit $ do
 
 embed :: Arithmetic a => a -> ArithmeticCircuit a
 embed x = circuit $ newAssigned $ const (x `scale` one)
+
+expansion :: MonadBlueprint i a m => Integer -> i -> m [i]
+expansion n k = do
+    bits <- bitsOf n k
+    k' <- gorner bits
+    constraint (\x -> x k - x k')
+    return bits
+
+splitExpansion :: MonadBlueprint i a m => Integer -> Integer -> i -> m (i, i)
+splitExpansion n1 n2 k = do
+    bits <- bitsOf (n1 + n2) k
+    let (lo, hi) = splitAt n1 bits
+    l <- gorner lo
+    h <- gorner hi
+    constraint (\x -> x k - x l - scale ((one + one) ^ n1) (x h))
+    return (l, h)
+
+bitsOf :: MonadBlueprint i a m => Integer -> i -> m [i]
+bitsOf n k = for [0 .. n - 1] $ \j ->
+    newConstrained (\x i -> x i * (x i - one)) ((!! j) . repr . ($ k))
+    where
+        repr :: forall b . (BinaryExpansion b, Finite b) => b -> [b]
+        repr = padBits (numberOfBits @b) . binaryExpansion
+
+gorner :: MonadBlueprint i a m => [i] -> m i
+gorner bits = case reverse bits of
+    []       -> newAssigned zero
+    (b : bs) -> foldlM (\i j -> newAssigned (\x -> x i + x i + x j)) b bs
 
 isZeroC :: Arithmetic a => ArithmeticCircuit a -> ArithmeticCircuit a
 isZeroC r = circuit $ fst <$> runInvert r

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -15,7 +15,7 @@ import           System.Random                                             (mkSt
 import           Test.QuickCheck                                           (Arbitrary (..))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embed, expansion, gorner, invertC, isZeroC)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embed, expansion, horner, invertC, isZeroC)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       hiding (constraint)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint (..), circuit, circuits)
 import           ZkFold.Symbolic.Compiler.Arithmetizable                   (Arithmetizable (..))
@@ -77,7 +77,7 @@ instance Arithmetic a => BinaryExpansion (ArithmeticCircuit a) where
             then []
             else circuits $ runCircuit r Haskell.>>= expansion (numberOfBits @a)
 
-    fromBinary bits = circuit $ for bits runCircuit Haskell.>>= gorner
+    fromBinary bits = circuit $ for bits runCircuit Haskell.>>= horner
 
 instance Arithmetic a => Arithmetizable a (Bool (ArithmeticCircuit a)) where
     arithmetize (Bool b) = arithmetize b

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -6,20 +6,18 @@
 module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Instance where
 
 import           Data.Aeson                                                hiding (Bool)
-import           Data.Foldable                                             (foldl', null)
+import           Data.Foldable                                             (null)
 import           Data.Map                                                  hiding (drop, foldl, foldl', foldr, map, null, splitAt, take)
 import           Data.Traversable                                          (for)
-import           Prelude                                                   (const, error, map, mempty, pure, return, reverse, show, zipWith, ($), (++), (.), (<$>), (<*>))
+import           Prelude                                                   (const, error, map, mempty, pure, return, show, zipWith, ($), (++), (<$>), (<*>))
 import qualified Prelude                                                   as Haskell
 import           System.Random                                             (mkStdGen)
 import           Test.QuickCheck                                           (Arbitrary (..))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Prelude                                            ((!!))
-
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embed, invertC, isZeroC)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embed, expansion, gorner, invertC, isZeroC)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       hiding (constraint)
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint(..), circuit, circuits)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint (..), circuit, circuits)
 import           ZkFold.Symbolic.Compiler.Arithmetizable                   (Arithmetizable (..))
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.Conditional
@@ -74,26 +72,12 @@ instance (Arithmetic a, FromConstant b a) => FromConstant b (ArithmeticCircuit a
     fromConstant c = embed (fromConstant c)
 
 instance Arithmetic a => BinaryExpansion (ArithmeticCircuit a) where
-    binaryExpansion r = if numberOfBits @a Haskell.== 0 then [] else circuits $ do
-        k <- runCircuit r
-        bits <- for [0 .. numberOfBits @a - 1] $ \j -> do
-            newConstrained (\x i -> x i * (x i - one)) ((!! j) . repr . ($ k))
-        outputs <- for bits output
-        k' <- runCircuit (fromBinary outputs)
-        constraint (\x -> x k - x k')
-        return bits
-        where
-          repr :: forall b . (BinaryExpansion b, Finite b) => b -> [b]
-          repr = padBits (numberOfBits @b) . binaryExpansion
+    binaryExpansion r =
+        if numberOfBits @a Haskell.== 0
+            then []
+            else circuits $ runCircuit r Haskell.>>= expansion (numberOfBits @a)
 
-    fromBinary bits =
-        case reverse bits of
-            [] -> zero
-            (b : bs) -> foldl' gorner b bs
-        where gorner s b = circuit $ do
-                i <- runCircuit s
-                j <- runCircuit b
-                newAssigned (\x -> x i + x i + x j)
+    fromBinary bits = circuit $ for bits runCircuit Haskell.>>= gorner
 
 instance Arithmetic a => Arithmetizable a (Bool (ArithmeticCircuit a)) where
     arithmetize (Bool b) = arithmetize b

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -2,83 +2,151 @@
 {-# LANGUAGE TypeApplications    #-}
 
 module ZkFold.Symbolic.Data.UInt (
-    UInt32(..)
+    UInt(..)
 ) where
 
-import           Data.Foldable                   (for_)
-import           Data.Traversable                (for)
-import           Prelude                         hiding ((^), Num(..), Bool(..), Ord(..), (/), (&&), (||), not, all, any)
+import           Control.Monad                                          (return, (>=>))
+import           Control.Monad.State                                    (StateT (..), runStateT)
+import           Data.Foldable                                          (find, foldrM, for_)
+import           Data.Map                                               (fromList, (!))
+import           Data.Maybe                                             (fromJust)
+import           Data.Proxy                                             (Proxy (..))
+import           Data.Ratio                                             ((%))
+import           Data.Traversable                                       (for, traverse)
+import           GHC.TypeNats                                           (KnownNat, Natural, natVal)
+import           Prelude                                                (Integer, const, error, flip, map, otherwise, zip, ($), (.))
+import qualified Prelude                                                as Haskell
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.Basic.Field (Zp)
+import           ZkFold.Base.Algebra.Basic.Field                        (Zp)
+import           ZkFold.Prelude                                         (length, replicate, splitAt)
 import           ZkFold.Symbolic.Compiler
-import           ZkFold.Symbolic.Data.Bool       (Bool(..))
-import           ZkFold.Symbolic.Data.Ord        (Ord(..))
-
-class IntType i x where
-    rangeCheck :: x -> x
-
-instance IntType i (Zp a) where
-    rangeCheck = id
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (expansion, splitExpansion)
 
 -- TODO (Issue #18): hide this constructor
--- TODO: change bytes to bits in the name
-newtype UInt32 x = UInt32 x
-    deriving (Show, Eq)
+newtype UInt (n :: Natural) x = UInt [x] -- ^ registers, in little-endian
+    deriving (Haskell.Show, Haskell.Eq)
 
 --------------------------------------------------------------------------------
 
-instance (AdditiveSemigroup (Zp a)) => AdditiveSemigroup (UInt32 (Zp a)) where
-    UInt32 x + UInt32 y = UInt32 $ rangeCheck @UInt32 $ x + y
+instance (Finite a, AdditiveSemigroup (Zp a), KnownNat n) => AdditiveSemigroup (UInt n (Zp a)) where
+    UInt x + UInt y
+        | numberOfRegisters @a @n Haskell.== 1 = UInt (x + y)
+        | otherwise = error "UInt: TODO"
 
-instance (AdditiveMonoid (Zp a)) => AdditiveMonoid (UInt32 (Zp a)) where
-    zero = UInt32 zero
+instance (Finite a, AdditiveMonoid (Zp a), KnownNat n) => AdditiveMonoid (UInt n (Zp a)) where
+    zero = UInt $ replicate (numberOfRegisters @a @n) zero
 
-instance (AdditiveGroup (Zp a)) => AdditiveGroup (UInt32 (Zp a)) where
-    UInt32 x - UInt32 y = UInt32 $ rangeCheck @UInt32 $ x - y
+instance (Finite a, AdditiveGroup (Zp a), KnownNat n) => AdditiveGroup (UInt n (Zp a)) where
+    UInt x - UInt y
+        | numberOfRegisters @a @n Haskell.== 1 = UInt (x - y)
+        | otherwise = error "UInt: TODO"
 
-    negate (UInt32 x) = UInt32 $ rangeCheck @UInt32 $ negate x
+    negate (UInt x) = UInt (map negate x)
 
-instance (MultiplicativeSemigroup (Zp a)) => MultiplicativeSemigroup (UInt32 (Zp a)) where
-    UInt32 x * UInt32 y = UInt32 $ rangeCheck @UInt32 $ x * y
+instance (Finite a, MultiplicativeSemigroup (Zp a), KnownNat n) => MultiplicativeSemigroup (UInt n (Zp a)) where
+    UInt x * UInt y
+        | numberOfRegisters @a @n Haskell.== 1 = UInt (x * y)
+        | otherwise = error "UInt: TODO"
 
-instance (MultiplicativeMonoid (Zp a)) => MultiplicativeMonoid (UInt32 (Zp a)) where
-    one = UInt32 one
+instance (Finite a, MultiplicativeMonoid (Zp a), KnownNat n) => MultiplicativeMonoid (UInt n (Zp a)) where
+    one = UInt $ one : replicate (numberOfRegisters @a @n - 1) zero
 
 --------------------------------------------------------------------------------
 
-instance Arithmetic a => IntType UInt32 (ArithmeticCircuit a) where
-    rangeCheck ac = circuit $ do
-        let two = one + one
-            Bool b = ac >= (two ^ (32 :: Integer))
-        i <- runCircuit b
-        constraint (\x -> x i)
+instance (Arithmetizable a x, KnownNat n) => Arithmetizable a (UInt n x) where
+    arithmetize (UInt cs) = for cs $ arithmetize >=> \case
+        [i] -> expansion (registerSize @a @n) i Haskell.>> return i
+        _ -> error "UInt: invalid number of circuits"
+
+    restore cs
+        | length cs Haskell.== numberOfRegisters @a @n = UInt $ map (restore . return) cs
+        | otherwise = error "UInt: invalid number of values"
+
+    typeSize = numberOfRegisters @a @n
+
+instance (Arithmetic a, KnownNat n) => AdditiveSemigroup (UInt n (ArithmeticCircuit a)) where
+    UInt x + UInt y = UInt $ circuits $ do
+        z <- newAssigned (const zero)
+        (zs, c) <- flip runStateT z $ traverse StateT (Haskell.zipWith fullAdder x y)
+        constraint ($ c)
+        return zs
+        where
+            fullAdder :: MonadBlueprint i a m => ArithmeticCircuit a -> ArithmeticCircuit a -> i -> m (i, i)
+            fullAdder xk yk c = do
+                i <- runCircuit xk
+                j <- runCircuit yk
+                s <- newAssigned (\w -> w i + w j + w c)
+                splitExpansion (registerSize @a @n) 1 s
+
+instance (Arithmetic a, KnownNat n) => AdditiveMonoid (UInt n (ArithmeticCircuit a)) where
+    zero = UInt $ replicate (numberOfRegisters @a @n) zero
+
+instance (Arithmetic a, KnownNat n) => AdditiveGroup (UInt n (ArithmeticCircuit a)) where
+    UInt cs - UInt ds = UInt $ circuits $ do
+        z <- newAssigned (const zero)
+        (zs, b) <- flip runStateT z $ traverse StateT (Haskell.zipWith fullSub cs ds)
+        constraint (\x -> x b - one)
+        return zs
+        where
+            fullSub :: MonadBlueprint i a m => ArithmeticCircuit a -> ArithmeticCircuit a -> i -> m (i, i)
+            fullSub xk yk b = do
+                let (t :: a) = (one + one) ^ registerSize @a @n - one
+                i <- runCircuit xk
+                j <- runCircuit yk
+                s <- newAssigned (\x -> x i - x j + x b + t `scale` one)
+                splitExpansion (registerSize @a @n) 1 s
+
+    negate (UInt cs) = UInt $ flip map cs $ \x -> circuit $ do
+        i <- runCircuit x
+        constraint ($ i)
         return i
 
-instance Arithmetizable a x => Arithmetizable a (UInt32 x) where
-    arithmetize (UInt32 a) = do
-        let cs = circuits (arithmetize a)
-        for_ cs $ runCircuit . rangeCheck @UInt32
-        for cs runCircuit
+instance (Arithmetic a, KnownNat n) => MultiplicativeSemigroup (UInt n (ArithmeticCircuit a)) where
+    UInt cs * UInt ds = UInt $ circuits $ do
+        is <- for cs runCircuit
+        js <- for ds runCircuit
+        let xs = fromList (zip [0..] is)
+            ys = fromList (zip [0..] js)
+            r  = numberOfRegisters @a @n
+        -- | es are pairwise products split according to target register
+        es <- for [0 .. r * 2 - 2] $ \i ->
+            for [Haskell.max 0 (i - r + 1) .. Haskell.min i (r - 1)] $ \j ->
+                newAssigned (\x -> x (xs ! j) * x (ys ! (i - j)))
+        -- | lo are pairwise products for answer, hi are overflow
+        let (lo, hi) = splitAt (numberOfRegisters @a @n) es
+        z <- newAssigned (const zero)
+        -- | ks are output registers, c is overflow
+        (ks, c) <- flip runStateT z $ for lo $ StateT . \zs c -> do
+            s <- foldrM (\i j -> newAssigned (\x -> x i + x j)) c zs
+            splitExpansion (registerSize @a @n) (maxOverflow @a @n) s
+        -- | all overflow should be zero
+        constraint ($ c)
+        for_ hi $ traverse (\i -> constraint ($ i))
+        return ks
 
-    restore [ac] = UInt32 $ restore [ac]
-    restore _   = error "UInt32: invalid number of values"
+instance (Arithmetic a, KnownNat n) => MultiplicativeMonoid (UInt n (ArithmeticCircuit a)) where
+    one = UInt $ one : replicate (numberOfRegisters @a @n - 1) zero
 
-    typeSize = 1
+--------------------------------------------------------------------------------
 
-instance Arithmetic a => AdditiveSemigroup (UInt32 (ArithmeticCircuit a)) where
-    UInt32 x + UInt32 y = UInt32 $ rangeCheck @UInt32 $ x + y
+maxOverflow :: forall a n . (Finite a, KnownNat n) => Integer
+maxOverflow = registerSize @a @n + Haskell.ceiling (log2 $ numberOfRegisters @a @n)
 
-instance Arithmetic a => AdditiveMonoid (UInt32 (ArithmeticCircuit a)) where
-    zero = UInt32 zero
+registerSize :: forall a n . (Finite a, KnownNat n) => Integer
+registerSize = Haskell.ceiling (toInteger @n % numberOfRegisters @a @n)
 
-instance Arithmetic a => AdditiveGroup (UInt32 (ArithmeticCircuit a)) where
-    UInt32 x - UInt32 y = UInt32 $ rangeCheck @UInt32 $ x - y
+numberOfRegisters :: forall a n . (Finite a, KnownNat n) => Integer
+numberOfRegisters = fromJust $ find (\c -> c * maxRegisterSize c Haskell.>= toInteger @n) [1 .. maxRegisterCount]
+    where
+        maxRegisterCount = 2 ^ bitLimit
+        bitLimit = Haskell.floor $ log2 (order @a)
+        maxRegisterSize regCount =
+            let maxAdded = Haskell.ceiling $ log2 regCount
+             in Haskell.floor $ (bitLimit - maxAdded) % (2 :: Integer)
 
-    negate (UInt32 x) = UInt32 $ rangeCheck @UInt32 $ negate x
+log2 :: Integer -> Haskell.Double
+log2 = Haskell.logBase 2 . Haskell.fromInteger
 
-instance Arithmetic a => MultiplicativeSemigroup (UInt32 (ArithmeticCircuit a)) where
-    UInt32 x * UInt32 y = UInt32 $ rangeCheck @UInt32 $ x * y
-
-instance Arithmetic a => MultiplicativeMonoid (UInt32 (ArithmeticCircuit a)) where
-    one = UInt32 one
+toInteger :: forall n . KnownNat n => Integer
+toInteger = Haskell.fromIntegral $ natVal (Proxy :: Proxy n)

--- a/tests/Tests/ArithmeticCircuit.hs
+++ b/tests/Tests/ArithmeticCircuit.hs
@@ -8,8 +8,8 @@ import           Data.Bool                                              (bool)
 import           Data.Map                                               (empty)
 import           Prelude                                                (IO, Show, String, flip, head, id, map, ($))
 import qualified Prelude                                                as Haskell
-import           Test.Hspec                                             (Spec, describe, hspec)
 import qualified Test.Hspec
+import           Test.Hspec                                             (Spec, describe, hspec)
 import           Test.QuickCheck
 
 import           ZkFold.Base.Algebra.Basic.Class
@@ -51,7 +51,7 @@ specArithmeticCircuit = hspec $ do
         it "checks isZero(0)" $
           let Bool (r :: ArithmeticCircuit a) = isZero (zero :: ArithmeticCircuit a)
            in withMaxSuccess 1 $ checkClosedCircuit r .&&. eval' r === one
-        it "computes binary expansion" $ withMaxSuccess 10 $ \(x :: a) ->
+        it "computes binary expansion" $ \(x :: a) ->
           let rs = binaryExpansion (embed x)
            in checkClosedCircuit (head rs) .&&. map eval' rs === padBits (numberOfBits @a) (binaryExpansion x)
         it "internalizes equality" $ \(x :: a) (y :: a) ->


### PR DESCRIPTION
* boosted `BinaryExpansion` performance by removing intermediate `output` operations
* made `UInt`'s bit width into parameter
* made `UInt`'s symbolic version to work on multiple registers