### PR TITLE
+ newtype wrappers for Eq and Ord deriving

### DIFF
--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -6,7 +6,6 @@
 module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Instance where
 
 import           Data.Aeson                                                hiding (Bool)
-import           Data.Foldable                                             (null)
 import           Data.Map                                                  hiding (drop, foldl, foldl', foldr, map, null, splitAt, take)
 import           Prelude                                                   (const, error, map, mempty, pure, return, show, zipWith, ($), (++), (<$>), (<*>), (>>=))
 import qualified Prelude                                                   as Haskell
@@ -87,22 +86,9 @@ instance (Arithmetizable a x, Field x) => DiscreteField (Bool (ArithmeticCircuit
       [] -> true
       xs -> Bool $ product1 (map isZeroC xs)
 
-instance Arithmetizable a x => Eq (Bool (ArithmeticCircuit a)) x where
-    x == y =
-        let x' = circuits (arithmetize x)
-            y' = circuits (arithmetize y)
-            zs = zipWith (-) x' y'
-        in if null zs
-            then true
-            else all1 (isZero @(Bool (ArithmeticCircuit a)) @(ArithmeticCircuit a)) zs
-
-    x /= y =
-        let x' = circuits (arithmetize x)
-            y' = circuits (arithmetize y)
-            zs = zipWith (-) x' y'
-        in if null zs
-            then false
-            else not $ all1 (isZero @(Bool (ArithmeticCircuit a)) @(ArithmeticCircuit a)) zs
+instance Arithmetic a => Eq (Bool (ArithmeticCircuit a)) (ArithmeticCircuit a) where
+    x == y = isZero (x - y)
+    x /= y = not $ isZero (x - y)
 
 instance Arithmetizable a x => Conditional (Bool (ArithmeticCircuit a)) x where
     bool brFalse brTrue (Bool b) =

--- a/src/ZkFold/Symbolic/Data/Eq/Structural.hs
+++ b/src/ZkFold/Symbolic/Data/Eq/Structural.hs
@@ -1,0 +1,28 @@
+module ZkFold.Symbolic.Data.Eq.Structural where
+
+import           Data.Function             (id)
+import           Data.List                 (null, zipWith)
+
+import           ZkFold.Symbolic.Compiler
+import           ZkFold.Symbolic.Data.Bool
+import           ZkFold.Symbolic.Data.Eq
+
+newtype Structural a = Structural a
+-- ^ A newtype wrapper for easy definition of Eq instances.
+
+instance Arithmetizable a x => Eq (Bool (ArithmeticCircuit a)) (Structural x) where
+    Structural x == Structural y =
+        let x' = circuits (arithmetize x) :: [ArithmeticCircuit a]
+            y' = circuits (arithmetize y)
+            zs = zipWith (==) x' y'
+         in if null zs
+              then true
+              else all1 id zs
+
+    Structural x /= Structural y =
+        let x' = circuits (arithmetize x) :: [ArithmeticCircuit a]
+            y' = circuits (arithmetize y)
+            zs = zipWith (==) x' y'
+         in if null zs
+              then false
+              else not (all1 id zs)

--- a/zkfold-base.cabal
+++ b/zkfold-base.cabal
@@ -132,6 +132,7 @@ library
       ZkFold.Symbolic.Data.Conditional
       ZkFold.Symbolic.Data.DiscreteField
       ZkFold.Symbolic.Data.Eq
+      ZkFold.Symbolic.Data.Eq.Structural
       ZkFold.Symbolic.Data.Ord
       ZkFold.Symbolic.Data.UInt
       ZkFold.Symbolic.GroebnerBasis


### PR DESCRIPTION
Added newtype wrappers for deriving Eq and Ord instances in Symbolic instead of forcing a single (not necessarily the most effective) instance.