### PR TITLE
Add UInt implementation

### DIFF
--- a/examples/Examples/UInt.hs
+++ b/examples/Examples/UInt.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Examples.UInt (exampleUIntAdd, exampleUIntMul) where
+
+import           Data.Data                                   (Proxy (Proxy))
+import           Data.Function                               (($))
+import           Data.List                                   ((++))
+import           Data.String                                 (String)
+import           GHC.TypeNats                                (KnownNat, natVal)
+import           System.IO                                   (IO, putStrLn)
+import           Text.Show                                   (show)
+
+import           ZkFold.Base.Algebra.Basic.Class             (AdditiveSemigroup (..), MultiplicativeSemigroup (..), Semiring)
+import           ZkFold.Base.Algebra.Basic.Field             (Zp)
+import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
+import           ZkFold.Symbolic.Compiler                    (ArithmeticCircuit, compileIO)
+import           ZkFold.Symbolic.Data.UInt                   (UInt)
+
+exampleUIntAdd :: forall n . KnownNat n => IO ()
+exampleUIntAdd = makeExample @n "+" "add" (+)
+
+exampleUIntMul :: forall n . KnownNat n => IO ()
+exampleUIntMul = makeExample @n "*" "mul" (*)
+
+makeExample :: forall n . KnownNat n => String -> String -> (forall a . Semiring (UInt n a) => UInt n a -> UInt n a -> UInt n a) -> IO ()
+makeExample shortName name op = do
+    let n = show $ natVal (Proxy @n)
+    putStrLn $ "\nExample: (" ++ shortName ++ ") operation on UInt" ++ n
+    let file = "compiled_scripts/uint" ++ n ++ "_" ++ name ++ ".json"
+    compileIO @(Zp BLS12_381_Scalar) file (op @(ArithmeticCircuit (Zp BLS12_381_Scalar)))

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -1,23 +1,28 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Main where
 
+import           Examples.Conditional (exampleConditional)
+import           Examples.Eq          (exampleEq)
+import           Examples.Fibonacci   (exampleFibonacci)
+import           Examples.LEQ         (exampleLEQ)
+import           Examples.MiMCHash    (exampleMiMC)
+import           Examples.ReverseList (exampleReverseList)
+import           Examples.UInt        (exampleUIntAdd, exampleUIntMul)
 import           Prelude
-import           System.Directory       (createDirectoryIfMissing)
-
-import           Examples.Conditional   (exampleConditional)
-import           Examples.Eq            (exampleEq)
-import           Examples.Fibonacci     (exampleFibonacci)
-import           Examples.LEQ           (exampleLEQ)
-import           Examples.MiMCHash      (exampleMiMC)
-import           Examples.ReverseList   (exampleReverseList)
+import           System.Directory     (createDirectoryIfMissing)
 
 main :: IO ()
 main = do
     createDirectoryIfMissing True "compiled_scripts"
-    
+
     exampleReverseList
     exampleEq
     exampleFibonacci
     exampleMiMC
     exampleLEQ
     exampleConditional
-    
+    exampleUIntAdd @32
+    exampleUIntAdd @500
+    exampleUIntMul @32
+    exampleUIntMul @500

--- a/src/ZkFold/Symbolic/Cardano/Types/Value.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/Value.hs
@@ -2,14 +2,14 @@
 
 module ZkFold.Symbolic.Cardano.Types.Value where
 
-import           Prelude                         (Eq (..), ($), error, otherwise, concat, return, mapM, (++), map)
+import           Prelude                         (Eq (..), concat, error, map, mapM, otherwise, return, ($), (++))
 
 import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Prelude                  (drop, length, take)
 import           ZkFold.Symbolic.Compiler
-import           ZkFold.Symbolic.Data.UInt       (UInt32)
-import           ZkFold.Prelude                  (length, take, drop)
+import           ZkFold.Symbolic.Data.UInt       (UInt)
 
-newtype Value size x = Value [(x, x, UInt32 x)]
+newtype Value size x = Value [(x, x, UInt 32 x)]
 
 instance (Arithmetizable a x, Finite size) => Arithmetizable a (Value size x) where
     arithmetize (Value value) = do
@@ -26,3 +26,4 @@ instance (Arithmetizable a x, Finite size) => Arithmetizable a (Value size x) wh
         | otherwise = error "restore Value: wrong number of arguments"
 
     typeSize = 3 * order @size * typeSize @a @x
+

