### PR TITLE
Make UInt instances lawful, add strict ops

### DIFF
--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -8,7 +8,7 @@ import           Examples.Fibonacci   (exampleFibonacci)
 import           Examples.LEQ         (exampleLEQ)
 import           Examples.MiMCHash    (exampleMiMC)
 import           Examples.ReverseList (exampleReverseList)
-import           Examples.UInt        (exampleUIntAdd, exampleUIntMul)
+import           Examples.UInt        (exampleUIntAdd, exampleUIntMul, exampleUIntStrictAdd, exampleUIntStrictMul)
 import           Prelude
 import           System.Directory     (createDirectoryIfMissing)
 
@@ -26,3 +26,7 @@ main = do
     exampleUIntAdd @500
     exampleUIntMul @32
     exampleUIntMul @500
+    exampleUIntStrictAdd @32
+    exampleUIntStrictAdd @500
+    exampleUIntStrictMul @32
+    exampleUIntStrictMul @500

--- a/tests/Tests/UInt.hs
+++ b/tests/Tests/UInt.hs
@@ -3,58 +3,67 @@
 
 module Tests.UInt (specUInt) where
 
+import           Control.Applicative             ((<*>))
 import           Control.Monad                   (return)
 import           Data.Data                       (Proxy (..))
 import           Data.Function                   (($))
+import           Data.Functor                    ((<$>))
 import           Data.List                       (map, (++))
-import           GHC.Num                         (integerToNatural)
 import           GHC.TypeNats                    (KnownNat, natVal)
 import           Numeric.Natural                 (Natural)
 import           Prelude                         (div, show)
 import qualified Prelude                         as Haskell
 import           System.IO                       (IO)
 import           Test.Hspec                      (describe, hspec)
-import           Test.QuickCheck                 (Gen, chooseInteger, (===))
+import           Test.QuickCheck                 (Gen, Property, (===))
 import           Tests.ArithmeticCircuit         (eval', it)
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field (Zp)
+import           ZkFold.Prelude                  (chooseNatural)
 import           ZkFold.Symbolic.Compiler        (ArithmeticCircuit)
 import           ZkFold.Symbolic.Data.UInt
 
 toss :: Natural -> Gen Natural
-toss x = integerToNatural Haskell.<$> chooseInteger (0, Haskell.fromIntegral x)
+toss x = chooseNatural (0, x)
 
 value :: forall a n . UInt n (ArithmeticCircuit a) -> UInt n a
 value (UInt xs x) = UInt (map eval' xs) (eval' x)
 
+type Binary a = a -> a -> a
+
+type UBinary n a = Binary (UInt n a)
+
+isHom :: (KnownNat n, Prime p) => UBinary n (Zp p) -> UBinary n (ArithmeticCircuit (Zp p)) -> Natural -> Natural -> Property
+isHom f g x y = value (fromConstant x `g` fromConstant y) === fromConstant x `f` fromConstant y
+
 specUInt :: forall p n . (Prime p, KnownNat n) => IO ()
 specUInt = hspec $ do
     let n = Haskell.toInteger $ natVal (Proxy :: Proxy n)
+        m = 2 ^ n - 1
     describe ("UInt" ++ show n ++ " specification") $ do
         it "Zp embeds Integer" $ do
-            x <- toss (2 ^ n - 1)
+            x <- toss m
             return $ toNatural @p @n (fromConstant x) === x
         it "Integer embeds Zp" $ \(x :: UInt n (Zp p)) ->
             fromConstant (toNatural x) === x
         it "AC embeds Integer" $ do
-            x <- toss (2 ^ n - 1)
+            x <- toss m
             return $ value @(Zp p) @n (fromConstant x) === fromConstant x
-        it "adds correctly" $ do
-            x <- toss (2 ^ n - 1)
-            y <- toss (2 ^ n - 1 - x)
-            return $ value @(Zp p) @n (fromConstant x + fromConstant y)
-                === fromConstant x + fromConstant y
+        it "adds correctly" $ isHom @n @p (+) (+) <$> toss m <*> toss m
         it "has zero" $ value @(Zp p) @n zero === zero
-        it "negates correctly" $ value @(Zp p) @n (negate zero) === negate zero
-        it "subtracts correctly" $ do
-            x <- toss (2 ^ n - 1)
-            y <- toss x
-            return $ value @(Zp p) @n (fromConstant x - fromConstant y)
-                === fromConstant x - fromConstant y
-        it "multiplies correctly" $ do
-            x <- toss (2 ^ n - 1)
-            y <- toss ((2 ^ n - 1) `div` x)
-            return $ value @(Zp p) @n (fromConstant x * fromConstant y)
-                === fromConstant x * fromConstant y
+        it "negates correctly" $ do
+            x <- toss m
+            return $ value @(Zp p) @n (negate (fromConstant x)) === negate (fromConstant x)
+        it "subtracts correctly" $ isHom @n @p (-) (-) <$> toss m <*> toss m
+        it "multiplies correctly" $ isHom @n @p (*) (*) <$> toss m <*> toss m
         it "has one" $ value @(Zp p) @n one === one
+        it "strictly adds correctly" $ do
+            x <- toss m
+            isHom @n @p strictAdd strictAdd x <$> toss (m - x)
+        it "strictly subtracts correctly" $ do
+            x <- toss m
+            isHom @n @p strictSub strictSub x <$> toss x
+        it "strictly multiplies correctly" $ do
+            x <- toss m
+            isHom @n @p strictMul strictMul x <$> toss (m `div` x)


### PR DESCRIPTION
* made `UInt` operations wrapping; this way, `UInt n` is isomorphic to $\mathbb{Z}_{2^n}$ ring and is lawful
* moved previously defined operations to the new `StrictNum` class