### PR TITLE
migrate to typenats from Finite singleton mechanism

### DIFF
--- a/bench/BenchPolyMul.hs
+++ b/bench/BenchPolyMul.hs
@@ -18,26 +18,18 @@ import           Test.Tasty.Bench
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field
+import           ZkFold.Base.Algebra.Basic.Number            (Prime)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381
 import           ZkFold.Base.Algebra.Polynomials.Univariate
 import           ZkFold.Prelude                              (zipWithDefault)
 
 deriving instance Generic (Poly c)
 deriving instance (Generic c, NFData c) => NFData (Poly c)
-deriving instance Generic BLS12_381_Scalar
-deriving instance NFData BLS12_381_Scalar
-
-deriving instance Generic BLS12_381_Base
-deriving instance NFData BLS12_381_Base
 
 -- | Only for testing DFT with smaller numbers which can be easily calculated by hand for cross-check.
 -- DFT of a polynomial of length n requires calculating primitive roots of unity of order n.
 -- Choosing 17 allows us to calculate DFT of polynomials of length up to 256 and 16 as all these numbers divide 257 - 1.
-data P257
-    deriving (Generic, NFData)
-instance Finite P257 where
-    order = 257
-instance Prime P257
+instance Prime 257
 
 -- | Generate random polynomials of given size
 --
@@ -74,9 +66,9 @@ main = do
       putStrLn $ "Karatsuba\t" <> show (ref == p1 `benchKaratsuba` p2)
       putStrLn $ "Vector\t\t"  <> show (ref == p1 `benchVec` p2)
       putStrLn $ "DFT\t\t"     <> show (ref == p1 `benchDft` p2)
-  defaultMain $ 
+  defaultMain
       [ bgroup "Field with roots of unity"           $ flip fmap sizes $ \s -> benchOps @BLS12_381_Scalar s ops
-      , bgroup "Field with roots of unity up to 256" $ flip fmap sizes $ \s -> benchOps @P257 s $ tail ops
+      , bgroup "Field with roots of unity up to 256" $ flip fmap sizes $ \s -> benchOps @257 s $ tail ops
       , bgroup "Field without roots of unity"        $ flip fmap sizes $ \s -> benchOps @BLS12_381_Base s $ tail ops
       ]
 

--- a/examples/Examples/ReverseList.hs
+++ b/examples/Examples/ReverseList.hs
@@ -3,10 +3,9 @@
 
 module Examples.ReverseList (exampleReverseList) where
 
-import           Prelude                                     
+import           Prelude
 
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
-import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
 import           ZkFold.Base.Data.Vector
 import           ZkFold.Symbolic.Compiler
@@ -21,4 +20,5 @@ exampleReverseList = do
 
     putStrLn "\nExample: Reverse List function\n"
 
-    compileIO @(Zp BLS12_381_Scalar) file (reverseList @(ArithmeticCircuit (Zp BLS12_381_Scalar)) @N32)
+    compileIO @(Zp BLS12_381_Scalar) file (reverseList @(ArithmeticCircuit (Zp BLS12_381_Scalar)) @32)
+

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,8 +1,13 @@
 cradle:
   cabal:
-    - path: "src"
-      component: "zkfold-base:lib:zkfold-base"
-    - path: "tests"
+    - path: "./src"
+      component: "lib:zkfold-base"
+
+    - path: "./tests"
       component: "zkfold-base:test:zkfold-base-test"
-    - path: "examples"
+
+    - path: "./examples"
       component: "zkfold-base:test:zkfold-base-examples"
+
+    - path: "./bench/BenchPolyMul.hs"
+      component: "zkfold-base:bench:polynomial-multiplication"

--- a/src/ZkFold/Base/Algebra/Basic/Class.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Class.hs
@@ -3,11 +3,14 @@
 
 module ZkFold.Base.Algebra.Basic.Class where
 
-import           GHC.Natural    (Natural, naturalFromInteger)
-import           Prelude        hiding (Num (..), length, negate, product, replicate, sum, (/), (^))
-import qualified Prelude        as Haskell
+import           Data.Kind                        (Type)
+import           GHC.Natural                      (Natural, naturalFromInteger)
+import           GHC.TypeNats                     (KnownNat)
+import           Prelude                          hiding (Num (..), length, negate, product, replicate, sum, (/), (^))
+import qualified Prelude                          as Haskell
 
-import           ZkFold.Prelude (length, replicate)
+import           ZkFold.Base.Algebra.Basic.Number (Prime, value)
+import           ZkFold.Prelude                   (length, replicate)
 
 infixl 7 *, /
 infixl 6 +, -
@@ -62,18 +65,19 @@ class (AdditiveMonoid a, MultiplicativeMonoid a, FromConstant Natural a) => Semi
 class (Semiring a, AdditiveGroup a, FromConstant Integer a) => Ring a
 
 -- NOTE: by convention, division by zero returns zero.
-class (Ring a, MultiplicativeGroup a) => Field a where 
+class (Ring a, MultiplicativeGroup a) => Field a where
     rootOfUnity :: Natural -> Maybe a
-    rootOfUnity 0 = Just one 
+    rootOfUnity 0 = Just one
     rootOfUnity _ = Nothing
 
-class Finite a where
-    order :: Natural
+class KnownNat (Order a) => Finite (a :: Type) where
+    type Order a :: Natural
+
+order :: forall a . Finite a => Natural
+order = value @(Order a)
 
 numberOfBits :: forall a . Finite a => Natural
 numberOfBits = ceiling $ logBase @Double 2 $ Haskell.fromIntegral $ order @a
-
-class Finite a => Prime a
 
 type FiniteAdditiveGroup a = (Finite a, AdditiveGroup a)
 
@@ -81,7 +85,7 @@ type FiniteMultiplicativeGroup a = (Finite a, MultiplicativeGroup a)
 
 type FiniteField a = (Finite a, Field a)
 
-type PrimeField a = (Prime a, FiniteField a)
+type PrimeField a = (FiniteField a, Prime (Order a))
 
 --------------------------------------------------------------------------------
 

--- a/src/ZkFold/Base/Algebra/Basic/Number.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Number.hs
@@ -1,37 +1,12 @@
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators    #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications    #-}
 
