### PR TITLE
fix Bool field instances

### DIFF
--- a/src/ZkFold/Base/Algebra/Basic/Class.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Class.hs
@@ -160,7 +160,7 @@ instance BinaryExpansion Integer where
 --------------------------------------------------------------------------------
 
 instance AdditiveSemigroup Bool where
-    (+) = (||)
+    (+) = (/=)
 
 instance AdditiveMonoid Bool where
     zero = False


### PR DESCRIPTION
Replace `or` with `xor` in `AdditiveSemigroup Bool` instance as otherwise group laws are not satisfied