--- a/src/ZkFold/Symbolic/Cardano/Types/Value.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/Value.hs
@@ -1,29 +1,13 @@
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DerivingVia #-}
 
 module ZkFold.Symbolic.Cardano.Types.Value where
 
-import           Prelude                         (Eq (..), concat, error, map, mapM, otherwise, return, ($), (++))
-
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Prelude                  (drop, length, take)
+import           ZkFold.Base.Data.Vector         (Vector (Vector))
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Data.UInt       (UInt)
 
-newtype Value size x = Value [(x, x, UInt 32 x)]
+newtype Value size a = Value [(a, a, UInt 32 a)]
 
-instance (Arithmetizable a x, Finite size) => Arithmetizable a (Value size x) where
-    arithmetize (Value value) = do
-        value' <- mapM (\(p, s, n) -> do
-            p' <- arithmetize p
-            s' <- arithmetize s
-            n' <- arithmetize n
-            return $ p' ++ s' ++ n') value
-        return $ concat value'
-
-    restore value
-        | length value == typeSize @a @(Value size x) =
-            Value $ map (\i -> restore $ take (3 * typeSize @a @x) $ drop (3 * i * typeSize @a @x) value) [0..(order @size - 1)]
-        | otherwise = error "restore Value: wrong number of arguments"
-
-    typeSize = 3 * order @size * typeSize @a @x
-
+deriving via (Vector size (ArithmeticCircuit a, ArithmeticCircuit a, UInt 32 (ArithmeticCircuit a)))
+    instance (Arithmetic a, Finite size) => Arithmetizable a (Value size (ArithmeticCircuit a))

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -16,7 +16,7 @@ import           Test.QuickCheck                                           (Arbi
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Prelude                                            ((!!))
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embed, horner, invertC, isZeroC)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embed, expansion, horner, invertC, isZeroC)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       hiding (constraint)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint (..), circuit, circuits)
 import           ZkFold.Symbolic.Compiler.Arithmetizable                   (Arithmetizable (..))
