### PR TITLE
Add naturals

### DIFF
--- a/examples/Examples/MiMCHash.hs
+++ b/examples/Examples/MiMCHash.hs
@@ -1,8 +1,10 @@
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Examples.MiMCHash (exampleMiMC) where
 
-import           Prelude                                     hiding ((||), not, Num(..), Eq(..), (^), (/), (!!), any)
+import           Examples.MiMC.Constants                     (mimcConstants)
+import           Numeric.Natural                             (Natural)
+import           Prelude                                     hiding (Eq (..), Num (..), any, not, (!!), (/), (^), (||))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
@@ -12,15 +14,13 @@ import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Data.Conditional            (bool)
 import           ZkFold.Symbolic.Types                       (Symbolic)
 
-import           Examples.MiMC.Constants                     (mimcConstants)
-
 -- | MiMC hash function
-mimcHash :: forall a . Symbolic a => Integer -> a -> a -> a -> a
-mimcHash nRounds k xL xR = 
+mimcHash :: forall a . Symbolic a => Natural -> a -> a -> a -> a
+mimcHash nRounds k xL xR =
     let c  = mimcConstants !! (nRounds-1)
         t5 = (xL + k + c) ^ (5 :: Integer)
     in bool (xR + t5) (mimcHash (nRounds-1) k (xR + t5) xL) (nRounds > 1)
-          
+
 exampleMiMC :: IO ()
 exampleMiMC = do
     let nRounds = 220
@@ -29,3 +29,4 @@ exampleMiMC = do
     putStrLn "\nExample: MiMC hash function\n"
 
     compileIO @(Zp BLS12_381_Scalar) file (mimcHash @(ArithmeticCircuit (Zp BLS12_381_Scalar)) nRounds zero)
+

--- a/examples/Examples/UInt.hs
+++ b/examples/Examples/UInt.hs
@@ -11,7 +11,7 @@ import           GHC.TypeNats                                (KnownNat, natVal)
 import           System.IO                                   (IO, putStrLn)
 import           Text.Show                                   (show)
 
-import           ZkFold.Base.Algebra.Basic.Class             (AdditiveSemigroup (..), MultiplicativeSemigroup (..), Semiring)
+import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
 import           ZkFold.Symbolic.Compiler                    (ArithmeticCircuit, compileIO)
@@ -23,7 +23,9 @@ exampleUIntAdd = makeExample @n "+" "add" (+)
 exampleUIntMul :: forall n . KnownNat n => IO ()
 exampleUIntMul = makeExample @n "*" "mul" (*)
 
-makeExample :: forall n . KnownNat n => String -> String -> (forall a . Semiring (UInt n a) => UInt n a -> UInt n a -> UInt n a) -> IO ()
+makeExample ::
+    forall n . KnownNat n => String -> String ->
+    (forall a . (AdditiveMonoid (UInt n a), MultiplicativeMonoid (UInt n a)) => UInt n a -> UInt n a -> UInt n a) -> IO ()
 makeExample shortName name op = do
     let n = show $ natVal (Proxy @n)
     putStrLn $ "\nExample: (" ++ shortName ++ ") operation on UInt" ++ n

--- a/src/ZkFold/Base/Algebra/Basic/Class.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Class.hs
@@ -146,7 +146,9 @@ instance AdditiveMonoid Natural where
     zero = 0
 
 instance AdditiveGroup Natural where
+    -- | @negate x@ is defined only if $(x = 0$), so this is not a lawful instance.
     negate = Haskell.negate
+    -- | @x - y@ is defined only if $(x \ge y$), so this is not a lawful instance.
     (-) = (Haskell.-)
 
 instance MultiplicativeSemigroup Natural where
@@ -186,6 +188,7 @@ instance Semiring Integer
 instance Ring Integer
 
 instance BinaryExpansion Integer where
+    -- | @binaryExpansion x@ is defined only if $(x \ge 0$), so this is not a lawful instance.
     binaryExpansion = map fromConstant . binaryExpansion . naturalFromInteger
 
 --------------------------------------------------------------------------------

--- a/src/ZkFold/Base/Algebra/Basic/Field.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Field.hs
@@ -10,11 +10,12 @@ module ZkFold.Base.Algebra.Basic.Field (
     Ext3(..)
     ) where
 
-import           Data.Aeson                        (ToJSON (..), FromJSON (..))
-import           Prelude                           hiding (Num(..), Fractional(..), length, (^))
-import qualified Prelude                           as Haskell
-import           System.Random                     (Random (..))
-import           Test.QuickCheck                   hiding (scale)
+import           Data.Aeson                                 (FromJSON (..), ToJSON (..))
+import           Numeric.Natural                            (Natural)
+import           Prelude                                    hiding (Fractional (..), Num (..), length, (^))
+import qualified Prelude                                    as Haskell
+import           System.Random                              (Random (..))
+import           Test.QuickCheck                            hiding (scale)
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Polynomials.Univariate
@@ -67,6 +68,11 @@ instance Prime p => MultiplicativeGroup (Zp p) where
 
 instance Finite p => FromConstant Integer (Zp p) where
     fromConstant = toZp @p
+
+instance Finite p => FromConstant Natural (Zp p) where
+    fromConstant = toZp @p . fromConstant
+
+instance Finite p => Semiring (Zp p)
 
 instance Finite p => Ring (Zp p)
 