-{-# OPTIONS_GHC -Wno-orphans  #-}
+module ZkFold.Base.Algebra.Basic.Number (KnownNat, Prime, value, type (*), type (+), type (^)) where
 
-module ZkFold.Base.Algebra.Basic.Number where
+import           Data.Data    (Proxy (Proxy))
+import           GHC.TypeNats (KnownNat, Natural, natVal, type (*), type (+), type (^))
 
-import           Prelude                         hiding (Num(..), (/), (^))
-import           Type.Data.Num.Unary             (Zero, Succ, (:*:))
+class KnownNat p => Prime p
 
-import           ZkFold.Base.Algebra.Basic.Class
-
--- | Type-level natural numbers
-
-instance Finite Zero where
-    order = 0
-
-instance Finite n => Finite (Succ n) where
-    order = 1 + order @n
-
-type N0     = Zero
-type N1     = Succ N0
-type N2     = Succ N1
-type N4     = N2 :*: N2
-type N8     = N4 :*: N2
-type N16    = N8 :*: N2
-type N32    = N16 :*: N2
-type N64    = N32 :*: N2
-type N128   = N64 :*: N2
-type N256   = N128 :*: N2
-type N512   = N256 :*: N2
-type N1024  = N512 :*: N2
-type N2048  = N1024 :*: N2
-type N4096  = N2048 :*: N2
-type N8192  = N4096 :*: N2
-type N16384 = N8192 :*: N2
-type N32768 = N16384 :*: N2
+value :: forall n . KnownNat n => Natural
+value = natVal (Proxy @n)

--- a/src/ZkFold/Base/Algebra/Basic/Permutations.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Permutations.hs
@@ -11,17 +11,18 @@ module ZkFold.Base.Algebra.Basic.Permutations (
     fromCycles
 ) where
 
-import           Data.Map                        (Map, elems, empty, singleton, union)
-import           Data.Maybe                      (fromJust)
-import qualified Data.Vector                     as V
-import           Numeric.Natural                 (Natural)
-import           Prelude                         hiding (Num (..), drop, length, (!!))
-import qualified Prelude                         as P
-import           Test.QuickCheck                 (Arbitrary (..))
+import           Data.Map                         (Map, elems, empty, singleton, union)
+import           Data.Maybe                       (fromJust)
+import qualified Data.Vector                      as V
+import           Numeric.Natural                  (Natural)
+import           Prelude                          hiding (Num (..), drop, length, (!!))
+import qualified Prelude                          as P
+import           Test.QuickCheck                  (Arbitrary (..))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Data.Vector         (Vector (..), fromVector, toVector)
-import           ZkFold.Prelude                  (chooseNatural, drop, length, (!!))
+import           ZkFold.Base.Algebra.Basic.Number
+import           ZkFold.Base.Data.Vector          (Vector (..), fromVector, toVector)
+import           ZkFold.Prelude                   (chooseNatural, drop, length, (!!))
 
 -- TODO (Issue #18): make the code safer
 
@@ -40,7 +41,7 @@ mkIndexPartition vs =
 newtype Permutation n = Permutation (Vector n Natural)
     deriving (Show, Eq)
 
-instance Finite n => Arbitrary (Permutation n) where
+instance KnownNat n => Arbitrary (Permutation n) where
     arbitrary =
         let f as [] = return as
             f as bs = do
@@ -48,7 +49,7 @@ instance Finite n => Arbitrary (Permutation n) where
                 let as' = (bs !! i) : as
                     bs' = drop i bs
                 f as' bs'
-        in Permutation . Vector <$> f [] [1..order @n]
+        in Permutation . Vector <$> f [] [1..value @n]
 
 fromPermutation :: Permutation n -> [Natural]
 fromPermutation (Permutation perm) = fromVector perm
@@ -64,7 +65,7 @@ applyCycle c (Permutation perm) = Permutation $ fmap f perm
             Just j  -> c V.! ((j P.+ 1) `mod` V.length c)
             Nothing -> i
 
-fromCycles :: Finite n => IndexPartition a -> Permutation n
+fromCycles :: KnownNat n => IndexPartition a -> Permutation n
 fromCycles p =
     let n = fromIntegral $ V.length $ V.concat $ elems p
     in foldr applyCycle (Permutation $ fromJust $ toVector [1 .. n]) $ elems p

--- a/src/ZkFold/Base/Algebra/Basic/Scale.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Scale.hs
@@ -27,7 +27,7 @@ newtype Self a = Self { getSelf :: a }
     deriving (Eq)
     deriving newtype (AdditiveSemigroup, AdditiveMonoid, AdditiveGroup,
                       MultiplicativeSemigroup, MultiplicativeMonoid, MultiplicativeGroup,
-                      BinaryExpansion, Finite)
+                      BinaryExpansion)
 
 deriving newtype instance FromConstant c a => FromConstant c (Self a)
 
@@ -36,6 +36,8 @@ deriving newtype instance Semiring a => Semiring (Self a)
 deriving newtype instance Ring a => Ring (Self a)
 
 deriving newtype instance Field a => Field (Self a)
+
+deriving newtype instance Finite a => Finite (Self a)
 
 instance Ring a => Scale (Self a) a where
     scale a (Self b) = Self (a * b)

--- a/src/ZkFold/Base/Algebra/EllipticCurve/BLS12_381.hs
+++ b/src/ZkFold/Base/Algebra/EllipticCurve/BLS12_381.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE OverloadedLists  #-}
 {-# LANGUAGE TypeApplications #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module ZkFold.Base.Algebra.EllipticCurve.BLS12_381 where
 
 import           Data.Bits                                  (shiftR)
@@ -10,19 +12,16 @@ import           Prelude                                    hiding (Num (..), (/
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field
+import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Base.Algebra.EllipticCurve.Class
 import           ZkFold.Base.Algebra.Polynomials.Univariate
 
 -------------------------------- Introducing Fields ----------------------------------
 
-data BLS12_381_Scalar
-instance Finite BLS12_381_Scalar where
-    order = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
+type BLS12_381_Scalar = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
 instance Prime BLS12_381_Scalar
 
-data BLS12_381_Base
-instance Finite BLS12_381_Base where
-    order = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+type BLS12_381_Base = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
 instance Prime BLS12_381_Base
 
 type Fr = Zp BLS12_381_Scalar

--- a/src/ZkFold/Base/Algebra/Polynomials/Multivariate/Monomial/Class.hs
+++ b/src/ZkFold/Base/Algebra/Polynomials/Multivariate/Monomial/Class.hs
@@ -1,12 +1,13 @@
 module ZkFold.Base.Algebra.Polynomials.Multivariate.Monomial.Class where
 
-import           Data.Map                          (Map, fromListWith)
-import qualified Data.Map                          as Map
-import           Prelude                           hiding (Num(..), (/), replicate)
+import           Data.Map                         (Map, fromListWith)
+import qualified Data.Map                         as Map
+import           Prelude                          hiding (Num (..), replicate, (/))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Data.Vector           (Vector, fromVector, toVector)
-import           ZkFold.Prelude                    (replicate)
+import           ZkFold.Base.Algebra.Basic.Number (KnownNat)
+import           ZkFold.Base.Data.Vector          (Vector, fromVector, toVector)
+import           ZkFold.Prelude                   (replicate)
 
 type Variable i = Ord i
 
@@ -31,7 +32,7 @@ class Monomial i j => ToMonomial i j m where
 instance Monomial i j => ToMonomial i j (Map i j) where
     toMonomial   = Just . Map.filter (/= zero)
 
-instance (Monomial i j, Integral j, Finite d) => ToMonomial i j (Vector d (i, Bool)) where
+instance (Monomial i j, Integral j, KnownNat d) => ToMonomial i j (Vector d (i, Bool)) where
     toMonomial m =
         let v = foldl (\acc (i, j) -> acc ++ replicate (fromIntegral j) (i, True)) [] $ Map.toList m
         in toVector v

--- a/src/ZkFold/Base/Data/Sparse/Matrix.hs
+++ b/src/ZkFold/Base/Data/Sparse/Matrix.hs
@@ -1,12 +1,12 @@
 module ZkFold.Base.Data.Sparse.Matrix where
 
-import           Data.Map                        (Map)
-import           Data.Zip                        (Semialign (..), Zip (..))
-import           Prelude                         hiding ((*), sum, length, zip, zipWith)
-import           Test.QuickCheck                 (Arbitrary (..))
+import           Data.Map                         (Map)
+import           Data.Zip                         (Semialign (..), Zip (..))
+import           Prelude                          hiding (length, sum, zip, zipWith, (*))
+import           Test.QuickCheck                  (Arbitrary (..))
 
-import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.Basic.Field (Zp)
+import           ZkFold.Base.Algebra.Basic.Field  (Zp)
+import           ZkFold.Base.Algebra.Basic.Number (KnownNat)
 
 newtype SMatrix m n a = SMatrix { fromSMatrix :: Map (Zp m, Zp n) a }
     deriving (Show, Eq)
@@ -17,15 +17,16 @@ instance Foldable (SMatrix m n) where
 instance Functor (SMatrix m n) where
     fmap f (SMatrix as) = SMatrix $ fmap f as
 
-instance (Finite m, Finite n) => Semialign (SMatrix m n) where
+instance (KnownNat m, KnownNat n) => Semialign (SMatrix m n) where
     align (SMatrix as) (SMatrix bs) = SMatrix $ align as bs
 
     alignWith f (SMatrix as) (SMatrix bs) = SMatrix $ alignWith f as bs
 
-instance (Finite m, Finite n) => Zip (SMatrix m n) where
+instance (KnownNat m, KnownNat n) => Zip (SMatrix m n) where
     zip (SMatrix as) (SMatrix bs) = SMatrix $ zip as bs
 
     zipWith f (SMatrix as) (SMatrix bs) = SMatrix $ zipWith f as bs
 
-instance (Finite m, Finite n, Arbitrary a) => Arbitrary (SMatrix m n a) where
+instance (KnownNat m, KnownNat n, Arbitrary a) => Arbitrary (SMatrix m n a) where
     arbitrary = SMatrix <$> arbitrary
+

--- a/src/ZkFold/Base/Data/Sparse/Vector.hs
+++ b/src/ZkFold/Base/Data/Sparse/Vector.hs
@@ -1,14 +1,15 @@
 module ZkFold.Base.Data.Sparse.Vector where
 
-import           Data.Map                        (Map, empty, filter)
-import           Data.These                      (These(..))
-import           Data.Zip                        (Semialign (..), Zip (..))
-import           Prelude                         hiding (Num(..), (/), sum, length, filter, zip, zipWith)
-import           Test.QuickCheck                 (Arbitrary (..))
+import           Data.Map                         (Map, empty, filter)
+import           Data.These                       (These (..))
+import           Data.Zip                         (Semialign (..), Zip (..))
+import           Prelude                          hiding (Num (..), filter, length, sum, zip, zipWith, (/))
+import           Test.QuickCheck                  (Arbitrary (..))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.Basic.Field (Zp)
-import           ZkFold.Base.Data.ByteString     (ToByteString(..))
+import           ZkFold.Base.Algebra.Basic.Field  (Zp)
+import           ZkFold.Base.Algebra.Basic.Number (KnownNat)
+import           ZkFold.Base.Data.ByteString      (ToByteString (..))
 
 newtype SVector size a = SVector { fromSVector :: Map (Zp size) a }
     deriving (Show, Eq)
@@ -22,39 +23,39 @@ instance Foldable (SVector size) where
 instance Functor (SVector size) where
     fmap f (SVector as) = SVector $ fmap f as
 
-instance Finite size => Semialign (SVector size) where
+instance KnownNat size => Semialign (SVector size) where
     align (SVector as) (SVector bs) = SVector $ align as bs
 
     alignWith f (SVector as) (SVector bs) = SVector $ alignWith f as bs
 
-instance Finite size => Zip (SVector size) where
+instance KnownNat size => Zip (SVector size) where
     zip (SVector as) (SVector bs) = SVector $ zip as bs
 
     zipWith f (SVector as) (SVector bs) = SVector $ zipWith f as bs
 
-instance (Finite size, Arbitrary a) => Arbitrary (SVector size a) where
+instance (KnownNat size, Arbitrary a) => Arbitrary (SVector size a) where
     arbitrary = SVector <$> arbitrary
 
-instance (Finite size, AdditiveMonoid a, Eq a) => AdditiveSemigroup (SVector size a) where
+instance (KnownNat size, AdditiveMonoid a, Eq a) => AdditiveSemigroup (SVector size a) where
     va + vb = SVector $ filter (/= zero) $ fromSVector $ alignWith (\case
         This a -> a
         That b -> b
         These a b -> a + b) va vb
 
-(.+) :: (Finite size, AdditiveMonoid a, Eq a) => SVector size a -> SVector size a -> SVector size a
+(.+) :: (KnownNat size, AdditiveMonoid a, Eq a) => SVector size a -> SVector size a -> SVector size a
 (.+) = (+)
 
-instance (Finite size, AdditiveMonoid a, Eq a) => AdditiveMonoid (SVector size a) where
+instance (KnownNat size, AdditiveMonoid a, Eq a) => AdditiveMonoid (SVector size a) where
     zero = SVector empty
 
-instance (Finite size, AdditiveGroup a, Eq a) => AdditiveGroup (SVector size a) where
+instance (KnownNat size, AdditiveGroup a, Eq a) => AdditiveGroup (SVector size a) where
     negate = fmap negate
 
-(.-) :: (Finite size, AdditiveGroup a, Eq a) => SVector size a -> SVector size a -> SVector size a
+(.-) :: (KnownNat size, AdditiveGroup a, Eq a) => SVector size a -> SVector size a -> SVector size a
 (.-) = (-)
 
-(.*) :: (Finite size, MultiplicativeSemigroup a) => SVector size a -> SVector size a -> SVector size a
+(.*) :: (KnownNat size, MultiplicativeSemigroup a) => SVector size a -> SVector size a -> SVector size a
 (.*) = zipWith (*)
 
-(./) :: (Finite size, MultiplicativeGroup a) => SVector size a -> SVector size a -> SVector size a
+(./) :: (KnownNat size, MultiplicativeGroup a) => SVector size a -> SVector size a -> SVector size a
 (./) = zipWith (/)

--- a/src/ZkFold/Base/Data/Vector.hs
+++ b/src/ZkFold/Base/Data/Vector.hs
@@ -1,24 +1,27 @@
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators    #-}
 
 module ZkFold.Base.Data.Vector where
 
-import           Data.Bifunctor                  (first)
-import           Data.These                      (These (..))
-import           Data.Zip                        (Semialign (..), Zip (..))
-import           Prelude                         hiding ((*), sum, length, zip, zipWith, replicate)
-import           System.Random                   (Random(..))
-import           Test.QuickCheck                 (Arbitrary (..))
+import           Data.Bifunctor                   (first)
+import           Data.These                       (These (..))
+import           Data.Zip                         (Semialign (..), Zip (..))
+import           Numeric.Natural                  (Natural)
+import           Prelude                          hiding (length, replicate, sum, zip, zipWith, (*))
+import           System.Random                    (Random (..))
+import           Test.QuickCheck                  (Arbitrary (..))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Data.ByteString     (ToByteString(..))
-import           ZkFold.Prelude                  (length, replicate)
+import           ZkFold.Base.Algebra.Basic.Number
+import           ZkFold.Base.Data.ByteString      (ToByteString (..))
+import           ZkFold.Prelude                   (length, replicate)
 
-newtype Vector size a = Vector [a]
-    deriving (Show, Eq)
+newtype Vector (size :: Natural) a = Vector [a]
+    deriving (Show, Eq, Functor, Foldable, Traversable)
 
-toVector :: forall size a . Finite size => [a] -> Maybe (Vector size a)
+toVector :: forall size a . KnownNat size => [a] -> Maybe (Vector size a)
 toVector as
-    | length as == order @size = Just $ Vector as
+    | length as == value @size = Just $ Vector as
     | otherwise                = Nothing
 
 fromVector :: Vector size a -> [a]
@@ -27,17 +30,14 @@ fromVector (Vector as) = as
 vectorDotProduct :: forall size a . Semiring a => Vector size a -> Vector size a -> a
 vectorDotProduct (Vector as) (Vector bs) = sum $ zipWith (*) as bs
 
+concat :: Vector m (Vector n a) -> Vector (m * n) a
+concat = Vector . concatMap fromVector
+
 instance ToByteString a => ToByteString (Vector n a) where
     toByteString = toByteString . fromVector
 
-instance Foldable (Vector size) where
-    foldr f z (Vector as) = foldr f z as
-
-instance Functor (Vector size) where
-    fmap f (Vector as) = Vector $ map f as
-
-instance Finite size => Applicative (Vector size) where
-    pure a = Vector $ replicate (order @size) a
+instance KnownNat size => Applicative (Vector size) where
+    pure a = Vector $ replicate (value @size) a
 
     (Vector fs) <*> (Vector as) = Vector $ zipWith ($) fs as
 
@@ -49,19 +49,19 @@ instance Zip (Vector size) where
 
     zipWith f (Vector as) (Vector bs) = Vector $ zipWith f as bs
 
-instance (Arbitrary a, Finite size) => Arbitrary (Vector size a) where
-    arbitrary = Vector <$> mapM (const arbitrary) [1..order @size]
+instance (Arbitrary a, KnownNat size) => Arbitrary (Vector size a) where
+    arbitrary = Vector <$> mapM (const arbitrary) [1..value @size]
 
-instance (Random a, Finite size) => Random (Vector size a) where
+instance (Random a, KnownNat size) => Random (Vector size a) where
     random g =
         let as = foldl (\(as', g') _ ->
                 let (a, g'') = random g'
                 in (as' ++ [a], g''))
-                ([], g) [1..order @size]
+                ([], g) [1..value @size]
         in first Vector as
-    
+
     randomR (Vector xs, Vector ys) g =
         let as = fst $ foldl (\((as', g'), (xs', ys')) _ ->
                 let (a, g'') = randomR (head xs', head ys') g'
-                in ((as' ++ [a], g''), (tail xs', tail ys'))) (([], g), (xs, ys)) [1..order @size]
+                in ((as' ++ [a], g''), (tail xs', tail ys'))) (([], g), (xs, ys)) [1..value @size]
         in first Vector as

--- a/src/ZkFold/Base/Protocol/ARK/Plonk.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Plonk.hs
@@ -5,7 +5,6 @@
 
 module ZkFold.Base.Protocol.ARK.Plonk where
 
-import           Data.ByteString                             (ByteString)
 import           Data.Map                                    (Map, elems, singleton)
 import qualified Data.Map                                    as Map
 import qualified Data.Vector                                 as V
@@ -45,16 +44,10 @@ instance Arbitrary (Plonk d t) where
         ac <- arbitrary
         Plonk omega k1 k2 (singleton (acOutput ac) 15) ac <$> arbitrary
 
--- TODO (Issue #25): We should have several options for size of the polynomials. Most code should be generic in this parameter.
-type PlonkSizeBS = 32
-type PlonkBS = Plonk PlonkSizeBS ByteString
-
 type PlonkPermutationSize d = 3 * d
 
 -- TODO (Issue #25): check that the extended polynomials are of the right size
 type PlonkMaxPolyDegree d = 4 * d + 7
-
-type PlonkMaxPolyDegreeBS = PlonkMaxPolyDegree PlonkSizeBS
 
 type PolyPlonkExtended d = PolyVec F (PlonkMaxPolyDegree d)
 

--- a/src/ZkFold/Base/Protocol/ARK/Plonk/Internal.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Plonk/Internal.hs
@@ -9,13 +9,14 @@ import           Data.Containers.ListUtils                    (nubOrd)
 import           Data.List                                    (find, permutations, sort, transpose)
 import           Data.Map                                     (Map, delete, elems, empty, fromList, toList)
 import           Data.Maybe                                   (mapMaybe)
+import qualified Data.Vector                                  as V
 import           Numeric.Natural                              (Natural)
 import           Prelude                                      hiding (Num (..), drop, length, sum, take, (!!), (/), (^))
 import           System.Random                                (RandomGen, mkStdGen, uniformR)
-import qualified Data.Vector as V
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field              (fromZp)
+import           ZkFold.Base.Algebra.Basic.Number             (KnownNat)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381  (BLS12_381_G1, BLS12_381_G2)
 import           ZkFold.Base.Algebra.EllipticCurve.Class
 import           ZkFold.Base.Algebra.Polynomials.Multivariate (M (..), P (..), SomePolynomial, polynomial, variables)
@@ -36,7 +37,7 @@ getParams l = findK' $ mkStdGen 0
     where
         omega = case rootOfUnity l of
                   Just o -> o
-                  _ -> error "impossible"
+                  _      -> error "impossible"
         hGroup = map (omega^) [1 :: Integer .. 2^l-1]
         hGroup' k = map (k*) hGroup
 
@@ -101,7 +102,7 @@ removeConstantVariable :: SomePolynomialF -> SomePolynomialF
 removeConstantVariable (P ms) =
     polynomial . map (\(c, M as) -> (c, M (0 `delete` as))) $ ms
 
-toPlonkArithmetization :: forall a . Finite a => Map Natural F -> ArithmeticCircuit F
+toPlonkArithmetization :: forall a . KnownNat a => Map Natural F -> ArithmeticCircuit F
     -> (PolyVec F a, PolyVec F a, PolyVec F a, PolyVec F a, PolyVec F a, PolyVec F a, PolyVec F a, PolyVec F a)
 toPlonkArithmetization inputs ac =
     let f (x0, x1, x2, x3, x4, x5, x6, x7) = [x0, x1, x2, x3, x4, x5, x6, x7]

--- a/src/ZkFold/Base/Protocol/ARK/Protostar/Gate.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Protostar/Gate.hs
@@ -1,12 +1,12 @@
 module ZkFold.Base.Protocol.ARK.Protostar.Gate where
 
-import           Data.Kind                                       (Type)
 import           Data.Zip                                        (zipWith)
 import           Numeric.Natural                                 (Natural)
 import           Prelude                                         hiding (Num (..), zipWith, (!!), (^))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field                 (Zp)
+import           ZkFold.Base.Algebra.Basic.Number                (KnownNat)
 import           ZkFold.Base.Algebra.Basic.Scale                 (scale')
 import           ZkFold.Base.Algebra.Polynomials.Multivariate    (SomePolynomial, evalPolynomial', subs, substitutePolynomial, var)
 import           ZkFold.Base.Data.Matrix                         (Matrix (..), outer, sum1, transpose)
@@ -15,9 +15,9 @@ import           ZkFold.Base.Protocol.ARK.Protostar.Internal     (PolynomialProt
 import           ZkFold.Base.Protocol.ARK.Protostar.SpecialSound (SpecialSoundProtocol (..), SpecialSoundTranscript)
 import           ZkFold.Symbolic.Compiler.Arithmetizable         (Arithmetic)
 
-data ProtostarGate (m :: Type) (n :: Type) (c :: Type) (d :: Type)
+data ProtostarGate (m :: Natural) (n :: Natural) (c :: Natural) (d :: Natural)
 
-instance (Arithmetic f, Finite m, Finite n, Finite c) => SpecialSoundProtocol f (ProtostarGate m n c d) where
+instance (Arithmetic f, KnownNat m, KnownNat n, KnownNat c) => SpecialSoundProtocol f (ProtostarGate m n c d) where
     type Witness f (ProtostarGate m n c d)       = Vector n (Vector c f)
     -- ^ [(a_j, w_j)]_{j=1}^n where [w_j]_{j=1}^n is from the paper together and [a_j]_{j=1}^n are their absolute indices
     type Input f (ProtostarGate m n c d)         = (Matrix m n f, Vector m (PolynomialProtostar f c d))

--- a/src/ZkFold/Base/Protocol/ARK/Protostar/Lookup.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Protostar/Lookup.hs
@@ -1,29 +1,28 @@
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module ZkFold.Base.Protocol.ARK.Protostar.Lookup where
 
-import           Data.Kind                                       (Type)
 import           Data.Map                                        (fromList, mapWithKey)
 import           Data.These                                      (These (..))
 import           Data.Zip
 import           Numeric.Natural                                 (Natural)
 import           Prelude                                         hiding (Num (..), repeat, sum, zip, zipWith, (!!), (/), (^))
-import           Type.Data.Num.Unary                             (Succ, (:+:))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field                 (Zp)
-import           ZkFold.Base.Algebra.Basic.Number                (N2)
+import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Base.Algebra.Polynomials.Multivariate    (SomePolynomial)
 import           ZkFold.Base.Data.Sparse.Vector                  (SVector (..))
 import           ZkFold.Base.Data.Vector                         (Vector)
 import           ZkFold.Base.Protocol.ARK.Protostar.SpecialSound (SpecialSoundProtocol (..), SpecialSoundTranscript)
 import           ZkFold.Symbolic.Compiler                        (Arithmetic)
 
-data ProtostarLookup (l :: Type) (sizeT :: Type)
+data ProtostarLookup (l :: Natural) (sizeT :: Natural)
 
 data ProtostarLookupParams f sizeT = ProtostarLookupParams (Zp sizeT -> f) (f -> [Zp sizeT])
 
-instance (Arithmetic f, Finite sizeT) => SpecialSoundProtocol f (ProtostarLookup l sizeT) where
+instance (Arithmetic f, KnownNat sizeT) => SpecialSoundProtocol f (ProtostarLookup l sizeT) where
     type Witness f (ProtostarLookup l sizeT)         = Vector l f
     -- ^ w in the paper
     type Input f (ProtostarLookup l sizeT)           = ProtostarLookupParams f sizeT
@@ -32,8 +31,8 @@ instance (Arithmetic f, Finite sizeT) => SpecialSoundProtocol f (ProtostarLookup
     -- ^ (w, m) or (h, g) in the paper
     type VerifierMessage t (ProtostarLookup l sizeT) = t
 
-    type Dimension (ProtostarLookup l sizeT)         = Succ (l :+: sizeT)
-    type Degree (ProtostarLookup l sizeT)            = N2
+    type Dimension (ProtostarLookup l sizeT)         = l + sizeT + 1
+    type Degree (ProtostarLookup l sizeT)            = 2
 
     rounds :: ProtostarLookup l sizeT -> Natural
     rounds _ = 2

--- a/src/ZkFold/Base/Protocol/ARK/Protostar/Permutation.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Protostar/Permutation.hs
@@ -1,19 +1,17 @@
 module ZkFold.Base.Protocol.ARK.Protostar.Permutation where
 
-import           Data.Kind                                       (Type)
 import           Data.Zip                                        (Zip (..))
 import           Numeric.Natural                                 (Natural)
 import           Prelude                                         hiding (Num (..), zipWith, (!!), (^))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.Basic.Number                (N1)
 import           ZkFold.Base.Algebra.Basic.Permutations          (Permutation, applyPermutation)
 import           ZkFold.Base.Algebra.Polynomials.Multivariate    (SomePolynomial, var)
 import           ZkFold.Base.Data.Vector                         (Vector)
 import           ZkFold.Base.Protocol.ARK.Protostar.SpecialSound (SpecialSoundProtocol (..), SpecialSoundTranscript)
 import           ZkFold.Symbolic.Compiler                        (Arithmetic)
 
-data ProtostarPermutation (n :: Type)
+data ProtostarPermutation (n :: Natural)
 
 instance Arithmetic f => SpecialSoundProtocol f (ProtostarPermutation n) where
     type Witness f (ProtostarPermutation n)         = Vector n f
@@ -25,7 +23,7 @@ instance Arithmetic f => SpecialSoundProtocol f (ProtostarPermutation n) where
     type VerifierMessage t (ProtostarPermutation n) = ()
 
     type Dimension (ProtostarPermutation n)         = n
-    type Degree (ProtostarPermutation n)            = N1
+    type Degree (ProtostarPermutation n)            = 1
 
     rounds :: ProtostarPermutation n -> Natural
     rounds _ = 1

--- a/src/ZkFold/Base/Protocol/ARK/Protostar/SpecialSound.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Protostar/SpecialSound.hs
@@ -17,9 +17,9 @@ class Arithmetic f => SpecialSoundProtocol f a where
       type ProverMessage t a
       type VerifierMessage t a
 
-      type Dimension a
+      type Dimension a :: Natural
       -- ^ l in the paper
-      type Degree a
+      type Degree a :: Natural
       -- ^ d in the paper
 
       rounds :: a -> Natural

--- a/src/ZkFold/Base/Protocol/Commitment/KZG.hs
+++ b/src/ZkFold/Base/Protocol/Commitment/KZG.hs
@@ -9,26 +9,25 @@ import           Data.ByteString                            (ByteString, empty)
 import           Data.Kind                                  (Type)
 import           Data.Map.Strict                            (Map, fromList, insert, keys, toList, (!))
 import qualified Data.Vector                                as V
+import           Numeric.Natural                            (Natural)
 import           Prelude                                    hiding (Num (..), length, sum, (/), (^))
 import           Test.QuickCheck                            (Arbitrary (..), chooseInt)
 
 import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Base.Algebra.EllipticCurve.Class
 import           ZkFold.Base.Algebra.Polynomials.Univariate
 import           ZkFold.Base.Data.ByteString                (FromByteString, ToByteString)
 import           ZkFold.Base.Protocol.NonInteractiveProof
 
-newtype KZG c1 c2 t f d = KZG f
+-- | `d` is the degree of polynomials in the protocol
+newtype KZG c1 c2 t f (d :: Natural) = KZG f
     deriving (Show, Eq, Arbitrary)
 
--- The degree of polynomials in the protocol
-instance Finite d => Finite (KZG c1 c2 t f d) where
-    order = order @d
-
-newtype WitnessKZG c1 c2 t f d = WitnessKZG { runWitness :: Map f (V.Vector (PolyVec f (KZG c1 c2 t f d))) }
+newtype WitnessKZG c1 c2 t f d = WitnessKZG { runWitness :: Map f (V.Vector (PolyVec f d)) }
 instance (EllipticCurve c1, f ~ ScalarField c1) => Show (WitnessKZG c1 c2 t f d) where
     show (WitnessKZG w) = "WitnessKZG " <> show w
-instance (EllipticCurve c1, f ~ ScalarField c1, Finite d) => Arbitrary (WitnessKZG c1 c2 t f d) where
+instance (EllipticCurve c1, f ~ ScalarField c1, KnownNat d) => Arbitrary (WitnessKZG c1 c2 t f d) where
     arbitrary = do
         n <- chooseInt (1, 3)
         m <- chooseInt (1, 5)
@@ -36,7 +35,7 @@ instance (EllipticCurve c1, f ~ ScalarField c1, Finite d) => Arbitrary (WitnessK
 
 -- TODO (Issue #18): check list lengths
 instance forall (c1 :: Type) (c2 :: Type) t f d kzg . (f ~ ScalarField c1, f ~ ScalarField c2,
-        Pairing c1 c2 t, ToByteString f, FromByteString f, Finite d, KZG c1 c2 t f d ~ kzg)
+        Pairing c1 c2 t, ToByteString f, FromByteString f, KnownNat d, KZG c1 c2 t f d ~ kzg)
         => NonInteractiveProof (KZG c1 c2 t f d) where
     type Transcript (KZG c1 c2 t f d)   = ByteString
     type Setup (KZG c1 c2 t f d)        = (V.Vector (Point c1), Point c2, Point c2)
@@ -46,7 +45,7 @@ instance forall (c1 :: Type) (c2 :: Type) t f d kzg . (f ~ ScalarField c1, f ~ S
 
     setup :: kzg -> Setup kzg
     setup (KZG x) =
-        let d  = order @kzg
+        let d  = value @d
             xs = V.fromList $ map (x^) [0..d-1]
             gs = fmap (`mul` gen) xs
         in (gs, gen, x `mul` gen)
@@ -57,7 +56,7 @@ instance forall (c1 :: Type) (c2 :: Type) t f d kzg . (f ~ ScalarField c1, f ~ S
     prove (gs, _, _) (WitnessKZG w) = snd $ foldl proveOne (empty, (mempty, mempty)) (toList w)
         where
             proveOne :: (Transcript kzg, (Input kzg, Proof kzg))
-                     -> (f, V.Vector (PolyVec f kzg))
+                     -> (f, V.Vector (PolyVec f d))
                      -> (Transcript kzg, (Input kzg, Proof kzg))
             proveOne (ts, (iMap, pMap)) (z, fs) = (ts'', (insert z (cms, fzs) iMap, insert z (gs `com` h) pMap))
                 where
@@ -95,13 +94,13 @@ instance forall (c1 :: Type) (c2 :: Type) t f d kzg . (f ~ ScalarField c1, f ~ S
                     (r, ts'')    = if ts == empty then (one, ts') else challenge ts'
 
                     v0' = r `mul` sum (V.zipWith mul gamma cms)
-                        - r `mul` (gs `com` toPolyVec @f @kzg [V.sum $ V.zipWith (*) gamma fzs])
+                        - r `mul` (gs `com` toPolyVec @f @d [V.sum $ V.zipWith (*) gamma fzs])
                         + (r * z) `mul` w
                     v1' = r `mul` w
 
 ------------------------------------ Helper functions ------------------------------------
 
-provePolyVecEval :: forall size f . (Finite size, FiniteField f, Eq f) => PolyVec f size -> f -> PolyVec f size
+provePolyVecEval :: forall size f . (KnownNat size, FiniteField f, Eq f) => PolyVec f size -> f -> PolyVec f size
 provePolyVecEval f z = (f - toPolyVec [negate $ f `evalPolyVec` z]) / toPolyVec [negate z, one]
 
 com :: (EllipticCurve curve, f ~ ScalarField curve) => V.Vector (Point curve) -> PolyVec f size -> Point curve

--- a/src/ZkFold/Symbolic/Cardano/Types/Value.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/Value.hs
@@ -2,12 +2,14 @@
 
 module ZkFold.Symbolic.Cardano.Types.Value where
 
-import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Data.Vector         (Vector (Vector))
-import           ZkFold.Symbolic.Compiler
-import           ZkFold.Symbolic.Data.UInt       (UInt)
+import           Numeric.Natural                  (Natural)
 
-newtype Value size a = Value [(a, a, UInt 32 a)]
+import           ZkFold.Base.Algebra.Basic.Number (KnownNat)
+import           ZkFold.Base.Data.Vector          (Vector (Vector))
+import           ZkFold.Symbolic.Compiler
+import           ZkFold.Symbolic.Data.UInt        (UInt)
+
+newtype Value (size :: Natural) a = Value [(a, a, UInt 32 a)]
 
 deriving via (Vector size (ArithmeticCircuit a, ArithmeticCircuit a, UInt 32 (ArithmeticCircuit a)))
-    instance (Arithmetic a, Finite size) => Arithmetizable a (Value size (ArithmeticCircuit a))
+    instance (Arithmetic a, KnownNat size) => Arithmetizable a (Value size (ArithmeticCircuit a))

--- a/src/ZkFold/Symbolic/Compiler.hs
+++ b/src/ZkFold/Symbolic/Compiler.hs
@@ -10,7 +10,7 @@ module ZkFold.Symbolic.Compiler (
 
 import           Control.Monad.State                        (execState)
 import           Data.Aeson                                 (ToJSON)
-import           Prelude                                    (IO, Show (..), FilePath, ($), (++), putStrLn, mempty)
+import           Prelude                                    (FilePath, IO, Show (..), mempty, putStrLn, ($), (++))
 
 import           ZkFold.Prelude                             (writeFileJSON)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
@@ -81,7 +81,7 @@ instance (FiniteField a, Eq a) => Monoid (ArithmeticCircuit a) where
 
 -- | A finite field of a large order.
 -- It is used in the compiler for generating new variable indices.
-type VarField = BLS12_381_Scalar
+type VarField = Zp BLS12_381_Scalar
 
 type Arithmetic a = (FiniteField a, Eq a, BinaryExpansion a)
 
@@ -89,8 +89,8 @@ type Arithmetic a = (FiniteField a, Eq a, BinaryExpansion a)
 toVar :: forall a . Arithmetic a => [Natural] -> Constraint a -> Natural
 toVar srcs c = fromBinary $ castBits $ binaryExpansion ex
     where
-        r  = toZp 903489679376934896793395274328947923579382759823 :: Zp VarField
-        g  = toZp 89175291725091202781479751781509570912743212325 :: Zp VarField
+        r  = toZp 903489679376934896793395274328947923579382759823 :: VarField
+        g  = toZp 89175291725091202781479751781509570912743212325 :: VarField
         v  = BinScale @a . (+ r) . fromConstant
         x  = g ^ runBinScale (v `evalPolynomial` c)
         ex = foldr (\p y -> x ^ p + y) x srcs

--- a/src/ZkFold/Symbolic/Data/Conditional.hs
+++ b/src/ZkFold/Symbolic/Data/Conditional.hs
@@ -2,12 +2,12 @@ module ZkFold.Symbolic.Data.Conditional (
     Conditional (..)
 ) where
 
-import           Prelude                         hiding (Num(..), Bool, (/))
-import qualified Prelude                         as Haskell
+import           Prelude                          hiding (Bool, Num (..), (/))
+import qualified Prelude                          as Haskell
 
-import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.Basic.Field (Zp)
-import           ZkFold.Symbolic.Data.Bool       (BoolType (..), Bool (..))
+import           ZkFold.Base.Algebra.Basic.Field  (Zp)
+import           ZkFold.Base.Algebra.Basic.Number (Prime)
+import           ZkFold.Symbolic.Data.Bool        (Bool (..), BoolType (..))
 
 class BoolType b => Conditional b a where
     bool :: a -> a -> b -> a

--- a/src/ZkFold/Symbolic/Data/DiscreteField.hs
+++ b/src/ZkFold/Symbolic/Data/DiscreteField.hs
@@ -1,12 +1,13 @@
 module ZkFold.Symbolic.Data.DiscreteField where
 
-import           Data.Bool                                              (bool)
-import           Prelude                                                hiding (Bool)
-import qualified Prelude                                                as Haskell
+import           Data.Bool                        (bool)
+import           Prelude                          hiding (Bool)
+import qualified Prelude                          as Haskell
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.Basic.Field                        (Zp)
-import           ZkFold.Symbolic.Data.Bool                              (Bool (..), BoolType (..))
+import           ZkFold.Base.Algebra.Basic.Field  (Zp)
+import           ZkFold.Base.Algebra.Basic.Number (Prime)
+import           ZkFold.Symbolic.Data.Bool        (Bool (..), BoolType (..))
 
 class (BoolType b, Field a) => DiscreteField b a where
     isZero :: a -> b

--- a/src/ZkFold/Symbolic/Data/Eq.hs
+++ b/src/ZkFold/Symbolic/Data/Eq.hs
@@ -3,13 +3,14 @@ module ZkFold.Symbolic.Data.Eq (
     elem
 ) where
 
-import           Data.Bool                                              (bool)
-import           Prelude                                                hiding (Bool, Eq (..), Num (..), any, elem, not, product, (/), (/=), (==))
-import qualified Prelude                                                as Haskell
+import           Data.Bool                        (bool)
+import           Prelude                          hiding (Bool, Eq (..), Num (..), any, elem, not, product, (/), (/=), (==))
+import qualified Prelude                          as Haskell
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.Basic.Field                        (Zp)
-import           ZkFold.Symbolic.Data.Bool                              (Bool (..), BoolType (..), any)
+import           ZkFold.Base.Algebra.Basic.Field  (Zp)
+import           ZkFold.Base.Algebra.Basic.Number (Prime)
+import           ZkFold.Symbolic.Data.Bool        (Bool (..), BoolType (..), any)
 
 class BoolType b => Eq b a where
     (==) :: a -> a -> b

--- a/src/ZkFold/Symbolic/Data/Ord.hs
+++ b/src/ZkFold/Symbolic/Data/Ord.hs
@@ -10,6 +10,7 @@ import qualified Prelude                                                as Haske
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field                        (Zp)
+import           ZkFold.Base.Algebra.Basic.Number                       (Prime)
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (boolCheckC, plusMultC)
 import           ZkFold.Symbolic.Data.Bool                              (Bool (..), BoolType (..))

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -60,34 +60,34 @@ cast n =
 
 --------------------------------------------------------------------------------
 
-toNatural :: forall p n . (Finite p, KnownNat n) => UInt n (Zp p) -> Natural
+toNatural :: forall p n . (KnownNat p, KnownNat n) => UInt n (Zp p) -> Natural
 toNatural (UInt xs x) = foldr (\p y -> fromZp p + base * y) 0 (xs ++ [x])
-    where base = 2 ^ registerSize @p @n
+    where base = 2 ^ registerSize @(Zp p) @n
 
-instance (Finite p, KnownNat n) => AdditiveSemigroup (UInt n (Zp p)) where
+instance (KnownNat p, KnownNat n) => AdditiveSemigroup (UInt n (Zp p)) where
     x + y = fromConstant $ toNatural x + toNatural y
 
-instance (Finite p, KnownNat n) => AdditiveMonoid (UInt n (Zp p)) where
+instance (KnownNat p, KnownNat n) => AdditiveMonoid (UInt n (Zp p)) where
     zero = fromConstant (0 :: Natural)
 
-instance (Finite p, KnownNat n) => AdditiveGroup (UInt n (Zp p)) where
+instance (KnownNat p, KnownNat n) => AdditiveGroup (UInt n (Zp p)) where
     x - y = fromConstant $ toNatural x + 2 ^ getNatural @n - toNatural y
     negate x = fromConstant $ 2 ^ getNatural @n - toNatural x
 
-instance (Finite p, KnownNat n) => MultiplicativeSemigroup (UInt n (Zp p)) where
+instance (KnownNat p, KnownNat n) => MultiplicativeSemigroup (UInt n (Zp p)) where
     x * y = fromConstant $ toNatural x * toNatural y
 
-instance (Finite p, KnownNat n) => MultiplicativeMonoid (UInt n (Zp p)) where
+instance (KnownNat p, KnownNat n) => MultiplicativeMonoid (UInt n (Zp p)) where
     one = fromConstant (1 :: Natural)
 
-instance (Finite p, KnownNat n) => Semiring (UInt n (Zp p))
+instance (KnownNat p, KnownNat n) => Semiring (UInt n (Zp p))
 
-instance (Finite p, KnownNat n) => Ring (UInt n (Zp p))
+instance (KnownNat p, KnownNat n) => Ring (UInt n (Zp p))
 
-instance (Finite p, KnownNat n) => Arbitrary (UInt n (Zp p)) where
+instance (KnownNat p, KnownNat n) => Arbitrary (UInt n (Zp p)) where
     arbitrary = UInt
-        <$> replicateA (numberOfRegisters @p @n - 1) (toss $ registerSize @p @n)
-        <*> toss (highRegisterSize @p @n)
+        <$> replicateA (numberOfRegisters @(Zp p) @n - 1) (toss $ registerSize @(Zp p) @n)
+        <*> toss (highRegisterSize @(Zp p) @n)
         where toss b = fromConstant <$> chooseInteger (0, 2 ^ b - 1)
 
 --------------------------------------------------------------------------------
@@ -237,7 +237,7 @@ class StrictNum a where
     strictSub :: a -> a -> a
     strictMul :: a -> a -> a
 
-instance (Finite p, KnownNat n) => StrictNum (UInt n (Zp p)) where
+instance (KnownNat p, KnownNat n) => StrictNum (UInt n (Zp p)) where
     strictAdd x y = strictConv $ toNatural x + toNatural y
     strictSub x y = strictConv $ toNatural x - toNatural y
     strictMul x y = strictConv $ toNatural x * toNatural y

--- a/src/ZkFold/Symbolic/GroebnerBasis.hs
+++ b/src/ZkFold/Symbolic/GroebnerBasis.hs
@@ -25,6 +25,7 @@ import           Prelude                                          hiding (Num (.
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field                  (Zp)
+import           ZkFold.Base.Algebra.Basic.Number                 (Prime)
 import qualified ZkFold.Base.Algebra.Polynomials.Multivariate     as Poly
 import           ZkFold.Prelude                                   ((!!))
 import           ZkFold.Symbolic.Compiler

--- a/src/ZkFold/Symbolic/GroebnerBasis/Types.hs
+++ b/src/ZkFold/Symbolic/GroebnerBasis/Types.hs
@@ -12,8 +12,8 @@ import           Data.Map                                     (Map)
 import           Numeric.Natural                              (Natural)
 import           Prelude                                      hiding (Num (..), length, replicate, (!!))
 
-import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field              (Zp)
+import           ZkFold.Base.Algebra.Basic.Number             (Prime)
 import           ZkFold.Symbolic.GroebnerBasis.Internal.Types
 
 type Variable p = Var (Zp p) Natural
@@ -30,4 +30,3 @@ type Polynomial p = Polynom (Zp p) Natural
 
 polynomial :: Prime p => [Monomial p] -> Polynomial p
 polynomial = P . sortBy (flip compare) . filter (not . zeroM)
-

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -8,6 +8,7 @@ import           Tests.Arithmetization                       (specArithmetizatio
 import           Tests.Field                                 (specField)
 import           Tests.GroebnerBasis                         (specGroebner)
 import           Tests.Group                                 (specAdditiveGroup)
+import           Tests.Multiplication                        (specMultiplication)
 import           Tests.NonInteractiveProof                   (specNonInteractiveProof)
 import           Tests.Pairing                               (specPairing)
 import           Tests.Permutations                          (specPermutations)
@@ -15,10 +16,8 @@ import           Tests.Plonk                                 (specPlonk)
 import           Tests.Scripts.LockedByTxId                  (specLockedByTxId)
 import           Tests.UInt                                  (specUInt)
 import           Tests.Univariate                            (specUnivariate)
-import           Tests.Multiplication                        (specMultiplication)
 
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
-import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381
 import           ZkFold.Base.Algebra.EllipticCurve.Class
 import           ZkFold.Base.Protocol.ARK.Plonk              (PlonkBS)
@@ -47,7 +46,7 @@ main = do
     specUnivariate
     specMultiplication
 
-    specNonInteractiveProof @(KZG BLS12_381_G1 BLS12_381_G2 BLS12_381_GT (Zp BLS12_381_Scalar) N32)
+    specNonInteractiveProof @(KZG BLS12_381_G1 BLS12_381_G2 BLS12_381_GT (Zp BLS12_381_Scalar) 32)
     specPlonk
     specNonInteractiveProof @PlonkBS
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -12,7 +12,7 @@ import           Tests.Multiplication                        (specMultiplication
 import           Tests.NonInteractiveProof                   (specNonInteractiveProof)
 import           Tests.Pairing                               (specPairing)
 import           Tests.Permutations                          (specPermutations)
-import           Tests.Plonk                                 (specPlonk)
+import           Tests.Plonk                                 (PlonkBS, specPlonk)
 import           Tests.Scripts.LockedByTxId                  (specLockedByTxId)
 import           Tests.UInt                                  (specUInt)
 import           Tests.Univariate                            (specUnivariate)
@@ -20,7 +20,6 @@ import           Tests.Univariate                            (specUnivariate)
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381
 import           ZkFold.Base.Algebra.EllipticCurve.Class
-import           ZkFold.Base.Protocol.ARK.Plonk              (PlonkBS)
 import           ZkFold.Base.Protocol.Commitment.KZG         (KZG)
 
 main :: IO ()

--- a/tests/Tests/Arithmetization/Test3.hs
+++ b/tests/Tests/Arithmetization/Test3.hs
@@ -1,23 +1,22 @@
-{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Tests.Arithmetization.Test3 (specArithmetization3) where
 
-import           Prelude                         hiding (Num(..), Eq(..), Ord(..), Bool, (^), (/), (||), not, any, replicate)
+import           Prelude                          hiding (Bool, Eq (..), Num (..), Ord (..), any, not, replicate, (/), (^), (||))
 import           Test.Hspec
 
-import           ZkFold.Base.Algebra.Basic.Class (Finite (..), Prime)
-import           ZkFold.Base.Algebra.Basic.Field (Zp)
+import           ZkFold.Base.Algebra.Basic.Field  (Zp)
+import           ZkFold.Base.Algebra.Basic.Number (Prime)
 import           ZkFold.Symbolic.Compiler
-import           ZkFold.Symbolic.Data.Bool       (Bool (..))
-import           ZkFold.Symbolic.Data.Ord        (Ord (..))
-import           ZkFold.Symbolic.Types           (Symbolic)
+import           ZkFold.Symbolic.Data.Bool        (Bool (..))
+import           ZkFold.Symbolic.Data.Ord         (Ord (..))
+import           ZkFold.Symbolic.Types            (Symbolic)
 
-data SmallField
-instance Finite SmallField where
-    order = 97
-instance Prime SmallField
+instance Prime 97
 
-type R = ArithmeticCircuit (Zp SmallField)
+type R = ArithmeticCircuit (Zp 97)
 
 -- A comparison test
 testFunc :: forall a . Symbolic a => a -> a -> Bool a
@@ -27,5 +26,6 @@ specArithmetization3 :: Spec
 specArithmetization3 = do
     describe "Arithmetization test 3" $ do
         it "should pass" $ do
-            let Bool r = compile @(Zp SmallField) (testFunc @R) :: Bool R
-            Bool (acValue (applyArgs r [3, 5])) `shouldBe` testFunc @(Zp SmallField) 3 5
+            let Bool r = compile @(Zp 97) (testFunc @R) :: Bool R
+            Bool (acValue (applyArgs r [3, 5])) `shouldBe` testFunc 3 5
+

--- a/tests/Tests/GroebnerBasis.hs
+++ b/tests/Tests/GroebnerBasis.hs
@@ -1,12 +1,13 @@
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Tests.GroebnerBasis (specGroebner) where
 
 import           Data.Map                                    (fromList)
-import           Prelude                                     hiding (Num(..), Eq(..), (^), (/))
-import           Test.Hspec                      
+import           Prelude                                     hiding (Eq (..), Num (..), (/), (^))
+import           Test.Hspec
 
 import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Base.Algebra.Basic.Number            (Prime)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381
 import           ZkFold.Symbolic.GroebnerBasis
 
@@ -25,48 +26,48 @@ specGroebner = hspec $ do
     describe "Groebner basis specification" $ do
         describe "Monomial zero test" $ do
             it "should pass" $ do
-                zeroM (monomial @Fr zero $ fromList [(1, variable 1), (2, variable 2), (3, variable 3)])
+                zeroM (monomial @(Order Fr) zero $ fromList [(1, variable 1), (2, variable 2), (3, variable 3)])
                     `shouldBe` True
         describe "Polynomial zero test" $ do
             it "should pass" $ do
-                zeroP (polynomial @Fr [monomial zero $ fromList [(1, variable 1), (2, variable 2), (3, variable 3)],
+                zeroP (polynomial @(Order Fr) [monomial zero $ fromList [(1, variable 1), (2, variable 2), (3, variable 3)],
                     monomial zero $ fromList [(1, variable 1), (2, variable 2), (3, variable 3)]])
                     `shouldBe` True
         describe "Similar monomials" $ do
             it "should be equal" $ do
-                similarM (monomial @Fr zero $ fromList [(1, variable 1), (2, variable 2), (3, variable 3)])
+                similarM (monomial @(Order Fr) zero $ fromList [(1, variable 1), (2, variable 2), (3, variable 3)])
                     (monomial one $ fromList [(1, variable 1), (2, variable 2), (3, variable 3)])
                     `shouldBe` True
         describe "Monomials comparisons" $ do
             it "should be correct" $ do
-                compare (monomial @Fr zero $ fromList [(1, variable 1), (2, variable 3), (3, variable 2)])
+                compare (monomial @(Order Fr) zero $ fromList [(1, variable 1), (2, variable 3), (3, variable 2)])
                     (monomial one $ fromList [(1, variable 1), (2, variable 2), (3, variable 3)])
                     `shouldBe` LT
-                compare (monomial @Fr one $ fromList [(1, variable 1), (3, variable 1)])
+                compare (monomial @(Order Fr) one $ fromList [(1, variable 1), (3, variable 1)])
                     (monomial one $ fromList [(1, variable 1), (2, variable 1), (3, variable 1)])
                     `shouldBe` LT
-                compare 
-                    (polynomial [monomial @Fr one $ fromList [(1, variable 1), (2, variable 1)],
+                compare
+                    (polynomial [monomial @(Order Fr) one $ fromList [(1, variable 1), (2, variable 1)],
                         monomial one $ fromList [(1, variable 1), (2, variable 1), (3, variable 1)]])
                     (polynomial [monomial one $ fromList [(1, variable 1), (2, variable 1), (3, variable 1)],
                         monomial one $ fromList [(1, variable 1), (3, variable 1)]])
                     `shouldBe` GT
         describe "Polynomial multiplication test" $ do
             it "should pass" $ do
-                (testPoly @Fr !! 0) * (testPoly !! 1)
+                (testPoly @(Order Fr) !! 0) * (testPoly !! 1)
                     `shouldBe` polynomial [monomial one $ fromList [(1, variable 1), (2, variable 2), (3, variable 1)],
                         monomial one $ fromList [(1, variable 1), (2, variable 2)],
                         monomial one $ fromList [(1, variable 1), (2, variable 1), (3, variable 2)],
                         monomial one $ fromList [(1, variable 1), (2, variable 1), (3, variable 1)]]
         describe "Leading term test" $ do
             it "should pass" $ do
-                map (lt . (testPoly @Fr !!)) [0..2]
+                map (lt . (testPoly @(Order Fr) !!)) [0..2]
                     `shouldBe` [monomial one $ fromList [(1, variable 1), (2, variable 1), (3, variable 1)],
                         monomial one $ fromList [(2, variable 1)],
                         monomial one $ fromList [(1, variable 1), (3, variable 1)]]
         describe "S-polynomial test" $ do
             it "should pass" $ do
-                let s = makeSPoly (testPoly @Fr !! 0) (testPoly !! 1)
+                let s = makeSPoly (testPoly @(Order Fr) !! 0) (testPoly !! 1)
                 s `shouldBe` polynomial [monomial one $ fromList [(1, variable 1), (2, variable 1)],
                     monomial (negate one) $ fromList [(1, variable 1), (3, variable 2)]]
                 s `fullReduceMany` [testPoly !! 2]
@@ -74,10 +75,11 @@ specGroebner = hspec $ do
                         monomial (negate one) $ fromList [(1, variable 1)]]
         describe "Groebner basis test" $ do
             it "should pass" $ do
-                let p0 = polynomial @Fr [monomial one $ fromList [(1, variable 1)]]
-                    gs = snd $ foldl (\args _ -> uncurry groebnerStep args) (p0, testPoly) [1::Integer ..200] 
+                let p0 = polynomial @(Order Fr) [monomial one $ fromList [(1, variable 1)]]
+                    gs = snd $ foldl (\args _ -> uncurry groebnerStep args) (p0, testPoly) [1::Integer ..200]
                     gs' = filter (not . zeroP) $ foldr (\p ps -> fullReduceMany p ps : ps) [] gs
                 gs' `shouldBe` [polynomial [monomial one $ fromList [(2, variable 1)],
                         monomial one $ fromList [(3, variable 1)]],
                     polynomial [monomial one $ fromList [(1, variable 1), (3, variable 1)],
                         monomial one $ fromList [(1, variable 1)]]]
+

--- a/tests/Tests/Pairing.hs
+++ b/tests/Tests/Pairing.hs
@@ -16,12 +16,8 @@ import           ZkFold.Base.Algebra.EllipticCurve.Class
 import           ZkFold.Base.Algebra.Polynomials.Univariate (PolyVec, deg, evalPolyVec, scalePV, toPolyVec, vec2poly)
 import           ZkFold.Base.Protocol.Commitment.KZG        (com)
 
-data TestPairing
-instance Finite TestPairing where
-    order = 32
-
 propVerificationKZG :: forall c1 c2 t f . (Pairing c1 c2 t, f ~ ScalarField c1, f ~ ScalarField c2)
-    =>f -> PolyVec f TestPairing -> f -> Bool
+    => f -> PolyVec f 32 -> f -> Bool
 propVerificationKZG x p z =
     let n  = deg $ vec2poly p
 

--- a/tests/Tests/Permutations.hs
+++ b/tests/Tests/Permutations.hs
@@ -9,13 +9,8 @@ import           Prelude                                hiding (Fractional (..),
 import           Test.Hspec
 import           Test.QuickCheck
 
-import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Permutations
 import           ZkFold.Base.Data.Vector                (fromVector)
-
-data TestSize
-instance Finite TestSize where
-    order = 100
 
 specPermutations :: IO ()
 specPermutations = hspec $ do
@@ -26,7 +21,6 @@ specPermutations = hspec $ do
         describe "Function: fromCycles" $ do
             it "should preserve the elements" $ property $
                 \v ->
-                    let ts = mkIndexPartition @Integer $ V.fromList $ fromVector @TestSize v
-                        p = fromPermutation @TestSize $ fromCycles $ ts
+                    let ts = mkIndexPartition @Integer $ V.fromList $ fromVector @100 v
+                        p = fromPermutation @100 $ fromCycles ts
                     in sort p == sort (V.toList $ V.concat $ elems ts)
-

--- a/tests/Tests/Plonk.hs
+++ b/tests/Tests/Plonk.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Tests.Plonk (specPlonk) where
+module Tests.Plonk (PlonkBS, PlonkMaxPolyDegreeBS, PlonkSizeBS, specPlonk) where
 
+import           Data.ByteString                              (ByteString)
 import           Data.Containers.ListUtils                    (nubOrd)
 import           Data.List                                    (transpose)
 import           Data.Map                                     (elems, fromList, singleton)
@@ -23,6 +24,10 @@ import           ZkFold.Base.Protocol.ARK.Plonk.Internal      (fromPlonkConstrai
 import           ZkFold.Base.Protocol.NonInteractiveProof     (NonInteractiveProof (..))
 import           ZkFold.Prelude                               (replicate, take, (!))
 import           ZkFold.Symbolic.Compiler
+
+type PlonkSizeBS = 32
+type PlonkBS = Plonk PlonkSizeBS ByteString
+type PlonkMaxPolyDegreeBS = PlonkMaxPolyDegree PlonkSizeBS
 
 propPlonkConstraintConversion :: (F, F, F, F, F, F, F, F) -> (F, F, F) -> Bool
 propPlonkConstraintConversion x (x1, x2, x3) =

--- a/tests/Tests/Plonk.hs
+++ b/tests/Tests/Plonk.hs
@@ -12,8 +12,9 @@ import           Test.Hspec
 import           Test.QuickCheck
 import           Tests.NonInteractiveProof                    (NonInteractiveProofTestData (..))
 
-import           ZkFold.Base.Algebra.Basic.Class              (AdditiveGroup (..), AdditiveSemigroup (..), Finite (..), MultiplicativeSemigroup (..), negate, zero)
+import           ZkFold.Base.Algebra.Basic.Class              (AdditiveGroup (..), AdditiveSemigroup (..), MultiplicativeSemigroup (..), negate, zero)
 import           ZkFold.Base.Algebra.Basic.Field              (fromZp)
+import           ZkFold.Base.Algebra.Basic.Number             (value)
 import           ZkFold.Base.Algebra.Basic.Scale              (Self (..))
 import           ZkFold.Base.Algebra.Polynomials.Multivariate
 import           ZkFold.Base.Algebra.Polynomials.Univariate   (evalPolyVec, fromPolyVec, polyVecInLagrangeBasis, polyVecLinear, polyVecZero, toPolyVec)
@@ -36,14 +37,14 @@ propPlonkConstraintConversion x (x1, x2, x3) =
 propPlonkConstraintSatisfaction :: ParamsPlonk -> NonInteractiveProofTestData PlonkBS -> Bool
 propPlonkConstraintSatisfaction (ParamsPlonk _ _ _ inputs ac) (TestData _ w) =
     let wmap = acWitness $ mapVarArithmeticCircuit ac
-        (ql, qr, qo, qm, qc, a, b, c) = toPlonkArithmetization @PlonkBS (singleton (acOutput ac) 15) ac
+        (ql, qr, qo, qm, qc, a, b, c) = toPlonkArithmetization @PlonkSizeBS (singleton (acOutput ac) 15) ac
         l = 1
 
         (WitnessInputPlonk wInput, _) = w
         w1'     = V.toList $ fmap ((wmap wInput !) . fromZp) (fromPolyVec a)
         w2'     = V.toList $ fmap ((wmap wInput !) . fromZp) (fromPolyVec b)
         w3'     = V.toList $ fmap ((wmap wInput !) . fromZp) (fromPolyVec c)
-        wPub    = take l (map negate $ elems inputs) ++ replicate (order @PlonkBS - l) zero
+        wPub    = take l (map negate $ elems inputs) ++ replicate (value @PlonkSizeBS - l) zero
 
         ql' = V.toList $ fromPolyVec ql
         qr' = V.toList $ fromPolyVec qr
@@ -59,14 +60,14 @@ propPlonkConstraintSatisfaction (ParamsPlonk _ _ _ inputs ac) (TestData _ w) =
 
 propPlonkPolyIdentity :: NonInteractiveProofTestData PlonkBS -> Bool
 propPlonkPolyIdentity (TestData plonk w) =
-    let zH = polyVecZero @F @PlonkBS @PlonkMaxPolyDegreeBS
+    let zH = polyVecZero @F @PlonkSizeBS @PlonkMaxPolyDegreeBS
 
         s = setup @PlonkBS plonk
         ((wPub, _, _, _, omega, _, _), (qlE, qrE, qoE, qmE, qcE, _, _, _), _, WitnessMap wmap, _) = s
         (WitnessInputPlonk wInput, ps) = w
         ProverSecretPlonk b1 b2 b3 b4 b5 b6 _ _ _ _ _ = ps
         (w1, w2, w3) = wmap wInput
-        pubPoly = polyVecInLagrangeBasis @F @PlonkBS @PlonkMaxPolyDegreeBS omega $ toPolyVec @F @PlonkBS wPub
+        pubPoly = polyVecInLagrangeBasis @F @PlonkSizeBS @PlonkMaxPolyDegreeBS omega $ toPolyVec @F @PlonkSizeBS wPub
 
         a = polyVecLinear b2 b1 * zH + polyVecInLagrangeBasis omega w1
         b = polyVecLinear b4 b3 * zH + polyVecInLagrangeBasis omega w2
@@ -84,7 +85,7 @@ propPlonkPolyIdentity (TestData plonk w) =
                 pubX = pubPoly `evalPolyVec` x
             in qlX * aX + qrX * bX + qoX * cX + qmX * aX * bX + qcX + pubX
 
-    in all ((== zero) . f . (omega^)) [0 .. order @PlonkBS - 1]
+    in all ((== zero) . f . (omega^)) [0 .. value @PlonkSizeBS - 1]
 
 specPlonk :: IO ()
 specPlonk = hspec $ do

--- a/tests/Tests/Scripts/LockedByTxId.hs
+++ b/tests/Tests/Scripts/LockedByTxId.hs
@@ -1,22 +1,23 @@
-{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Tests.Scripts.LockedByTxId (specLockedByTxId) where
 
 import           Data.Map                                    (fromList)
-import           Prelude                                     hiding (Num(..), Eq(..), Ord(..), Bool)
-import qualified Prelude as Haskell
+import           Prelude                                     hiding (Bool, Eq (..), Num (..), Ord (..))
+import qualified Prelude                                     as Haskell
 import           Test.Hspec
 import           Test.QuickCheck
+import           Tests.Plonk                                 (PlonkBS)
 
 import           ZkFold.Base.Algebra.Basic.Class             (FromConstant (..))
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (Fr)
-import           ZkFold.Base.Protocol.ARK.Plonk              (Plonk(..), PlonkBS, WitnessInputPlonk (..), ProverSecretPlonk)
+import           ZkFold.Base.Protocol.ARK.Plonk              (Plonk (..), ProverSecretPlonk, WitnessInputPlonk (..))
 import           ZkFold.Base.Protocol.ARK.Plonk.Internal     (getParams)
-import           ZkFold.Base.Protocol.NonInteractiveProof    (NonInteractiveProof(..))
+import           ZkFold.Base.Protocol.NonInteractiveProof    (NonInteractiveProof (..))
 import           ZkFold.Symbolic.Cardano.Types.Tx            (TxId (..))
 import           ZkFold.Symbolic.Compiler                    hiding (input)
 import           ZkFold.Symbolic.Data.Bool                   (Bool (..), BoolType (..))
-import           ZkFold.Symbolic.Data.Eq                     (Eq(..))
+import           ZkFold.Symbolic.Data.Eq                     (Eq (..))
 import           ZkFold.Symbolic.Types                       (Symbolic)
 
 lockedByTxId :: forall a a' . (Symbolic a , FromConstant a' a) => TxId a' -> TxId a -> () -> Bool a

--- a/tests/Tests/UInt.hs
+++ b/tests/Tests/UInt.hs
@@ -3,25 +3,26 @@
 
 module Tests.UInt (specUInt) where
 
-import           Control.Applicative             ((<*>))
-import           Control.Monad                   (return)
-import           Data.Data                       (Proxy (..))
-import           Data.Function                   (($))
-import           Data.Functor                    ((<$>))
-import           Data.List                       (map, (++))
-import           GHC.TypeNats                    (KnownNat, natVal)
-import           Numeric.Natural                 (Natural)
-import           Prelude                         (div, show)
-import qualified Prelude                         as Haskell
-import           System.IO                       (IO)
-import           Test.Hspec                      (describe, hspec)
-import           Test.QuickCheck                 (Gen, Property, (===))
-import           Tests.ArithmeticCircuit         (eval', it)
+import           Control.Applicative              ((<*>))
+import           Control.Monad                    (return)
+import           Data.Data                        (Proxy (..))
+import           Data.Function                    (($))
+import           Data.Functor                     ((<$>))
+import           Data.List                        (map, (++))
+import           GHC.TypeNats                     (KnownNat, natVal)
+import           Numeric.Natural                  (Natural)
+import           Prelude                          (div, show)
+import qualified Prelude                          as Haskell
+import           System.IO                        (IO)
+import           Test.Hspec                       (describe, hspec)
+import           Test.QuickCheck                  (Gen, Property, (===))
+import           Tests.ArithmeticCircuit          (eval', it)
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.Basic.Field (Zp)
-import           ZkFold.Prelude                  (chooseNatural)
-import           ZkFold.Symbolic.Compiler        (ArithmeticCircuit)
+import           ZkFold.Base.Algebra.Basic.Field  (Zp)
+import           ZkFold.Base.Algebra.Basic.Number (Prime)
+import           ZkFold.Prelude                   (chooseNatural)
+import           ZkFold.Symbolic.Compiler         (ArithmeticCircuit)
 import           ZkFold.Symbolic.Data.UInt
 
 toss :: Natural -> Gen Natural

--- a/tests/Tests/Univariate.hs
+++ b/tests/Tests/Univariate.hs
@@ -19,46 +19,47 @@ import           Test.Hspec
 import           Test.QuickCheck
 
 import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Base.Algebra.Polynomials.Univariate
-import           ZkFold.Base.Protocol.ARK.Plonk             (F, PlonkBS, PlonkMaxPolyDegreeBS)
+import           ZkFold.Base.Protocol.ARK.Plonk             (F, PlonkMaxPolyDegreeBS, PlonkSizeBS)
 import           ZkFold.Prelude                             (length, take)
 
 -- TODO (Issue #22): remove dependencies from KZG and Plonk
 -- TODO (Issue #22): make all tests polymorphic in the polynomial type
 
-propToPolyVec :: forall c size . (Ring c, Finite size) => [c] -> Bool
+propToPolyVec :: forall c size . (Ring c, KnownNat size) => [c] -> Bool
 propToPolyVec cs =
     let PV p = toPolyVec @c @size $ V.fromList cs
-    in length p == order @size
+    in length p == value @size
 
-propCastPolyVec :: forall c size size' . (Ring c, Finite size, Finite size', Eq c) => [c] -> Bool
+propCastPolyVec :: forall c size size' . (Ring c, KnownNat size, KnownNat size', Eq c) => [c] -> Bool
 propCastPolyVec cs =
-    let n = min (order @size) (order @size')
+    let n = min (value @size) (value @size')
         cs' = V.fromList $ bool cs (take n cs) (length cs > n)
         PV p' = castPolyVec @c @size @size' (toPolyVec @c @size cs')
-    in length p' == order @size'
+    in length p' == value @size'
 
-propPolyVecDivision :: forall c size . (Field c, Finite size, Eq c) => PolyVec c size -> PolyVec c size -> Bool
+propPolyVecDivision :: forall c size . (Field c, KnownNat size, Eq c) => PolyVec c size -> PolyVec c size -> Bool
 propPolyVecDivision p q =
     let d1 = deg $ vec2poly p
         d2 = deg $ vec2poly q
-    in (p * q) / q == p || (d1 + d2 > fromIntegral (order @size) - 1)
+    in (p * q) / q == p || (d1 + d2 > fromIntegral (value @size) - 1)
 
 propPolyVecZero :: Natural -> Bool
 propPolyVecZero i =
     let Just omega = rootOfUnity 5 :: Maybe F
-        p = polyVecZero @F @PlonkBS @PlonkMaxPolyDegreeBS
+        p = polyVecZero @F @PlonkSizeBS @PlonkMaxPolyDegreeBS
         x = omega^abs i
     in p `evalPolyVec` x == zero
 
 propPolyVecLagrange :: Natural -> Bool
 propPolyVecLagrange i =
     let Just omega = rootOfUnity 5 :: Maybe F
-        p = polyVecLagrange @F @PlonkBS @PlonkMaxPolyDegreeBS i omega
+        p = polyVecLagrange @F @PlonkSizeBS @PlonkMaxPolyDegreeBS i omega
     in p `evalPolyVec` (omega^i) == one &&
-        all ((== zero) . (p `evalPolyVec`) . (omega^)) ([1 .. order @PlonkBS] \\ [i])
+        all ((== zero) . (p `evalPolyVec`) . (omega^)) ([1 .. value @PlonkSizeBS] \\ [i])
 
-propPolyVecGrandProduct :: (Field c, Finite size, Ord c) => PolyVec c size -> c -> c -> Bool
+propPolyVecGrandProduct :: (Field c, KnownNat size, Ord c) => PolyVec c size -> c -> c -> Bool
 propPolyVecGrandProduct p beta gamma =
     let PV cs = p
         cs' = V.modify VA.sort cs
@@ -69,44 +70,44 @@ propPolyVecGrandProduct p beta gamma =
 specUnivariate :: IO ()
 specUnivariate = hspec $ do
     describe "Univariate polynomials specification" $ do
-        describe ("Type: " ++ show (typeOf @(PolyVec F PlonkBS) zero)) $ do
+        describe ("Type: " ++ show (typeOf @(PolyVec F PlonkSizeBS) zero)) $ do
             describe "toPolyVec" $ do
                 it "should return a list of the correct length" $ do
-                    property $ propToPolyVec @F @PlonkBS
+                    property $ propToPolyVec @F @PlonkSizeBS
             describe "castPolyVec" $ do
                 it "should return a list of the correct length" $ do
-                    property $ propCastPolyVec @F @PlonkBS @PlonkBS
+                    property $ propCastPolyVec @F @PlonkSizeBS @PlonkSizeBS
                 it "should return a list of the correct length" $ do
-                    property $ propCastPolyVec @F @PlonkBS @PlonkMaxPolyDegreeBS
+                    property $ propCastPolyVec @F @PlonkSizeBS @PlonkMaxPolyDegreeBS
                 it "should return a list of the correct length" $ do
-                    property $ propCastPolyVec @F @PlonkMaxPolyDegreeBS @PlonkBS
+                    property $ propCastPolyVec @F @PlonkMaxPolyDegreeBS @PlonkSizeBS
             describe "Ring axioms" $ do
                 it "should satisfy additive associativity" $ do
-                    property $ \(a :: PolyVec F PlonkBS) b c -> (a + b) + c == a + (b + c)
+                    property $ \(a :: PolyVec F PlonkSizeBS) b c -> (a + b) + c == a + (b + c)
                 it "should satisfy additive commutativity" $ do
-                    property $ \(a :: PolyVec F PlonkBS) b -> a + b == b + a
+                    property $ \(a :: PolyVec F PlonkSizeBS) b -> a + b == b + a
                 it "should satisfy additive identity" $ do
-                    property $ \(a :: PolyVec F PlonkBS) -> a + zero == a
+                    property $ \(a :: PolyVec F PlonkSizeBS) -> a + zero == a
                 it "should satisfy additive inverse" $ do
-                    property $ \(a :: PolyVec F PlonkBS) -> a + negate a == zero
+                    property $ \(a :: PolyVec F PlonkSizeBS) -> a + negate a == zero
                 it "should satisfy multiplicative associativity" $ do
-                    property $ \(a :: PolyVec F PlonkBS) b c -> (a * b) * c == a * (b * c)
+                    property $ \(a :: PolyVec F PlonkSizeBS) b c -> (a * b) * c == a * (b * c)
                 it "should satisfy multiplicative commutativity" $ do
-                    property $ \(a :: PolyVec F PlonkBS) b -> a * b == b * a
+                    property $ \(a :: PolyVec F PlonkSizeBS) b -> a * b == b * a
                 it "should satisfy multiplicative identity" $ do
-                    property $ \(a :: PolyVec F PlonkBS) -> a * one == a
+                    property $ \(a :: PolyVec F PlonkSizeBS) -> a * one == a
                 it "should satisfy distributivity" $ do
-                    property $ \(a :: PolyVec F PlonkBS) b c -> a * (b + c) == a * b + a * c
+                    property $ \(a :: PolyVec F PlonkSizeBS) b c -> a * (b + c) == a * b + a * c
             describe "Polynomial division" $ do
                 it "should satisfy the definition" $ do
-                    property $ \(p :: PolyVec F PlonkBS) q -> q /= zero ==> propPolyVecDivision p q
+                    property $ \(p :: PolyVec F PlonkSizeBS) q -> q /= zero ==> propPolyVecDivision p q
             describe "polyVecZero" $ do
                 it "should satisfy the definition" $ do
-                    all propPolyVecZero [0 .. order @PlonkMaxPolyDegreeBS - 1] `shouldBe` True
+                    all propPolyVecZero [0 .. value @PlonkMaxPolyDegreeBS - 1] `shouldBe` True
             describe "Lagrange polynomial" $ do
                 it "should satisfy the definition" $ do
-                    all propPolyVecLagrange [1 .. order @PlonkBS] `shouldBe` True
+                    all propPolyVecLagrange [1 .. value @PlonkSizeBS] `shouldBe` True
             describe "polyVecGrandProduct" $ do
                 it "should satisfy the definition" $ do
-                    property $ propPolyVecGrandProduct @F @PlonkBS
+                    property $ propPolyVecGrandProduct @F @PlonkSizeBS
 

--- a/tests/Tests/Univariate.hs
+++ b/tests/Tests/Univariate.hs
@@ -17,11 +17,12 @@ import           Prelude                                    hiding (Fractional (
 import           Prelude                                    (abs)
 import           Test.Hspec
 import           Test.QuickCheck
+import           Tests.Plonk                                (PlonkMaxPolyDegreeBS, PlonkSizeBS)
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Base.Algebra.Polynomials.Univariate
-import           ZkFold.Base.Protocol.ARK.Plonk             (F, PlonkMaxPolyDegreeBS, PlonkSizeBS)
+import           ZkFold.Base.Protocol.ARK.Plonk             (F)
 import           ZkFold.Prelude                             (length, take)
 
 -- TODO (Issue #22): remove dependencies from KZG and Plonk

--- a/zkfold-base.cabal
+++ b/zkfold-base.cabal
@@ -184,6 +184,7 @@ test-suite zkfold-base-test
       Tests.Multiplication
     build-depends:
       base                          >= 4.9 && < 5,
+      bytestring                                 ,
       containers                                 ,
       hspec                                < 2.12,
       QuickCheck                                 ,

--- a/zkfold-base.cabal
+++ b/zkfold-base.cabal
@@ -52,6 +52,7 @@ common options
       MultiWayIf,
       NamedFieldPuns,
       NoImplicitPrelude,
+      NoStarIsType,
       NumericUnderscores,
       OverloadedStrings,
       OverloadedLabels,


### PR DESCRIPTION
* migrated all users of `Finite` typeclass to typelevel naturals where it makes sense
* except for `typeSize` in `Arithmetizable` because currently, `typeSize @(UInt n a)` uses a complicated algorithm to be computed
* added some utility functions for `Vector` manipulation