@@ -73,17 +73,7 @@ instance (Arithmetic a, FromConstant b a) => FromConstant b (ArithmeticCircuit a
     fromConstant c = embed (fromConstant c)
 
 instance Arithmetic a => BinaryExpansion (ArithmeticCircuit a) where
-    binaryExpansion r = circuits $ do
-        k <- runCircuit r
-        bits <- for [0 .. numberOfBits @a - 1] $ \j -> do
-            newConstrained (\x i -> x i * (x i - one)) ((!! j) . repr . ($ k))
-        k' <- horner bits
-        constraint (\x -> x k - x k')
-        return bits
-        where
-          repr :: forall b . (BinaryExpansion b, Finite b) => b -> [b]
-          repr = padBits (numberOfBits @b) . binaryExpansion
-
+    binaryExpansion r = circuits $ runCircuit r >>= expansion (numberOfBits @a)
     fromBinary bits = circuit $ Haskell.traverse runCircuit bits >>= horner
 
 instance Arithmetic a => Arithmetizable a (Bool (ArithmeticCircuit a)) where

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -8,14 +8,12 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Instance where
 import           Data.Aeson                                                hiding (Bool)
 import           Data.Foldable                                             (null)
 import           Data.Map                                                  hiding (drop, foldl, foldl', foldr, map, null, splitAt, take)
-import           Data.Traversable                                          (for)
-import           Prelude                                                   (const, error, map, mempty, pure, return, show, zipWith, ($), (++), (.), (<$>), (<*>), (>>=))
+import           Prelude                                                   (const, error, map, mempty, pure, return, show, zipWith, ($), (++), (<$>), (<*>), (>>=))
 import qualified Prelude                                                   as Haskell
 import           System.Random                                             (mkStdGen)
 import           Test.QuickCheck                                           (Arbitrary (..))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Prelude                                            ((!!))
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embed, expansion, horner, invertC, isZeroC)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       hiding (constraint)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint (..), circuit, circuits)

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -5,80 +5,224 @@ module ZkFold.Symbolic.Data.UInt (
     UInt(..)
 ) where
 
-import           Data.Foldable                   (for_)
-import           Data.Traversable                (for)
-import           GHC.TypeNats                    (Natural)
-import           Prelude                         hiding (Bool (..), Num (..), Ord (..), all, any, not, (&&), (/), (^), (||))
+import           Control.Monad.State                                    (StateT (..))
+import           Data.Foldable                                          (find, foldr, foldrM, for_)
+import           Data.List                                              (map, unfoldr, zip, zipWith)
+import           Data.Map                                               (fromList, (!))
+import           Data.Maybe                                             (fromMaybe)
+import           Data.Proxy                                             (Proxy (..))
+import           Data.Ratio                                             ((%))
+import           Data.Traversable                                       (for, traverse)
+import           Data.Tuple                                             (swap)
+import           GHC.TypeNats                                           (KnownNat, Natural, natVal)
+import           Prelude                                                (Integer, error, flip, otherwise, return, ($), (++), (.), (>>=))
+import qualified Prelude                                                as Haskell
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.Basic.Field (Zp)
-import           ZkFold.Symbolic.Compiler
-import           ZkFold.Symbolic.Data.Bool       (Bool (..))
-import           ZkFold.Symbolic.Data.Ord        (Ord (..))
-
-class IntType i x where
-    rangeCheck :: x -> x
-
-instance IntType i (Zp a) where
-    rangeCheck = id
+import           ZkFold.Base.Algebra.Basic.Field                        (Zp, fromZp)
+import           ZkFold.Prelude                                         (length, replicate, splitAt)
+import           ZkFold.Symbolic.Compiler                               hiding (forceZero)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (expansion, splitExpansion)
 
 -- TODO (Issue #18): hide this constructor
-newtype UInt (n :: Natural) x = UInt x
-    deriving (Show, Eq)
+data UInt (n :: Natural) a = UInt ![a] !a
+    deriving (Haskell.Show, Haskell.Eq)
+
+instance (FromConstant Integer a, Finite a, AdditiveMonoid a, KnownNat n) => FromConstant Integer (UInt n a) where
+    fromConstant n
+        | n Haskell.< 0 = error "n is negative"
+        | otherwise =
+            let base = 2 ^ registerSize @a @n
+                redex = map fromConstant $ flip unfoldr n $ \case
+                    0 -> Haskell.Nothing
+                    x -> Haskell.Just (swap $ x `Haskell.divMod` base)
+                r = numberOfRegisters @a @n - 1
+            in case splitAt r redex of
+                (lo, [hi]) -> UInt lo hi
+                (lo, [])   -> UInt (lo ++ replicate (length lo - r) zero) zero
+                (_, _)     -> error "number is too big"
 
 --------------------------------------------------------------------------------
 
-instance (AdditiveSemigroup (Zp a)) => AdditiveSemigroup (UInt n (Zp a)) where
-    UInt x + UInt y = UInt $ rangeCheck @UInt $ x + y
+toInteger :: forall p n . (Finite p, KnownNat n) => UInt n (Zp p) -> Integer
+toInteger (UInt xs x) = foldr (\p y -> fromZp p + base * y) 0 (xs ++ [x])
+    where base = 2 ^ registerSize @p @n
 
-instance (AdditiveMonoid (Zp a)) => AdditiveMonoid (UInt n (Zp a)) where
-    zero = UInt zero
+instance (Finite p, KnownNat n) => AdditiveSemigroup (UInt n (Zp p)) where
+    x + y = fromConstant $ toInteger x + toInteger y
 
-instance (AdditiveGroup (Zp a)) => AdditiveGroup (UInt n (Zp a)) where
-    UInt x - UInt y = UInt $ rangeCheck @UInt $ x - y
+instance (Finite p, KnownNat n) => AdditiveMonoid (UInt n (Zp p)) where
+    zero = fromConstant (0 :: Integer)
 
-    negate (UInt x) = UInt $ rangeCheck @UInt $ negate x
+instance (Finite p, KnownNat n) => AdditiveGroup (UInt n (Zp p)) where
+    x - y = fromConstant $ toInteger x - toInteger y
+    negate = fromConstant . negate . toInteger
 
-instance (MultiplicativeSemigroup (Zp a)) => MultiplicativeSemigroup (UInt n (Zp a)) where
-    UInt x * UInt y = UInt $ rangeCheck @UInt $ x * y
+instance (Finite p, KnownNat n) => MultiplicativeSemigroup (UInt n (Zp p)) where
+    x * y = fromConstant $ toInteger x * toInteger y
 
-instance (MultiplicativeMonoid (Zp a)) => MultiplicativeMonoid (UInt n (Zp a)) where
-    one = UInt one
+instance (Finite p, KnownNat n) => MultiplicativeMonoid (UInt n (Zp p)) where
+    one = fromConstant (1 :: Integer)
 
 --------------------------------------------------------------------------------
 
-instance Arithmetic a => IntType UInt (ArithmeticCircuit a) where
-    rangeCheck ac = circuit $ do
-        let two = one + one
-            Bool b = ac >= (two ^ (32 :: Integer))
-        i <- runCircuit b
-        constraint (\x -> x i)
-        return i
+instance (Arithmetic a, KnownNat n) => Arithmetizable a (UInt n (ArithmeticCircuit a)) where
+    arithmetize (UInt as a) = for (as ++ [a]) runCircuit
 
-instance Arithmetizable a x => Arithmetizable a (UInt n x) where
-    arithmetize (UInt a) = do
-        let cs = circuits (arithmetize a)
-        for_ cs $ runCircuit . rangeCheck @UInt
-        for cs runCircuit
+    restore as = case splitAt (numberOfRegisters @a @n - 1) as of
+        (lo, [hi]) -> UInt lo hi
+        (_, _)     -> error "UInt: invalid number of values"
 
-    restore [ac] = UInt $ restore [ac]
-    restore _    = error "UInt32: invalid number of values"
+    typeSize = numberOfRegisters @a @n
 
-    typeSize = 1
+instance (Arithmetic a, KnownNat n) => AdditiveSemigroup (UInt n (ArithmeticCircuit a)) where
+    UInt [] x + UInt [] y = UInt [] $ circuit $ do
+        z <- runCircuit (x + y)
+        _ <- expansion (highRegisterSize @a @n) z
+        return z
 
-instance Arithmetic a => AdditiveSemigroup (UInt n (ArithmeticCircuit a)) where
-    UInt x + UInt y = UInt $ rangeCheck @UInt $ x + y
+    UInt (x : xs) z + UInt (y : ys) w =
+        let solve :: MonadBlueprint i a m => m [i]
+            solve = do
+                (i, j) <- runCircuit (x + y) >>= splitExpansion (registerSize @a @n) 1
+                (zs, c) <- flip runStateT j $ traverse StateT (zipWith fullAdder xs ys)
+                k <- fullAdded z w c
+                _ <- expansion (highRegisterSize @a @n) k
+                return (k : i : zs)
 
-instance Arithmetic a => AdditiveMonoid (UInt n (ArithmeticCircuit a)) where
-    zero = UInt zero
+            fullAdder :: MonadBlueprint i a m => ArithmeticCircuit a -> ArithmeticCircuit a -> i -> m (i, i)
+            fullAdder xk yk c = fullAdded xk yk c >>= splitExpansion (registerSize @a @n) 1
 
-instance Arithmetic a => AdditiveGroup (UInt n (ArithmeticCircuit a)) where
-    UInt x - UInt y = UInt $ rangeCheck @UInt $ x - y
+            fullAdded :: MonadBlueprint i a m => ArithmeticCircuit a -> ArithmeticCircuit a -> i -> m i
+            fullAdded xk yk c = do
+                i <- runCircuit xk
+                j <- runCircuit yk
+                newAssigned (\v -> v i + v j + v c)
 
-    negate (UInt x) = UInt $ rangeCheck @UInt $ negate x
+         in case circuits solve of
+            (hi : lo) -> UInt lo hi
+            []        -> error "UInt: unreachable"
 
-instance Arithmetic a => MultiplicativeSemigroup (UInt n (ArithmeticCircuit a)) where
-    UInt x * UInt y = UInt $ rangeCheck @UInt $ x * y
+    UInt _ _ + UInt _ _ = error "UInt: unreachable"
 
-instance Arithmetic a => MultiplicativeMonoid (UInt n (ArithmeticCircuit a)) where
-    one = UInt one
+instance (Arithmetic a, KnownNat n) => AdditiveMonoid (UInt n (ArithmeticCircuit a)) where
+    zero = UInt (replicate (numberOfRegisters @a @n - 1) zero) zero
+
+instance (Arithmetic a, KnownNat n) => AdditiveGroup (UInt n (ArithmeticCircuit a)) where
+    UInt [] x - UInt [] y = UInt [] $ circuit $ do
+        z <- runCircuit (x - y)
+        _ <- expansion (highRegisterSize @a @n) z
+        return z
+
+    UInt (x : xs) z - UInt (y : ys) w =
+        let t :: a
+            t = (one + one) ^ registerSize @a @n - one
+
+            solve :: MonadBlueprint i a m => m [i]
+            solve = do
+                i <- runCircuit x
+                j <- runCircuit y
+                s <- newAssigned (\v -> v i - v j + t `scale` one)
+                (k, b0) <- splitExpansion (registerSize @a @n) 1 s
+                (zs, b) <- flip runStateT b0 $ traverse StateT (zipWith fullSub xs ys)
+                i' <- runCircuit z
+                j' <- runCircuit w
+                s' <- newAssigned (\v -> v i' - v j' + v b)
+                _ <- expansion (highRegisterSize @a @n) s'
+                return (s' : k : zs)
+
+            fullSub :: MonadBlueprint i a m => ArithmeticCircuit a -> ArithmeticCircuit a -> i -> m (i, i)
+            fullSub xk yk b = do
+                i <- runCircuit xk
+                j <- runCircuit yk
+                s <- newAssigned (\v -> v i - v j + v b + t `scale` one)
+                splitExpansion (registerSize @a @n) 1 s
+
+         in case circuits solve of
+            (hi : lo) -> UInt lo hi
+            []        -> error "UInt: unreachable"
+
+    UInt _ _ - UInt _ _ = error "UInt: unreachable"
+
+    negate (UInt xs x) = UInt (map forceZero xs) (forceZero x)
+        where
+            forceZero r = circuit $ do
+                i <- runCircuit r
+                constraint ($ i)
+                return i
+
+instance (Arithmetic a, KnownNat n) => MultiplicativeSemigroup (UInt n (ArithmeticCircuit a)) where
+    UInt [] x * UInt [] y = UInt [] $ circuit $ do
+        z <- runCircuit (x * y)
+        _ <- expansion (highRegisterSize @a @n) z
+        return z
+
+    UInt (x : xs) z * UInt (y : ys) w =
+        let solve :: MonadBlueprint i a m => m [i]
+            solve = do
+                i <- runCircuit x
+                j <- runCircuit y
+                is <- for xs runCircuit
+                js <- for ys runCircuit
+                i' <- runCircuit z
+                j' <- runCircuit w
+                let cs = fromList $ zip [0..] (i : is ++ [i'])
+                    ds = fromList $ zip [0..] (j : js ++ [j'])
+                    r  = numberOfRegisters @a @n
+                -- single addend for lower register
+                q <- newAssigned (\v -> v i * v j)
+                -- multiple addends for middle registers
+                qs <- for [1 .. r - 2] $ \k ->
+                    for [0 .. k] $ \l ->
+                        newAssigned (\v -> v (cs ! l) * v (ds ! (k - l)))
+                -- lower register
+                (p, c) <- splitExpansion (registerSize @a @n) (registerSize @a @n) q
+                -- middle registers
+                (ps, c') <- flip runStateT c $ for qs $ StateT . \rs c' -> do
+                    s <- foldrM (\k l -> newAssigned (\v -> v k + v l)) c' rs
+                    splitExpansion (registerSize @a @n) (maxOverflow @a @n) s
+                -- high register
+                p' <- foldrM (\k l -> newAssigned (\v -> v l + v (cs ! k) * v (cs ! (r - 1 - k)))) c' [0 .. r - 1]
+                _ <- expansion (highRegisterSize @a @n) p'
+                -- all addends higher should be zero
+                for_ [r .. r * 2 - 2] $ \k ->
+                    for_ [k - r + 1 .. r - 1] $ \l ->
+                        constraint (\v -> v (cs ! l) * v (ds ! (k - l)))
+                return (p' : p : ps)
+
+         in case circuits solve of
+            (hi : lo) -> UInt lo hi
+            []        -> error "UInt: unreachable"
+
+    UInt _ _ * UInt _ _ = error "UInt: unreachable"
+
+instance (Arithmetic a, KnownNat n) => MultiplicativeMonoid (UInt n (ArithmeticCircuit a)) where
+    one | numberOfRegisters @a @n Haskell.== 1 = UInt [] one
+        | otherwise = UInt (one : replicate (numberOfRegisters @a @n - 2) zero) zero
+
+--------------------------------------------------------------------------------
+
+maxOverflow :: forall a n . (Finite a, KnownNat n) => Integer
+maxOverflow = registerSize @a @n + Haskell.ceiling (log2 $ numberOfRegisters @a @n)
+
+highRegisterSize :: forall a n . (Finite a, KnownNat n) => Integer
+highRegisterSize = getInteger @n - registerSize @a @n * (numberOfRegisters @a @n - 1)
+
+registerSize :: forall a n . (Finite a, KnownNat n) => Integer
+registerSize = Haskell.ceiling (getInteger @n % numberOfRegisters @a @n)
+
+numberOfRegisters :: forall a n . (Finite a, KnownNat n) => Integer
+numberOfRegisters = fromMaybe (error "too many bits, field is not big enough")
+    $ find (\c -> c * maxRegisterSize c Haskell.>= getInteger @n) [1 .. maxRegisterCount]
+    where
+        maxRegisterCount = 2 ^ bitLimit
+        bitLimit = Haskell.floor $ log2 (order @a)
+        maxRegisterSize regCount =
+            let maxAdded = Haskell.ceiling $ log2 regCount
+             in Haskell.floor $ (bitLimit - maxAdded) % (2 :: Integer)
+
+log2 :: Integer -> Haskell.Double
+log2 = Haskell.logBase 2 . Haskell.fromInteger
+
+getInteger :: forall n . KnownNat n => Integer
+getInteger = Haskell.fromIntegral $ natVal (Proxy :: Proxy n)

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -2,18 +2,19 @@
 {-# LANGUAGE TypeApplications    #-}
 
 module ZkFold.Symbolic.Data.UInt (
-    UInt32(..)
+    UInt(..)
 ) where
 
 import           Data.Foldable                   (for_)
 import           Data.Traversable                (for)
-import           Prelude                         hiding ((^), Num(..), Bool(..), Ord(..), (/), (&&), (||), not, all, any)
+import           GHC.TypeNats                    (Natural)
+import           Prelude                         hiding (Bool (..), Num (..), Ord (..), all, any, not, (&&), (/), (^), (||))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field (Zp)
 import           ZkFold.Symbolic.Compiler
-import           ZkFold.Symbolic.Data.Bool       (Bool(..))
-import           ZkFold.Symbolic.Data.Ord        (Ord(..))
+import           ZkFold.Symbolic.Data.Bool       (Bool (..))
+import           ZkFold.Symbolic.Data.Ord        (Ord (..))
 
 class IntType i x where
     rangeCheck :: x -> x
@@ -22,32 +23,31 @@ instance IntType i (Zp a) where
     rangeCheck = id
 
 -- TODO (Issue #18): hide this constructor
--- TODO: change bytes to bits in the name
-newtype UInt32 x = UInt32 x
+newtype UInt (n :: Natural) x = UInt x
     deriving (Show, Eq)
 
 --------------------------------------------------------------------------------
 
-instance (AdditiveSemigroup (Zp a)) => AdditiveSemigroup (UInt32 (Zp a)) where
-    UInt32 x + UInt32 y = UInt32 $ rangeCheck @UInt32 $ x + y
+instance (AdditiveSemigroup (Zp a)) => AdditiveSemigroup (UInt n (Zp a)) where
+    UInt x + UInt y = UInt $ rangeCheck @UInt $ x + y
 
-instance (AdditiveMonoid (Zp a)) => AdditiveMonoid (UInt32 (Zp a)) where
-    zero = UInt32 zero
+instance (AdditiveMonoid (Zp a)) => AdditiveMonoid (UInt n (Zp a)) where
+    zero = UInt zero
 
-instance (AdditiveGroup (Zp a)) => AdditiveGroup (UInt32 (Zp a)) where
-    UInt32 x - UInt32 y = UInt32 $ rangeCheck @UInt32 $ x - y
+instance (AdditiveGroup (Zp a)) => AdditiveGroup (UInt n (Zp a)) where
+    UInt x - UInt y = UInt $ rangeCheck @UInt $ x - y
 
-    negate (UInt32 x) = UInt32 $ rangeCheck @UInt32 $ negate x
+    negate (UInt x) = UInt $ rangeCheck @UInt $ negate x
 
-instance (MultiplicativeSemigroup (Zp a)) => MultiplicativeSemigroup (UInt32 (Zp a)) where
-    UInt32 x * UInt32 y = UInt32 $ rangeCheck @UInt32 $ x * y
+instance (MultiplicativeSemigroup (Zp a)) => MultiplicativeSemigroup (UInt n (Zp a)) where
+    UInt x * UInt y = UInt $ rangeCheck @UInt $ x * y
 
-instance (MultiplicativeMonoid (Zp a)) => MultiplicativeMonoid (UInt32 (Zp a)) where
-    one = UInt32 one
+instance (MultiplicativeMonoid (Zp a)) => MultiplicativeMonoid (UInt n (Zp a)) where
+    one = UInt one
 
 --------------------------------------------------------------------------------
 
-instance Arithmetic a => IntType UInt32 (ArithmeticCircuit a) where
+instance Arithmetic a => IntType UInt (ArithmeticCircuit a) where
     rangeCheck ac = circuit $ do
         let two = one + one
             Bool b = ac >= (two ^ (32 :: Integer))
@@ -55,30 +55,30 @@ instance Arithmetic a => IntType UInt32 (ArithmeticCircuit a) where
         constraint (\x -> x i)
         return i
 
-instance Arithmetizable a x => Arithmetizable a (UInt32 x) where
-    arithmetize (UInt32 a) = do
+instance Arithmetizable a x => Arithmetizable a (UInt n x) where
+    arithmetize (UInt a) = do
         let cs = circuits (arithmetize a)
-        for_ cs $ runCircuit . rangeCheck @UInt32
+        for_ cs $ runCircuit . rangeCheck @UInt
         for cs runCircuit
 
-    restore [ac] = UInt32 $ restore [ac]
-    restore _   = error "UInt32: invalid number of values"
+    restore [ac] = UInt $ restore [ac]
+    restore _    = error "UInt32: invalid number of values"
 
     typeSize = 1
 
-instance Arithmetic a => AdditiveSemigroup (UInt32 (ArithmeticCircuit a)) where
-    UInt32 x + UInt32 y = UInt32 $ rangeCheck @UInt32 $ x + y
+instance Arithmetic a => AdditiveSemigroup (UInt n (ArithmeticCircuit a)) where
+    UInt x + UInt y = UInt $ rangeCheck @UInt $ x + y
 
-instance Arithmetic a => AdditiveMonoid (UInt32 (ArithmeticCircuit a)) where
-    zero = UInt32 zero
+instance Arithmetic a => AdditiveMonoid (UInt n (ArithmeticCircuit a)) where
+    zero = UInt zero
 
-instance Arithmetic a => AdditiveGroup (UInt32 (ArithmeticCircuit a)) where
-    UInt32 x - UInt32 y = UInt32 $ rangeCheck @UInt32 $ x - y
+instance Arithmetic a => AdditiveGroup (UInt n (ArithmeticCircuit a)) where
+    UInt x - UInt y = UInt $ rangeCheck @UInt $ x - y
 
-    negate (UInt32 x) = UInt32 $ rangeCheck @UInt32 $ negate x
+    negate (UInt x) = UInt $ rangeCheck @UInt $ negate x
 
-instance Arithmetic a => MultiplicativeSemigroup (UInt32 (ArithmeticCircuit a)) where
-    UInt32 x * UInt32 y = UInt32 $ rangeCheck @UInt32 $ x * y
+instance Arithmetic a => MultiplicativeSemigroup (UInt n (ArithmeticCircuit a)) where
+    UInt x * UInt y = UInt $ rangeCheck @UInt $ x * y
 
-instance Arithmetic a => MultiplicativeMonoid (UInt32 (ArithmeticCircuit a)) where
-    one = UInt32 one
+instance Arithmetic a => MultiplicativeMonoid (UInt n (ArithmeticCircuit a)) where
+    one = UInt one

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -2,8 +2,7 @@
 
 module Main where
 
-import           Prelude                                     hiding (Bool, Num (..), Fractional(..), (==), length, take, drop, replicate)
-
+import           Prelude                                     hiding (Bool, Fractional (..), Num (..), drop, length, replicate, take, (==))
 import           Tests.ArithmeticCircuit                     (specArithmeticCircuit)
 import           Tests.Arithmetization                       (specArithmetization)
 import           Tests.Field                                 (specField)
@@ -14,6 +13,7 @@ import           Tests.Pairing                               (specPairing)
 import           Tests.Permutations                          (specPermutations)
 import           Tests.Plonk                                 (specPlonk)
 import           Tests.Scripts.LockedByTxId                  (specLockedByTxId)
+import           Tests.UInt                                  (specUInt)
 import           Tests.Univariate                            (specUnivariate)
 
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
@@ -26,6 +26,8 @@ import           ZkFold.Base.Protocol.Commitment.KZG         (KZG)
 main :: IO ()
 main = do
     specArithmeticCircuit @(Zp BLS12_381_Scalar)
+    specUInt @BLS12_381_Scalar @32
+    specUInt @BLS12_381_Scalar @500
 
     specLockedByTxId
 

--- a/tests/Tests/ArithmeticCircuit.hs
+++ b/tests/Tests/ArithmeticCircuit.hs
@@ -2,14 +2,14 @@
 {-# LANGUAGE IncoherentInstances #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Tests.ArithmeticCircuit (specArithmeticCircuit) where
+module Tests.ArithmeticCircuit (eval', it, specArithmeticCircuit) where
 
 import           Data.Bool                                              (bool)
 import           Data.Map                                               (empty)
 import           Prelude                                                (IO, Show, String, flip, head, id, map, ($))
 import qualified Prelude                                                as Haskell
-import           Test.Hspec                                             (Spec, describe, hspec)
 import qualified Test.Hspec
+import           Test.Hspec                                             (Spec, describe, hspec)
 import           Test.QuickCheck
 
 import           ZkFold.Base.Algebra.Basic.Class

--- a/tests/Tests/UInt.hs
+++ b/tests/Tests/UInt.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Tests.UInt (specUInt) where
+
+import           Control.Monad                   (return)
+import           Data.Data                       (Proxy (..))
+import           Data.Function                   (($))
+import           Data.List                       (map, (++))
+import           GHC.TypeNats                    (KnownNat, natVal)
+import           Prelude                         (Integer, div, show)
+import qualified Prelude                         as Haskell
+import           System.IO                       (IO)
+import           Test.Hspec                      (describe, hspec)
+import           Test.QuickCheck                 (Gen, chooseInteger, (===))
+import           Tests.ArithmeticCircuit         (eval', it)
+
+import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Base.Algebra.Basic.Field (Zp)
+import           ZkFold.Symbolic.Compiler        (ArithmeticCircuit)
+import           ZkFold.Symbolic.Data.UInt
+
+toss :: Integer -> Gen Integer
+toss x = chooseInteger (0, x)
+
+value :: forall a n . UInt n (ArithmeticCircuit a) -> UInt n a
+value (UInt xs x) = UInt (map eval' xs) (eval' x)
+
+specUInt :: forall p n . (Prime p, KnownNat n) => IO ()
+specUInt = hspec $ do
+    let n = Haskell.toInteger $ natVal (Proxy :: Proxy n)
+    describe ("UInt" ++ show n ++ " specification") $ do
+        it "Zp embeds Integer" $ do
+            x <- toss (2 ^ n - 1)
+            return $ toInteger @p @n (fromConstant x) === x
+        it "Integer embeds Zp" $ \(x :: UInt n (Zp p)) ->
+            fromConstant (toInteger x) === x
+        it "AC embeds Integer" $ do
+            x <- toss (2 ^ n - 1)
+            return $ value @(Zp p) @n (fromConstant x) === fromConstant x
+        it "adds correctly" $ do
+            x <- toss (2 ^ n - 1)
+            y <- toss (2 ^ n - 1 - x)
+            return $ value @(Zp p) @n (fromConstant x + fromConstant y)
+                === fromConstant x + fromConstant y
+        it "has zero" $ value @(Zp p) @n zero === zero
+        it "negates correctly" $ value @(Zp p) @n (negate zero) === negate zero
+        it "subtracts correctly" $ do
+            x <- toss (2 ^ n - 1)
+            y <- toss x
+            return $ value @(Zp p) @n (fromConstant x - fromConstant y)
+                === fromConstant x - fromConstant y
+        it "multiplies correctly" $ do
+            x <- toss (2 ^ n - 1)
+            y <- toss ((2 ^ n - 1) `div` x)
+            return $ value @(Zp p) @n (fromConstant x * fromConstant y)
+                === fromConstant x * fromConstant y
+        it "has one" $ value @(Zp p) @n one === one

--- a/zkfold-base.cabal
+++ b/zkfold-base.cabal
@@ -198,6 +198,7 @@ test-suite zkfold-base-examples
       Examples.MiMCHash
       Examples.MiMC.Constants
       Examples.ReverseList
+      Examples.UInt
     build-depends:
       base                          >= 4.9 && < 5,
       containers                                 ,

--- a/zkfold-base.cabal
+++ b/zkfold-base.cabal
@@ -175,6 +175,7 @@ test-suite zkfold-base-test
       Tests.Permutations
       Tests.Plonk
       Tests.Scripts.LockedByTxId
+      Tests.UInt
       Tests.Univariate
     build-depends:
       base                          >= 4.9 && < 5,


### PR DESCRIPTION
* made `UInt32` into `UInt` generic over bit width
* implemented correct, optimal circuits for computations with `UInt`
* added tests for `UInt` circuits
* simplified `Arithmetizable` instance of `Cardano.Types.Value`
* added helpful blueprint combinators for binary decomposition