@@ -155,6 +161,8 @@ instance (Field f, Eq f, IrreduciblePoly f e) => MultiplicativeGroup (Ext2 f e) 
 instance (FromConstant f f', Field f') => FromConstant f (Ext2 f' e) where
     fromConstant e = Ext2 (fromConstant e) zero
 
+instance (Field f, Eq f, IrreduciblePoly f e) => Semiring (Ext2 f e)
+
 instance (Field f, Eq f, IrreduciblePoly f e) => Ring (Ext2 f e)
 
 instance ToByteString f => ToByteString (Ext2 f e) where
@@ -200,6 +208,8 @@ instance (Field f, Eq f, IrreduciblePoly f e) => MultiplicativeGroup (Ext3 f e) 
 
 instance (FromConstant f f', Field f') => FromConstant f (Ext3 f' ip) where
     fromConstant e = Ext3 (fromConstant e) zero zero
+
+instance (Field f, Eq f, IrreduciblePoly f e) => Semiring (Ext3 f e)
 
 instance (Field f, Eq f, IrreduciblePoly f e) => Ring (Ext3 f e)
 

--- a/src/ZkFold/Base/Algebra/Basic/Permutations.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Permutations.hs
@@ -10,43 +10,44 @@ module ZkFold.Base.Algebra.Basic.Permutations (
     fromCycles
 ) where
 
-import           Data.Map                         (Map, empty, union, elems, singleton)
-import           Data.Maybe                       (fromJust)
-import           Prelude                          hiding (Num(..), (!!), length, drop)
-import           Test.QuickCheck                  (Arbitrary (..), choose)
+import           Data.Map                        (Map, elems, empty, singleton, union)
+import           Data.Maybe                      (fromJust)
+import           Numeric.Natural                 (Natural)
+import           Prelude                         hiding (Num (..), drop, length, (!!))
+import           Test.QuickCheck                 (Arbitrary (..))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Data.Vector          (Vector(..), toVector, fromVector)
-import           ZkFold.Prelude                   ((!!), length, elemIndex, drop)
+import           ZkFold.Base.Data.Vector         (Vector (..), fromVector, toVector)
+import           ZkFold.Prelude                  (chooseNatural, drop, elemIndex, length, (!!))
 
 -- TODO (Issue #18): make the code safer
 
 ------------------------------ Index sets and partitions -------------------------------------
 
-type IndexSet = [Integer]
-type IndexPartition = Map Integer IndexSet
+type IndexSet = [Natural]
+type IndexPartition a = Map a IndexSet
 
-mkIndexPartition :: [Integer] -> IndexPartition
+mkIndexPartition :: Ord a => [a] -> IndexPartition a
 mkIndexPartition vs =
     let f i = singleton i $ map snd $ filter (\(v, _) -> v == i) $ zip vs [1 .. length vs]
     in foldl union empty $ map f vs
 
 ------------------------------------- Permutations -------------------------------------------
 
-newtype Permutation n = Permutation (Vector n Integer)
+newtype Permutation n = Permutation (Vector n Natural)
     deriving (Show, Eq)
 
 instance Finite n => Arbitrary (Permutation n) where
     arbitrary =
         let f as [] = return as
             f as bs = do
-                i <- choose (0, length bs - 1)
+                i <- chooseNatural (0, length bs - 1)
                 let as' = (bs !! i) : as
                     bs' = drop i bs
                 f as' bs'
         in Permutation . Vector <$> f [] [1..order @n]
 
-fromPermutation :: Permutation n -> [Integer]
+fromPermutation :: Permutation n -> [Natural]
 fromPermutation (Permutation perm) = fromVector perm
 
 applyPermutation :: Permutation n -> Vector n a -> Vector n a
@@ -55,12 +56,13 @@ applyPermutation (Permutation (Vector ps)) (Vector as) = Vector $ map (as !!) ps
 applyCycle :: IndexSet -> Permutation n -> Permutation n
 applyCycle c (Permutation perm) = Permutation $ fmap f perm
     where
-        f :: Integer -> Integer
+        f :: Natural -> Natural
         f i = case i `elemIndex` c of
             Just j  -> c !! ((j + 1) `mod` length c)
             Nothing -> i
 
-fromCycles :: Finite n => IndexPartition -> Permutation n
+fromCycles :: Finite n => IndexPartition a -> Permutation n
 fromCycles p =
     let n = length $ concat $ elems p
     in foldr applyCycle (Permutation $ fromJust $ toVector [1 .. n]) $ elems p
+

--- a/src/ZkFold/Base/Algebra/Basic/Scale.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Scale.hs
@@ -11,6 +11,8 @@ newtype BinScale b a = BinScale { runBinScale :: a }
 
 deriving newtype instance FromConstant c a => FromConstant c (BinScale b a)
 
+deriving newtype instance Semiring a => Semiring (BinScale b a)
+
 deriving newtype instance Ring a => Ring (BinScale b a)
 
 instance (AdditiveMonoid a, Eq b, BinaryExpansion b) => Scale (BinScale b a) b where
@@ -28,6 +30,8 @@ newtype Self a = Self { getSelf :: a }
                       BinaryExpansion, Finite)
 
 deriving newtype instance FromConstant c a => FromConstant c (Self a)
+
+deriving newtype instance Semiring a => Semiring (Self a)
 
 deriving newtype instance Ring a => Ring (Self a)
 

--- a/src/ZkFold/Base/Algebra/EllipticCurve/BLS12_381.hs
+++ b/src/ZkFold/Base/Algebra/EllipticCurve/BLS12_381.hs
@@ -2,9 +2,10 @@
 
 module ZkFold.Base.Algebra.EllipticCurve.BLS12_381 where
 
-import           Data.Bits                         (shiftR)
-import           Data.List                         (unfoldr)
-import           Prelude                           hiding (Num(..), (/), (^))
+import           Data.Bits                                  (shiftR)
+import           Data.List                                  (unfoldr)
+import           Numeric.Natural                            (Natural)
+import           Prelude                                    hiding (Num (..), (/), (^))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field
@@ -156,10 +157,10 @@ miller' p q r (i:iters) result =
 pairingBLS :: Point BLS12_381_G1 -> Point BLS12_381_G2 -> BLS12_381_GT
 pairingBLS Inf _ = zero
 pairingBLS _ Inf = zero
-pairingBLS p q = pow' (miller p q) (((order @(BaseField BLS12_381_G1))^(12 :: Integer) - 1) `div` (order @(ScalarField BLS12_381_G1))) one
+pairingBLS p q   = pow' (miller p q) (((order @(BaseField BLS12_381_G1))^(12 :: Integer) - 1) `div` (order @(ScalarField BLS12_381_G1))) one
 
 -- Used for the final exponentiation; opportunity for further perf optimization
-pow' :: (Field a) => a -> Integer -> a -> a
+pow' :: (Field a) => a -> Natural -> a -> a
 pow' a0 e result
   | e <= 1    = a0
   | even e    = accum2
@@ -167,3 +168,4 @@ pow' a0 e result
   where
     accum  = pow' a0 (shiftR e 1) result
     accum2 = accum * accum
+

--- a/src/ZkFold/Base/Algebra/Polynomials/Multivariate.hs
+++ b/src/ZkFold/Base/Algebra/Polynomials/Multivariate.hs
@@ -20,6 +20,7 @@ module ZkFold.Base.Algebra.Polynomials.Multivariate (
 import           Data.Containers.ListUtils                                 (nubOrd)
 import           Data.Map                                                  (Map, keys, singleton, toList)
 import           Data.Maybe                                                (fromJust)
+import           Numeric.Natural                                           (Natural)
 import           Prelude                                                   hiding (Num (..), length, product, replicate, sum, (!!), (^))
 
 import           ZkFold.Base.Algebra.Basic.Class
@@ -30,10 +31,10 @@ import           ZkFold.Base.Algebra.Polynomials.Multivariate.Set
 import           ZkFold.Base.Algebra.Polynomials.Multivariate.Substitution
 
 -- | Most general type for a multivariate monomial
-type SomeMonomial = M Integer Integer (Map Integer Integer)
+type SomeMonomial = M Natural Natural (Map Natural Natural)
 
 -- | Most general type for a multivariate polynomial
-type SomePolynomial c = P c Integer Integer (Map Integer Integer) [(c, M Integer Integer (Map Integer Integer))]
+type SomePolynomial c = P c Natural Natural (Map Natural Natural) [(c, M Natural Natural (Map Natural Natural))]
 
 -- | Monomial constructor
 monomial :: Monomial i j => Map i j -> M i j (Map i j)

--- a/src/ZkFold/Base/Algebra/Polynomials/Multivariate/Monomial.hs
+++ b/src/ZkFold/Base/Algebra/Polynomials/Multivariate/Monomial.hs
@@ -26,10 +26,10 @@ instance (Show i, Show j, FromMonomial i j m) => Show (M i j m) where
             showVar :: (i, j) -> String
             showVar (i, j) = "x" ++ show i ++ (if j == one then "" else "^" ++ show j)
 
-instance (FromMonomial i j m) => (Eq (M i j m)) where
-    (M asl) == (M asr) = fromMonomial @i @j @m asl == fromMonomial @i @j @m asr
+instance FromMonomial i j m => Eq (M i j m) where
+    M asl == M asr = fromMonomial @i @j @m asl == fromMonomial @i @j @m asr
 
-instance (FromMonomial i j m) => Ord (M i j m) where
+instance FromMonomial i j m => Ord (M i j m) where
     compare (M asl) (M asr) = go (toList $ fromMonomial @i @j @m asl) (toList $ fromMonomial @i @j @m asr)
         where
             go [] [] = EQ
@@ -43,13 +43,13 @@ instance Arbitrary m => Arbitrary (M i j m) where
     arbitrary = M <$> arbitrary
 
 instance Monomial i j => MultiplicativeSemigroup (M i j (Map i j)) where
-    (M l) * (M r) = M $ Map.filter (/= zero) $ unionWith (+) (fromMonomial @i @j l) (fromMonomial @i @j r)
+    M l * M r = M $ Map.filter (/= zero) $ unionWith (+) (fromMonomial @i @j l) (fromMonomial @i @j r)
 
 instance Monomial i j => MultiplicativeMonoid (M i j (Map i j)) where
     one = M empty
 
-instance Monomial i j => MultiplicativeGroup (M i j (Map i j)) where
+instance (Monomial i j, Ring j) => MultiplicativeGroup (M i j (Map i j)) where
     invert (M m) = M $ Map.map negate $ fromMonomial @i @j m
 
-    (M l) / (M r) = M $ differenceWith f (fromMonomial @i @j l) (fromMonomial @i @j r)
+    M l / M r = M $ differenceWith f (fromMonomial @i @j l) (fromMonomial @i @j r)
         where f a b = if a == b then Nothing else Just (a - b)

--- a/src/ZkFold/Base/Algebra/Polynomials/Multivariate/Monomial/Class.hs
+++ b/src/ZkFold/Base/Algebra/Polynomials/Multivariate/Monomial/Class.hs
@@ -10,7 +10,7 @@ import           ZkFold.Prelude                    (replicate)
 
 type Variable i = Ord i
 
-type Monomial i j = (Variable i, Eq j, Ord j, Ring j)
+type Monomial i j = (Variable i, Ord j, Semiring j)
 
 ----------------------------------- FromMonomial -----------------------------------
 
@@ -33,5 +33,5 @@ instance Monomial i j => ToMonomial i j (Map i j) where
 
 instance (Monomial i j, Integral j, Finite d) => ToMonomial i j (Vector d (i, Bool)) where
     toMonomial m =
-        let v = foldl (\acc (i, j) -> acc ++ replicate (toInteger j) (i, True)) [] $ Map.toList m
+        let v = foldl (\acc (i, j) -> acc ++ replicate (fromIntegral j) (i, True)) [] $ Map.toList m
         in toVector v

--- a/src/ZkFold/Base/Algebra/Polynomials/Multivariate/Polynomial.hs
+++ b/src/ZkFold/Base/Algebra/Polynomials/Multivariate/Polynomial.hs
@@ -72,8 +72,10 @@ instance forall c i j m p . (Polynomial c i j, m ~ Map i j, p ~ [(c, M i j m)]) 
 instance forall c i j m p . (Polynomial c i j, m ~ Map i j, p ~ [(c, M i j m)]) => MultiplicativeMonoid (P c i j m p) where
     one = P [(one, M empty)]
 
-instance forall c i j m p . (Polynomial c i j, m ~ Map i j, p ~ [(c, M i j m)]) => FromConstant Integer (P c i j m p) where
+instance forall c c' i j m p . (FromConstant c' c, m ~ Map i j, p ~ [(c, M i j m)]) => FromConstant c' (P c i j m p) where
     fromConstant x = P [(fromConstant x, M empty)]
+
+instance forall c i j m p . (Polynomial c i j, m ~ Map i j, p ~ [(c, M i j m)]) => Semiring (P c i j m p)
 
 instance forall c i j m p . (Polynomial c i j, m ~ Map i j, p ~ [(c, M i j m)]) => Ring (P c i j m p)
 

--- a/src/ZkFold/Base/Algebra/Polynomials/Univariate.hs
+++ b/src/ZkFold/Base/Algebra/Polynomials/Univariate.hs
@@ -44,6 +44,7 @@ lt :: Poly c -> c
 lt (P cs) = last cs
 
 deg :: Poly c -> Integer
+-- | Degree of zero polynomial is `-1`
 deg (P cs) = fromIntegral (length cs) - 1
 
 scaleP :: Ring c => c -> Natural -> Poly c -> Poly c
@@ -56,6 +57,7 @@ qr a b = go a b zero
             where
                 c = lt x / lt y
                 n = fromIntegral (deg x - deg y)
+                -- ^ if `deg x < deg y`, `n` is not evaluated, so this would not error out
                 x' = x - scaleP c n y
                 q' = q + scaleP c n one
 

--- a/src/ZkFold/Base/Algebra/Polynomials/Univariate.hs
+++ b/src/ZkFold/Base/Algebra/Polynomials/Univariate.hs
@@ -3,11 +3,12 @@
 
 module ZkFold.Base.Algebra.Polynomials.Univariate where
 
-import           Prelude                           hiding (Num(..), (/), (^), sum, product, length, replicate, take, drop)
-import           Test.QuickCheck                   (Arbitrary(..))
+import           Numeric.Natural                 (Natural)
+import           Prelude                         hiding (Num (..), drop, length, product, replicate, sum, take, (/), (^))
+import           Test.QuickCheck                 (Arbitrary (..))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Prelude                    (replicate, length, take, drop, zipWithDefault)
+import           ZkFold.Prelude                  (drop, length, replicate, take, zipWithDefault)
 
 -------------------------------- Arbitrary degree polynomials --------------------------------
 
@@ -43,9 +44,9 @@ lt :: Poly c -> c
 lt (P cs) = last cs
 
 deg :: Poly c -> Integer
-deg (P cs) = length cs - 1
+deg (P cs) = fromIntegral (length cs) - 1
 
-scaleP :: Ring c => c -> Integer -> Poly c -> Poly c
+scaleP :: Ring c => c -> Natural -> Poly c -> Poly c
 scaleP a n (P cs) = P $ replicate n zero ++ map (a *) cs
 
 qr :: (Field c, Eq c) => Poly c -> Poly c -> (Poly c, Poly c)
@@ -54,7 +55,7 @@ qr a b = go a b zero
         go x y q = if deg x < deg y then (q, x) else go x' y q'
             where
                 c = lt x / lt y
-                n = deg x - deg y
+                n = fromIntegral (deg x - deg y)
                 x' = x - scaleP c n y
                 q' = q + scaleP c n one
 
@@ -134,7 +135,7 @@ polyVecZero = poly2vec $ scaleP one (order @size) one - one
 
 -- L_i(x) : p(omega^i) = 1, p(omega^j) = 0, j /= i, 1 <= i <= n, 1 <= j <= n
 polyVecLagrange :: forall c size size' . (Field c, Eq c, Finite size, Finite size') =>
-    Integer -> c -> PolyVec c size'
+    Natural -> c -> PolyVec c size'
 polyVecLagrange i omega = scalePV (omega^i / fromConstant (order @size)) $ (polyVecZero @c @size @size' - one) / polyVecLinear (negate $ omega^i) one
 
 -- p(x) = c_1 * L_1(x) + c_2 * L_2(x) + ... + c_n * L_n(x)
@@ -157,7 +158,7 @@ polyVecGrandProduct (PV as) (PV bs) (PV sigmas) beta gamma =
 removeZeros :: (Ring c, Eq c) => Poly c -> Poly c
 removeZeros (P cs) = P $ reverse $ go $ reverse cs
     where
-        go [] = []
+        go []     = []
         go (x:xs) = if x == zero then go xs else x:xs
 
 addZeros :: forall c size . (Ring c, Finite size) => [c] -> [c]

--- a/src/ZkFold/Base/Protocol/ARK/Plonk/Internal.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Plonk/Internal.hs
@@ -2,23 +2,24 @@
 
 module ZkFold.Base.Protocol.ARK.Plonk.Internal where
 
-import           Control.Monad                                         (guard)
-import           Data.Bifunctor                                        (first)
-import           Data.Bool                                             (bool)
-import           Data.Containers.ListUtils                             (nubOrd)
-import           Data.List                                             (permutations, find, transpose, sort)
-import           Data.Map                                              (Map, fromList, empty, elems, toList, delete)
-import           Data.Maybe                                            (mapMaybe)
-import           Prelude                                               hiding (Num(..), (^), (/), (!!), sum, length, take, drop)
-import           System.Random                                         (RandomGen, Random (..), mkStdGen)
+import           Control.Monad                                (guard)
+import           Data.Bifunctor                               (first)
+import           Data.Bool                                    (bool)
+import           Data.Containers.ListUtils                    (nubOrd)
+import           Data.List                                    (find, permutations, sort, transpose)
+import           Data.Map                                     (Map, delete, elems, empty, fromList, toList)
+import           Data.Maybe                                   (mapMaybe)
+import           Numeric.Natural                              (Natural)
+import           Prelude                                      hiding (Num (..), drop, length, sum, take, (!!), (/), (^))
+import           System.Random                                (RandomGen, mkStdGen, uniformR)
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.Basic.Field                       (toZp, fromZp)
-import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381           (BLS12_381_G1, BLS12_381_G2)
+import           ZkFold.Base.Algebra.Basic.Field              (fromZp)
+import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381  (BLS12_381_G1, BLS12_381_G2)
 import           ZkFold.Base.Algebra.EllipticCurve.Class
-import           ZkFold.Base.Algebra.Polynomials.Univariate            (PolyVec, toPolyVec)
-import           ZkFold.Base.Algebra.Polynomials.Multivariate          (SomePolynomial, P (..), M (..), polynomial, variables)
-import           ZkFold.Prelude                                        (take, length)
+import           ZkFold.Base.Algebra.Polynomials.Multivariate (M (..), P (..), SomePolynomial, polynomial, variables)
+import           ZkFold.Base.Algebra.Polynomials.Univariate   (PolyVec, toPolyVec)
+import           ZkFold.Prelude                               (length, take)
 import           ZkFold.Symbolic.Compiler
 
 type F = ScalarField BLS12_381_G1
@@ -29,7 +30,7 @@ type SomePolynomialF = SomePolynomial F
 
 -- TODO (Issue #15): safer code and better tests for this module
 
-getParams :: Integer -> (F, F, F)
+getParams :: Natural -> (F, F, F)
 getParams l = findK' $ mkStdGen 0
     where
         omega = rootOfUnity l
@@ -38,8 +39,8 @@ getParams l = findK' $ mkStdGen 0
 
         findK' :: RandomGen g => g -> (F, F, F)
         findK' g =
-            let (k1, g') = first toZp $ randomR (1, order @F - 1) g
-                (k2, g'') = first toZp $ randomR (1, order @F - 1) g'
+            let (k1, g') = first fromConstant $ uniformR (1, order @F - 1) g
+                (k2, g'') = first fromConstant $ uniformR (1, order @F - 1) g'
             in bool (findK' g'') (omega, k1, k2) $
                 all (`notElem` hGroup) (hGroup' k1)
                 && all (`notElem` hGroup' k1) (hGroup' k2)
@@ -49,17 +50,17 @@ toPlonkConstaint p@(P ms) =
     let xs    = nubOrd $ variables p
         i     = order @F
         perms = nubOrd $ map (take 3) $ permutations $ case length xs of
-            0         -> [i, i, i]
-            1         -> [i, i, head xs, head xs]
-            2         -> [i] ++ xs ++ xs
-            _         -> xs ++ xs
+            0 -> [i, i, i]
+            1 -> [i, i, head xs, head xs]
+            2 -> [i] ++ xs ++ xs
+            _ -> xs ++ xs
 
-        getCoef :: Map Integer Integer -> F
+        getCoef :: Map Natural Natural -> F
         getCoef m = case find (\(_, M as) -> m == as) ms of
             Just (c, _) -> c
-            _            -> zero
+            _           -> zero
 
-        getCoefs :: [Integer] -> Maybe (F, F, F, F, F, F, F, F)
+        getCoefs :: [Natural] -> Maybe (F, F, F, F, F, F, F, F)
         getCoefs [a, b, c] = do
             let xa = fromList [(a, 1)]
                 xb = fromList [(b, 1)]
@@ -72,7 +73,7 @@ toPlonkConstaint p@(P ms) =
                 qm = getCoef xaxb
                 qc = getCoef empty
             guard $ p - polynomial [(ql, M xa), (qr, M xb), (qo, M xc), (qm, M xaxb), (qc, M empty)] == zero
-            return (ql, qr, qo, qm, qc, toZp a, toZp b, toZp c)
+            return (ql, qr, qo, qm, qc, fromConstant a, fromConstant b, fromConstant c)
         getCoefs _ = Nothing
 
     in head $ mapMaybe getCoefs perms
@@ -86,18 +87,18 @@ fromPlonkConstraint (ql, qr, qo, qm, qc, a, b, c) =
 
     in polynomial [(ql, M xa), (qr, M xb), (qo, M xc), (qm, M xaxb), (qc, M empty)]
 
-addPublicInput :: Integer -> F -> [SomePolynomialF] -> [SomePolynomialF]
+addPublicInput :: Natural -> F -> [SomePolynomialF] -> [SomePolynomialF]
 addPublicInput i _ ps =
     polynomial [(one, M (fromList [(i, 1)]))] : ps
 
-addPublicInputs :: Map Integer F -> [SomePolynomialF] -> [SomePolynomialF]
+addPublicInputs :: Map Natural F -> [SomePolynomialF] -> [SomePolynomialF]
 addPublicInputs inputs ps = foldr (\(i, x) ps' -> addPublicInput i x ps') ps $ toList inputs
 
 removeConstantVariable :: SomePolynomialF -> SomePolynomialF
 removeConstantVariable (P ms) =
     polynomial . map (\(c, M as) -> (c, M (0 `delete` as))) $ ms
 
-toPlonkArithmetization :: forall a . Finite a => Map Integer F -> ArithmeticCircuit F
+toPlonkArithmetization :: forall a . Finite a => Map Natural F -> ArithmeticCircuit F
     -> (PolyVec F a, PolyVec F a, PolyVec F a, PolyVec F a, PolyVec F a, PolyVec F a, PolyVec F a, PolyVec F a)
 toPlonkArithmetization inputs ac =
     let f (x0, x1, x2, x3, x4, x5, x6, x7) = [x0, x1, x2, x3, x4, x5, x6, x7]
@@ -109,3 +110,4 @@ toPlonkArithmetization inputs ac =
     in case map toPolyVec $ transpose $ map (f . toPlonkConstaint . removeConstantVariable) system of
             [ql, qr, qo, qm, qc, a, b, c] -> (ql, qr, qo, qm, qc, a, b, c)
             _                             -> error "toPlonkArithmetization: something went wrong"
+

--- a/src/ZkFold/Base/Protocol/ARK/Protostar/Gate.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Protostar/Gate.hs
@@ -2,16 +2,17 @@ module ZkFold.Base.Protocol.ARK.Protostar.Gate where
 
 import           Data.Kind                                       (Type)
 import           Data.Zip                                        (zipWith)
-import           Prelude                                         hiding (Num (..), (^), (!!), zipWith)
+import           Numeric.Natural                                 (Natural)
+import           Prelude                                         hiding (Num (..), zipWith, (!!), (^))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field                 (Zp)
 import           ZkFold.Base.Algebra.Basic.Scale                 (scale')
-import           ZkFold.Base.Algebra.Polynomials.Multivariate    (evalPolynomial', subs, SomePolynomial, substitutePolynomial, var)
-import           ZkFold.Base.Data.Matrix                         (Matrix (..), outer, transpose, sum1)
+import           ZkFold.Base.Algebra.Polynomials.Multivariate    (SomePolynomial, evalPolynomial', subs, substitutePolynomial, var)
+import           ZkFold.Base.Data.Matrix                         (Matrix (..), outer, sum1, transpose)
 import           ZkFold.Base.Data.Vector                         (Vector)
 import           ZkFold.Base.Protocol.ARK.Protostar.Internal     (PolynomialProtostar)
-import           ZkFold.Base.Protocol.ARK.Protostar.SpecialSound (SpecialSoundProtocol(..), SpecialSoundTranscript)
+import           ZkFold.Base.Protocol.ARK.Protostar.SpecialSound (SpecialSoundProtocol (..), SpecialSoundTranscript)
 import           ZkFold.Symbolic.Compiler.Arithmetizable         (Arithmetic)
 
 data ProtostarGate (m :: Type) (n :: Type) (c :: Type) (d :: Type)
@@ -28,7 +29,7 @@ instance (Arithmetic f, Finite m, Finite n, Finite c) => SpecialSoundProtocol f 
     type Dimension (ProtostarGate m n c d)        = n
     type Degree (ProtostarGate m n c d)           = d
 
-    rounds :: ProtostarGate m n c d -> Integer
+    rounds :: ProtostarGate m n c d -> Natural
     rounds _ = 1
 
     prover :: ProtostarGate m n c d
@@ -40,7 +41,7 @@ instance (Arithmetic f, Finite m, Finite n, Finite c) => SpecialSoundProtocol f 
 
     verifier' :: ProtostarGate m n c d
               -> Input f (ProtostarGate m n c d)
-              -> SpecialSoundTranscript Integer (ProtostarGate m n c d)
+              -> SpecialSoundTranscript Natural (ProtostarGate m n c d)
               -> Vector (Dimension (ProtostarGate m n c d)) (SomePolynomial f)
     verifier' _ (s, g) [(w, _)] =
       let w' = fmap ((var .) . subs) w :: Vector n (Zp c -> SomePolynomial f)
@@ -57,3 +58,4 @@ instance (Arithmetic f, Finite m, Finite n, Finite c) => SpecialSoundProtocol f 
           z  = transpose $ outer evalPolynomial' w' g
       in all (== zero) $ sum1 $ zipWith scale' s z
     verifier _ _ _ = error "Invalid transcript"
+

--- a/src/ZkFold/Base/Protocol/ARK/Protostar/Lookup.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Protostar/Lookup.hs
@@ -4,18 +4,19 @@ module ZkFold.Base.Protocol.ARK.Protostar.Lookup where
 
 import           Data.Kind                                       (Type)
 import           Data.Map                                        (fromList, mapWithKey)
-import           Data.These                                      (These(..))
+import           Data.These                                      (These (..))
 import           Data.Zip
-import           Prelude                                         hiding (Num (..), (/), (^), (!!), sum, zip, repeat, zipWith)
-import           Type.Data.Num.Unary                             ((:+:), Succ)
+import           Numeric.Natural                                 (Natural)
+import           Prelude                                         hiding (Num (..), repeat, sum, zip, zipWith, (!!), (/), (^))
+import           Type.Data.Num.Unary                             (Succ, (:+:))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field                 (Zp)
 import           ZkFold.Base.Algebra.Basic.Number                (N2)
 import           ZkFold.Base.Algebra.Polynomials.Multivariate    (SomePolynomial)
-import           ZkFold.Base.Data.Sparse.Vector                  (SVector(..))
+import           ZkFold.Base.Data.Sparse.Vector                  (SVector (..))
 import           ZkFold.Base.Data.Vector                         (Vector)
-import           ZkFold.Base.Protocol.ARK.Protostar.SpecialSound (SpecialSoundProtocol(..), SpecialSoundTranscript)
+import           ZkFold.Base.Protocol.ARK.Protostar.SpecialSound (SpecialSoundProtocol (..), SpecialSoundTranscript)
 import           ZkFold.Symbolic.Compiler                        (Arithmetic)
 
 data ProtostarLookup (l :: Type) (sizeT :: Type)
@@ -34,7 +35,7 @@ instance (Arithmetic f, Finite sizeT) => SpecialSoundProtocol f (ProtostarLookup
     type Dimension (ProtostarLookup l sizeT)         = Succ (l :+: sizeT)
     type Degree (ProtostarLookup l sizeT)            = N2
 
-    rounds :: ProtostarLookup l sizeT -> Integer
+    rounds :: ProtostarLookup l sizeT -> Natural
     rounds _ = 2
 
     prover :: ProtostarLookup l sizeT
@@ -54,7 +55,7 @@ instance (Arithmetic f, Finite sizeT) => SpecialSoundProtocol f (ProtostarLookup
     -- TODO: implement this
     verifier' :: ProtostarLookup l sizeT
               -> Input f (ProtostarLookup l sizeT)
-              -> SpecialSoundTranscript Integer (ProtostarLookup l sizeT)
+              -> SpecialSoundTranscript Natural (ProtostarLookup l sizeT)
               -> Vector (Dimension (ProtostarLookup l sizeT)) (SomePolynomial f)
     verifier' = undefined
 
@@ -73,3 +74,4 @@ instance (Arithmetic f, Finite sizeT) => SpecialSoundProtocol f (ProtostarLookup
             c3 = all (== one) $ alignWith f g' m
         in c1 && c2 && c3
     verifier _ _ _ = error "Invalid transcript"
+

--- a/src/ZkFold/Base/Protocol/ARK/Protostar/Permutation.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Protostar/Permutation.hs
@@ -1,15 +1,16 @@
 module ZkFold.Base.Protocol.ARK.Protostar.Permutation where
 
 import           Data.Kind                                       (Type)
-import           Data.Zip                                        (Zip(..))
-import           Prelude                                         hiding (Num (..), (^), (!!), zipWith)
+import           Data.Zip                                        (Zip (..))
+import           Numeric.Natural                                 (Natural)
+import           Prelude                                         hiding (Num (..), zipWith, (!!), (^))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Number                (N1)
 import           ZkFold.Base.Algebra.Basic.Permutations          (Permutation, applyPermutation)
 import           ZkFold.Base.Algebra.Polynomials.Multivariate    (SomePolynomial, var)
 import           ZkFold.Base.Data.Vector                         (Vector)
-import           ZkFold.Base.Protocol.ARK.Protostar.SpecialSound (SpecialSoundProtocol(..), SpecialSoundTranscript)
+import           ZkFold.Base.Protocol.ARK.Protostar.SpecialSound (SpecialSoundProtocol (..), SpecialSoundTranscript)
 import           ZkFold.Symbolic.Compiler                        (Arithmetic)
 
 data ProtostarPermutation (n :: Type)
@@ -26,7 +27,7 @@ instance Arithmetic f => SpecialSoundProtocol f (ProtostarPermutation n) where
     type Dimension (ProtostarPermutation n)         = n
     type Degree (ProtostarPermutation n)            = N1
 
-    rounds :: ProtostarPermutation n -> Integer
+    rounds :: ProtostarPermutation n -> Natural
     rounds _ = 1
 
     prover :: ProtostarPermutation n
@@ -38,7 +39,7 @@ instance Arithmetic f => SpecialSoundProtocol f (ProtostarPermutation n) where
 
     verifier' :: ProtostarPermutation n
               -> Input f (ProtostarPermutation n)
-              -> SpecialSoundTranscript Integer (ProtostarPermutation n)
+              -> SpecialSoundTranscript Natural (ProtostarPermutation n)
               -> Vector (Dimension (ProtostarPermutation n)) (SomePolynomial f)
     verifier' _ sigma [(w, _)] = zipWith (-) (applyPermutation sigma wX) wX
       where wX = fmap var w
@@ -51,3 +52,4 @@ instance Arithmetic f => SpecialSoundProtocol f (ProtostarPermutation n) where
              -> Bool
     verifier _ sigma [(w, _)] = applyPermutation sigma w == w
     verifier _ _     _        = error "Invalid transcript"
+

--- a/src/ZkFold/Base/Protocol/ARK/Protostar/SpecialSound.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Protostar/SpecialSound.hs
@@ -2,6 +2,7 @@
 
 module ZkFold.Base.Protocol.ARK.Protostar.SpecialSound where
 
+import           Numeric.Natural                              (Natural)
 import           Prelude                                      hiding (length)
 
 import           ZkFold.Base.Algebra.Polynomials.Multivariate (SomePolynomial)
@@ -21,12 +22,13 @@ class Arithmetic f => SpecialSoundProtocol f a where
       type Degree a
       -- ^ d in the paper
 
-      rounds    :: a -> Integer
+      rounds :: a -> Natural
       -- ^ k in the paper
 
       prover :: a -> Witness f a -> Input f a -> SpecialSoundTranscript f a -> ProverMessage f a
 
-      verifier' :: a -> Input f a -> SpecialSoundTranscript Integer a
+      verifier' :: a -> Input f a -> SpecialSoundTranscript Natural a
             -> Vector (Dimension a) (SomePolynomial f)
 
       verifier :: a -> Input f a -> SpecialSoundTranscript f a -> Bool
+

--- a/src/ZkFold/Base/Protocol/NonInteractiveProof.hs
+++ b/src/ZkFold/Base/Protocol/NonInteractiveProof.hs
@@ -6,9 +6,10 @@ module ZkFold.Base.Protocol.NonInteractiveProof where
 import           Crypto.Hash.SHA256          (hash)
 import           Data.ByteString             (ByteString, cons)
 import           Data.Maybe                  (fromJust)
+import           Numeric.Natural             (Natural)
 import           Prelude
 
-import           ZkFold.Base.Data.ByteString (ToByteString(..), FromByteString (..))
+import           ZkFold.Base.Data.ByteString (FromByteString (..), ToByteString (..))
 
 class Monoid t => ToTranscript t a where
     toTranscript :: a -> t
@@ -32,7 +33,7 @@ challenge ts =
     let ts' = newTranscript @t @a ts
     in (fromTranscript ts', ts')
 
-challenges :: FromTranscript t a => t -> Integer -> ([a], t)
+challenges :: FromTranscript t a => t -> Natural -> ([a], t)
 challenges ts0 n = go ts0 n []
   where
     go ts 0 acc = (acc, ts)
@@ -56,3 +57,4 @@ class NonInteractiveProof a where
     prove :: Setup a -> Witness a -> (Input a, Proof a)
 
     verify :: Setup a -> Input a -> Proof a -> Bool
+

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit.hs
@@ -28,16 +28,17 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit (
     ) where
 
 import           Control.Monad.State                                 (execState)
-import           Data.Map                                            hiding (take, drop, splitAt, foldl, null, map, foldr)
-import           Prelude                                             hiding (Num (..), (^), (!!), sum, take, drop, splitAt, product, length)
+import           Data.Map                                            hiding (drop, foldl, foldr, map, null, splitAt, take)
+import           Numeric.Natural                                     (Natural)
+import           Prelude                                             hiding (Num (..), drop, length, product, splitAt, sum, take, (!!), (^))
 import           Test.QuickCheck                                     (Arbitrary, Property, conjoin, property, vector, withMaxSuccess, (===))
 import           Text.Pretty.Simple                                  (pPrint)
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Polynomials.Multivariate        (evalPolynomial')
 import           ZkFold.Prelude                                      (length)
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (ArithmeticCircuit(..), Arithmetic, Constraint, apply, eval, forceZero)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Instance ()
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (Arithmetic, ArithmeticCircuit (..), Constraint, apply, eval, forceZero)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Map
 
 --------------------------------- High-level functions --------------------------------
@@ -55,12 +56,12 @@ optimize = undefined
 ----------------------------------- Information -----------------------------------
 
 -- | Calculates the number of constraints in the system.
-acSizeN :: ArithmeticCircuit a -> Integer
+acSizeN :: ArithmeticCircuit a -> Natural
 acSizeN = length . acSystem
 
 -- | Calculates the number of variables in the system.
 -- The constant `1` is not counted.
-acSizeM :: ArithmeticCircuit a -> Integer
+acSizeM :: ArithmeticCircuit a -> Natural
 acSizeM = length . acVarOrder
 
 acValue :: ArithmeticCircuit a -> a

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
@@ -13,6 +13,7 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (
 
 import           Data.Foldable                                             (foldlM)
 import           Data.Traversable                                          (for)
+import           Numeric.Natural                                           (Natural)
 import           Prelude                                                   hiding (Bool, Eq (..), negate, splitAt, (!!), (*), (+), (-), (^))
 
 import           ZkFold.Base.Algebra.Basic.Class
@@ -32,7 +33,7 @@ boolCheckC r = circuit $ do
 embed :: Arithmetic a => a -> ArithmeticCircuit a
 embed x = circuit $ newAssigned $ const (x `scale` one)
 
-expansion :: MonadBlueprint i a m => Integer -> i -> m [i]
+expansion :: MonadBlueprint i a m => Natural -> i -> m [i]
 -- ^ @expansion n k@ computes a binary expansion of @k@ if it fits in @n@ bits.
 expansion n k = do
     bits <- bitsOf n k
@@ -40,7 +41,7 @@ expansion n k = do
     constraint (\x -> x k - x k')
     return bits
 
-splitExpansion :: MonadBlueprint i a m => Integer -> Integer -> i -> m (i, i)
+splitExpansion :: MonadBlueprint i a m => Natural -> Natural -> i -> m (i, i)
 -- ^ @splitExpansion n1 n2 k@ computes two values @(l, h)@ such that
 -- @k = 2^n1 h + l@, @l@ fits in @n1@ bits and @h@ fits in n2 bits (if such
 -- values exist).
@@ -52,7 +53,7 @@ splitExpansion n1 n2 k = do
     constraint (\x -> x k - x l - scale ((one + one) ^ n1) (x h))
     return (l, h)
 
-bitsOf :: MonadBlueprint i a m => Integer -> i -> m [i]
+bitsOf :: MonadBlueprint i a m => Natural -> i -> m [i]
 -- ^ @bitsOf n k@ creates @n@ bits and sets their witnesses equal to @n@ smaller
 -- bits of @k@.
 bitsOf n k = for [0 .. n - 1] $ \j ->

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -69,6 +69,8 @@ instance Arithmetic a => MultiplicativeGroup (ArithmeticCircuit a) where
 instance (Arithmetic a, FromConstant b a) => FromConstant b (ArithmeticCircuit a) where
     fromConstant c = embed (fromConstant c)
 
+instance Arithmetic a => Semiring (ArithmeticCircuit a)
+
 instance Arithmetic a => Ring (ArithmeticCircuit a)
 
 instance Arithmetic a => BinaryExpansion (ArithmeticCircuit a) where

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Map.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Map.hs
@@ -5,33 +5,34 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Map (
         mapVarWitness
     ) where
 
-import           Data.Bifunctor                                        (Bifunctor(..))
-import           Data.Containers.ListUtils                             (nubOrd)
-import           Data.List                                             (sort)
-import           Data.Map                                              hiding (take, drop, splitAt, foldl, null, map, foldr)
-import           Prelude                                               hiding (Num (..), (^), (!!), sum, take, drop, splitAt, product, length)
+import           Data.Bifunctor                                      (Bifunctor (..))
+import           Data.Containers.ListUtils                           (nubOrd)
+import           Data.List                                           (sort)
+import           Data.Map                                            hiding (drop, foldl, foldr, map, null, splitAt, take)
+import           Numeric.Natural                                     (Natural)
+import           Prelude                                             hiding (Num (..), drop, length, product, splitAt, sum, take, (!!), (^))
 
 import           ZkFold.Base.Algebra.Polynomials.Multivariate
-import           ZkFold.Prelude                                        (elemIndex)
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal   (Arithmetic, ArithmeticCircuit(..), ConstraintMonomial, Constraint)
+import           ZkFold.Prelude                                      (elemIndex)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (Arithmetic, ArithmeticCircuit (..), Constraint, ConstraintMonomial)
 
 -- This module contains functions for mapping variables in arithmetic circuits.
 
-mapVar :: [Integer] -> Integer -> Integer
+mapVar :: [Natural] -> Natural -> Natural
 mapVar vars x = case x `elemIndex` vars of
     Just i  -> i
     Nothing -> error "mapVar: something went wrong"
 
-mapVarMonomial :: [Integer] -> ConstraintMonomial -> ConstraintMonomial
+mapVarMonomial :: [Natural] -> ConstraintMonomial -> ConstraintMonomial
 mapVarMonomial vars (M as) = M $ mapKeys (mapVar vars) as
 
-mapVarPolynomial :: [Integer] -> Constraint c -> Constraint c
+mapVarPolynomial :: [Natural] -> Constraint c -> Constraint c
 mapVarPolynomial vars (P ms) = P $ map (second $ mapVarMonomial vars) ms
 
-mapVarPolynomials :: [Integer] -> [Constraint c] -> [Constraint c]
+mapVarPolynomials :: [Natural] -> [Constraint c] -> [Constraint c]
 mapVarPolynomials vars = map (mapVarPolynomial vars)
 
-mapVarWitness :: [Integer] -> (Map Integer a -> Map Integer a)
+mapVarWitness :: [Natural] -> (Map Natural a -> Map Natural a)
 mapVarWitness vars = mapKeys (mapVar vars)
 
 mapVarArithmeticCircuit :: Arithmetic a => ArithmeticCircuit a -> ArithmeticCircuit a
@@ -44,3 +45,4 @@ mapVarArithmeticCircuit ac =
         acWitness = mapVarWitness vars . acWitness ac,
         acOutput  = mapVar vars $ acOutput ac
     }
+

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
@@ -178,6 +178,8 @@ instance Ord i => MultiplicativeGroup (Sources a i) where
 instance Ord i => FromConstant c (Sources a i) where
   fromConstant _ = mempty
 
+instance Ord i => Semiring (Sources a i)
+
 instance Ord i => Ring (Sources a i)
 
 instance (Finite a, Ord i) => BinaryExpansion (Sources a i) where

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
@@ -18,7 +18,8 @@ import           Data.Functor                                        (($>))
 import           Data.Map                                            ((!))
 import           Data.Set                                            (Set)
 import qualified Data.Set                                            as Set
-import           Prelude                                             hiding (Bool (..), Eq (..), replicate, (*), (-))
+import           Numeric.Natural                                     (Natural)
+import           Prelude                                             hiding (Bool (..), Eq (..), replicate, (*), (+), (-))
 import qualified Prelude                                             as Haskell
 
 import           ZkFold.Base.Algebra.Basic.Class
@@ -104,7 +105,7 @@ class Monad m => MonadBlueprint i a m | m -> i, m -> a where
     newAssigned :: ClosedPoly i a -> m i
     newAssigned p = newConstrained (\x i -> p x - x i) p
 
-instance Arithmetic a => MonadBlueprint Integer a (State (ArithmeticCircuit a)) where
+instance Arithmetic a => MonadBlueprint Natural a (State (ArithmeticCircuit a)) where
     input = acOutput <$> I.input
 
     output i = gets (\r -> r { acOutput = i })
@@ -112,11 +113,14 @@ instance Arithmetic a => MonadBlueprint Integer a (State (ArithmeticCircuit a)) 
     runCircuit r = modify (<> r) $> acOutput r
 
     newConstrained
-        :: NewConstraint Integer a
-        -> Witness Integer a
-        -> State (ArithmeticCircuit a) Integer
+        :: NewConstraint Natural a
+        -> Witness Natural a
+        -> State (ArithmeticCircuit a) Natural
     newConstrained new witness = do
-        let s = sources witness `Set.difference` sources (`new` (-1))
+        let ws = sources witness
+            -- | We need a throwaway variable to feed into `new`
+            x = maximum (Set.mapMonotonic (+1) ws <> Set.singleton 0)
+            s = ws `Set.difference` sources (`new` x)
         i <- addVariable =<< newVariableWithSource (Set.toList s) (new var)
         constraint (`new` i)
         assignment (\m -> getSelf $ witness (Self . (m !)))

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
@@ -118,8 +118,9 @@ instance Arithmetic a => MonadBlueprint Natural a (State (ArithmeticCircuit a)) 
         -> State (ArithmeticCircuit a) Natural
     newConstrained new witness = do
         let ws = sources witness
-            -- | We need a throwaway variable to feed into `new`
+            -- | We need a throwaway variable to feed into `new` which definitely would not be present in a witness
             x = maximum (Set.mapMonotonic (+1) ws <> Set.singleton 0)
+            -- | `s` is meant to be a set of variables used in a witness not present in a constraint.
             s = ws `Set.difference` sources (`new` x)
         i <- addVariable =<< newVariableWithSource (Set.toList s) (new var)
         constraint (`new` i)

--- a/src/ZkFold/Symbolic/Compiler/Arithmetizable.hs
+++ b/src/ZkFold/Symbolic/Compiler/Arithmetizable.hs
@@ -11,7 +11,8 @@ module ZkFold.Symbolic.Compiler.Arithmetizable (
     ) where
 
 import           Data.Typeable                                             (Typeable)
-import           Prelude                                                   hiding (Num (..), (^), (!!), sum, take, drop, splitAt, product, length)
+import           Numeric.Natural                                           (Natural)
+import           Prelude                                                   hiding (Num (..), drop, length, product, splitAt, sum, take, (!!), (^))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Data.Vector
@@ -30,7 +31,7 @@ class Arithmetic a => Arithmetizable a x where
     restore :: [ArithmeticCircuit a] -> x
 
     -- | Returns the number of finite field elements needed to desscribe `x`.
-    typeSize :: Integer
+    typeSize :: Natural
 
 -- A wrapper for `Arithmetizable` types.
 data SomeArithmetizable a where

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -58,16 +58,24 @@ toNatural (UInt xs x) = foldr (\p y -> fromZp p + base * y) 0 (xs ++ [x])
     where base = 2 ^ registerSize @p @n
 
 instance (Finite p, KnownNat n) => AdditiveSemigroup (UInt n (Zp p)) where
+    -- | This operation is defined only if $(x + y < 2^n$), so this is not a
+    -- lawful instance.
     x + y = fromConstant $ toNatural x + toNatural y
 
 instance (Finite p, KnownNat n) => AdditiveMonoid (UInt n (Zp p)) where
     zero = fromConstant (0 :: Natural)
 
 instance (Finite p, KnownNat n) => AdditiveGroup (UInt n (Zp p)) where
+    -- | This operation is defined only if $(x \ge y$), so this is not a lawful
+    -- instance.
     x - y = fromConstant $ toNatural x - toNatural y
+    -- | @negate x@ is defined only if $(x = 0$), so this is not a lawful
+    -- instance.
     negate = fromConstant . negate . toNatural
 
 instance (Finite p, KnownNat n) => MultiplicativeSemigroup (UInt n (Zp p)) where
+    -- | This operation is defined only if $(x \cdot y < 2^n$), so this is not a
+    -- lawful instance.
     x * y = fromConstant $ toNatural x * toNatural y
 
 instance (Finite p, KnownNat n) => MultiplicativeMonoid (UInt n (Zp p)) where

--- a/src/ZkFold/Symbolic/GroebnerBasis/Internal.hs
+++ b/src/ZkFold/Symbolic/GroebnerBasis/Internal.hs
@@ -1,11 +1,12 @@
 module ZkFold.Symbolic.GroebnerBasis.Internal where
 
-import           Data.List                       (sortBy)
-import           Data.Map                        (notMember)
-import           Prelude                         hiding (Num(..), (/), (!!), lcm, length, sum, take, drop)
+import           Data.List                                        (sortBy)
+import           Data.Map                                         (notMember)
+import           Numeric.Natural                                  (Natural)
+import           Prelude                                          hiding (Num (..), drop, lcm, length, sum, take, (!!), (/))
 
-import           ZkFold.Base.Algebra.Basic.Class hiding (scale)
-import           ZkFold.Prelude                  (length)
+import           ZkFold.Base.Algebra.Basic.Class                  hiding (scale)
+import           ZkFold.Prelude                                   (length)
 import           ZkFold.Symbolic.GroebnerBasis.Internal.Reduction
 import           ZkFold.Symbolic.GroebnerBasis.Internal.Types
 
@@ -19,14 +20,14 @@ makeSPoly l r = if null as then zero else addPoly l' r'
           ra  = divideM lcm (lt l)
           la  = scale (negate one) $ divideM lcm (lt r)
 
-varNumber :: Polynom c a -> Integer
+varNumber :: Polynom c a -> Natural
 varNumber (P [])         = 0
 varNumber (P (M _ as:_)) = length as
 
-varIsMissing :: Integer -> Polynom c a -> Bool
+varIsMissing :: Natural -> Polynom c a -> Bool
 varIsMissing i (P ms) = all (\(M _ as) -> notMember (i-1) as) ms
 
-checkVarUnique :: Integer -> [Polynom c a] -> Bool
+checkVarUnique :: Natural -> [Polynom c a] -> Bool
 checkVarUnique i fs = length (filter (== False) $ map (varIsMissing i) fs) == 1
 
 checkLTSimple :: Polynom c a -> Bool
@@ -63,3 +64,4 @@ groebnerStep h fs
             fs'  = trimSystem h' fs
             fs'' = addSPolyStep (reverse fs') (reverse fs') fs'
         in (h', fs'')
+

--- a/src/ZkFold/Symbolic/GroebnerBasis/Types.hs
+++ b/src/ZkFold/Symbolic/GroebnerBasis/Types.hs
@@ -7,25 +7,27 @@ module ZkFold.Symbolic.GroebnerBasis.Types (
     polynomial
     ) where
 
-import           Data.List                         (sortBy)
-import           Data.Map                          (Map)
-import           Prelude                           hiding (Num(..), (!!), length, replicate)
+import           Data.List                                    (sortBy)
+import           Data.Map                                     (Map)
+import           Numeric.Natural                              (Natural)
+import           Prelude                                      hiding (Num (..), length, replicate, (!!))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.Basic.Field   (Zp)
+import           ZkFold.Base.Algebra.Basic.Field              (Zp)
 import           ZkFold.Symbolic.GroebnerBasis.Internal.Types
 
-type Variable p = Var (Zp p) Integer
+type Variable p = Var (Zp p) Natural
 
-variable :: Integer -> Variable p
+variable :: Natural -> Variable p
 variable = Free
 
-type Monomial p = Monom (Zp p) Integer
+type Monomial p = Monom (Zp p) Natural
 
-monomial :: Zp p -> Map Integer (Variable p) -> Monomial p
+monomial :: Zp p -> Map Natural (Variable p) -> Monomial p
 monomial = M
 
-type Polynomial p = Polynom (Zp p) Integer
+type Polynomial p = Polynom (Zp p) Natural
 
 polynomial :: Prime p => [Monomial p] -> Polynomial p
 polynomial = P . sortBy (flip compare) . filter (not . zeroM)
+

--- a/tests/Tests/Permutations.hs
+++ b/tests/Tests/Permutations.hs
@@ -4,7 +4,7 @@ module Tests.Permutations (specPermutations) where
 
 import           Data.List                              (sort)
 import           Data.Map                               (elems)
-import           Prelude                                hiding (Num(..), Fractional(..), length)
+import           Prelude                                hiding (Fractional (..), Num (..), length)
 import           Test.Hspec
 import           Test.QuickCheck
 
@@ -22,10 +22,11 @@ specPermutations = hspec $ do
     describe "Permutations specification" $ do
         describe "Function: mkIndexPartition" $ do
             it "should preserve the total number of elements" $ property $
-                \xs -> length (concat $ elems $ mkIndexPartition xs) `shouldBe` length xs
+                \xs -> length (concat $ elems $ mkIndexPartition @Integer xs) `shouldBe` length xs
         describe "Function: fromCycles" $ do
             it "should preserve the elements" $ property $
-                \v -> 
-                    let ts = mkIndexPartition $ fromVector @TestSize v
+                \v ->
+                    let ts = mkIndexPartition @Integer $ fromVector @TestSize v
                         p = fromPermutation @TestSize $ fromCycles ts
                     in sort p == sort (concat $ elems ts)
+

--- a/tests/Tests/UInt.hs
+++ b/tests/Tests/UInt.hs
@@ -7,8 +7,10 @@ import           Control.Monad                   (return)
 import           Data.Data                       (Proxy (..))
 import           Data.Function                   (($))
 import           Data.List                       (map, (++))
+import           GHC.Num                         (integerToNatural)
 import           GHC.TypeNats                    (KnownNat, natVal)
-import           Prelude                         (Integer, div, show)
+import           Numeric.Natural                 (Natural)
+import           Prelude                         (div, show)
 import qualified Prelude                         as Haskell
 import           System.IO                       (IO)
 import           Test.Hspec                      (describe, hspec)
@@ -20,8 +22,8 @@ import           ZkFold.Base.Algebra.Basic.Field (Zp)
 import           ZkFold.Symbolic.Compiler        (ArithmeticCircuit)
 import           ZkFold.Symbolic.Data.UInt
 
-toss :: Integer -> Gen Integer
-toss x = chooseInteger (0, x)
+toss :: Natural -> Gen Natural
+toss x = integerToNatural Haskell.<$> chooseInteger (0, Haskell.fromIntegral x)
 
 value :: forall a n . UInt n (ArithmeticCircuit a) -> UInt n a
 value (UInt xs x) = UInt (map eval' xs) (eval' x)
@@ -32,9 +34,9 @@ specUInt = hspec $ do
     describe ("UInt" ++ show n ++ " specification") $ do
         it "Zp embeds Integer" $ do
             x <- toss (2 ^ n - 1)
-            return $ toInteger @p @n (fromConstant x) === x
+            return $ toNatural @p @n (fromConstant x) === x
         it "Integer embeds Zp" $ \(x :: UInt n (Zp p)) ->
-            fromConstant (toInteger x) === x
+            fromConstant (toNatural x) === x
         it "AC embeds Integer" $ do
             x <- toss (2 ^ n - 1)
             return $ value @(Zp p) @n (fromConstant x) === fromConstant x

--- a/tests/Tests/Univariate.hs
+++ b/tests/Tests/Univariate.hs
@@ -8,17 +8,17 @@ module Tests.Univariate (specUnivariate) where
 
 import           Data.Bool                                  (bool)
 import           Data.Data                                  (typeOf)
-import           Data.List                                  ((\\), sort)
+import           Data.List                                  (sort, (\\))
+import           Numeric.Natural                            (Natural)
+import           Prelude                                    hiding (Fractional (..), Num (..), drop, length, take, (!!), (^))
 import           Prelude                                    (abs)
-import           Prelude                                    hiding ((^), Num(..), Fractional(..), (!!), length, take, drop)
 import           Test.Hspec
 import           Test.QuickCheck
 
 import           ZkFold.Base.Algebra.Basic.Class
-
 import           ZkFold.Base.Algebra.Polynomials.Univariate
-import           ZkFold.Base.Protocol.ARK.Plonk             (PlonkBS, PlonkMaxPolyDegreeBS, F)
-import           ZkFold.Prelude                             (take, length)
+import           ZkFold.Base.Protocol.ARK.Plonk             (F, PlonkBS, PlonkMaxPolyDegreeBS)
+import           ZkFold.Prelude                             (length, take)
 
 -- TODO (Issue #22): remove dependencies from KZG and Plonk
 -- TODO (Issue #22): make all tests polymorphic in the polynomial type
@@ -36,23 +36,23 @@ propCastPolyVec cs =
     in length p' == order @size'
 
 propPolyVecDivision :: forall c size . (Field c, Finite size, Eq c) => PolyVec c size -> PolyVec c size -> Bool
-propPolyVecDivision p q = 
+propPolyVecDivision p q =
     let d1 = deg $ vec2poly p
         d2 = deg $ vec2poly q
-    in (p * q) / q == p || (d1 + d2 > order @size - 1)
+    in (p * q) / q == p || (d1 + d2 > fromIntegral (order @size) - 1)
 
-propPolyVecZero :: Integer -> Bool
+propPolyVecZero :: Natural -> Bool
 propPolyVecZero i =
     let omega = rootOfUnity 5 :: F
         p = polyVecZero @F @PlonkBS @PlonkMaxPolyDegreeBS
         x = omega^abs i
     in p `evalPolyVec` x == zero
 
-propPolyVecLagrange :: Integer -> Bool
+propPolyVecLagrange :: Natural -> Bool
 propPolyVecLagrange i =
     let omega = rootOfUnity 5 :: F
         p = polyVecLagrange @F @PlonkBS @PlonkMaxPolyDegreeBS i omega
-    in p `evalPolyVec` (omega^i) == one && 
+    in p `evalPolyVec` (omega^i) == one &&
         all ((== zero) . (p `evalPolyVec`) . (omega^)) ([1 .. order @PlonkBS] \\ [i])
 
 propPolyVecGrandProduct :: (Field c, Finite size, Ord c) => PolyVec c size -> c -> c -> Bool
@@ -106,3 +106,4 @@ specUnivariate = hspec $ do
             describe "polyVecGrandProduct" $ do
                 it "should satisfy the definition" $ do
                     property $ propPolyVecGrandProduct @F @PlonkBS
+


### PR DESCRIPTION
This is a big one.
* Made `Semiring` into a class with a `FromConstant Natural` constraint;
* Added an initial semiring instance -- `instance Semiring Natural`;
* Migrated most functions and types from `Integer` to `Natural` as this makes much more sense.

1. Some migrations might be unnecessary, in this case I could change it back.
2. Maybe, we could avoid specifying the concrete type of variables in polynomials until where this is actually needed. Most of the time, there is no substantial difference between Naturals and Integers.