### PR TITLE
FunctionSpace modifications

### DIFF
--- a/src/ZkFold/Base/Algebra/Basic/VectorSpace.hs
+++ b/src/ZkFold/Base/Algebra/Basic/VectorSpace.hs
@@ -152,3 +152,11 @@ instance {-# OVERLAPPING #-}
         pi2 (_ :*: v) = v
 
     curryV k x = curryV (k . (:*:) x)
+
+composeFunctions
+  :: ( FunctionSpace a g
+     , FunctionSpace a f
+     , OutputSpace a f ~ InputSpace a g
+     )
+  => g -> f -> InputSpace a f a -> OutputSpace a g a
+composeFunctions g f = uncurryV g . uncurryV f

--- a/src/ZkFold/Base/Algebra/Basic/VectorSpace.hs
+++ b/src/ZkFold/Base/Algebra/Basic/VectorSpace.hs
@@ -26,8 +26,8 @@ class VectorSpace a v where
     set with "out-of-bounds" basis elements corresponding with 0.
     -}
     type Basis a v :: Type
-    indexV :: v a -> Basis a v -> a
     tabulateV :: (Basis a v -> a) -> v a
+    indexV :: v a -> Basis a v -> a
 
 addV :: (AdditiveSemigroup a, VectorSpace a v) => v a -> v a -> v a
 addV = zipWithV (+)

--- a/src/ZkFold/Base/Algebra/Basic/VectorSpace.hs
+++ b/src/ZkFold/Base/Algebra/Basic/VectorSpace.hs
@@ -18,8 +18,8 @@ import           ZkFold.Base.Algebra.Basic.Class
 a `Field` then @v a@ is a vector space over it. If @a@ is a `Ring` then
 we have a free module, rather than a vector space. `VectorSpace` may also be thought of
 as a "monorepresentable" class, similar to `Representable` but with a fixed
-element type. A `VectorSpace` can be thought of as a fixed size tuple of variables
-@(x1,..,xn)@.
+element type. A `VectorSpace` can be thought of as a space of fixed size
+tuple of variables @(x1,..,xn)@.
 -}
 class VectorSpace a v where
     {- | The `Basis` for a `VectorSpace`. More accurately, `Basis` will be a spanning

--- a/src/ZkFold/Base/Algebra/Basic/VectorSpace.hs
+++ b/src/ZkFold/Base/Algebra/Basic/VectorSpace.hs
@@ -121,11 +121,8 @@ class
   ( VectorSpace a (InputSpace a f)
   , VectorSpace a (OutputSpace a f)
   ) => FunctionSpace a f where
-    -- | Dually to vector spaces, a function of vector spaces
-    -- enables coindexing, essentially evaluation;
-    coindexV :: f -> InputSpace a f a -> OutputSpace a f a
-    -- | and also enables cotabulating.
-    cotabulateV :: (InputSpace a f a -> OutputSpace a f a) -> f
+    uncurryV :: f -> InputSpace a f a -> OutputSpace a f a
+    curryV :: (InputSpace a f a -> OutputSpace a f a) -> f
 
 type family InputSpace a f where
   InputSpace a (x a -> f) = x :*: InputSpace a f
@@ -140,8 +137,8 @@ instance {-# OVERLAPPABLE #-}
   , OutputSpace a (y a) ~ y
   , InputSpace a (y a) ~ U1
   ) => FunctionSpace a (y a) where
-    coindexV f _ = f
-    cotabulateV k = k U1
+    uncurryV f _ = f
+    curryV k = k U1
 
 instance {-# OVERLAPPING #-}
   ( VectorSpace a x
@@ -149,9 +146,9 @@ instance {-# OVERLAPPING #-}
   , InputSpace a (x a -> f) ~ x :*: InputSpace a f
   , FunctionSpace a f
   ) => FunctionSpace a (x a -> f) where
-    coindexV f i = coindexV (f (pi1 i)) (pi2 i)
+    uncurryV f i = uncurryV (f (pi1 i)) (pi2 i)
       where
         pi1 (u :*: _) = u
         pi2 (_ :*: v) = v
 
-    cotabulateV k x = cotabulateV (k . (:*:) x)
+    curryV k x = curryV (k . (:*:) x)

--- a/src/ZkFold/Base/Algebra/Basic/VectorSpace.hs
+++ b/src/ZkFold/Base/Algebra/Basic/VectorSpace.hs
@@ -110,9 +110,9 @@ The type @FunctionSpace a f => f@ should be equal to some
 
 @(VectorSpace a v0, .. ,VectorSpace a vN) => vN a -> .. -> v1 a -> v0 a@
 
-which via uncurrying is equivalent to
+which via multiple-uncurrying is equivalent to
 
-@(VectorSpace a v0, .. ,VectorSpace a vN) => (vN :*: .. :*: v1) a -> v0 a@
+@(VectorSpace a v0, .. ,VectorSpace a vN) => (vN :*: .. :*: v1 :*: U1) a -> v0 a@
 
 A `FunctionSpace` can be thought of as the space of functions of the form
 @(y1,..,yj) = f(x1,..,xi)@

--- a/src/ZkFold/Base/Algebra/Basic/VectorSpace.hs
+++ b/src/ZkFold/Base/Algebra/Basic/VectorSpace.hs
@@ -18,7 +18,8 @@ import           ZkFold.Base.Algebra.Basic.Class
 a `Field` then @v a@ is a vector space over it. If @a@ is a `Ring` then
 we have a free module, rather than a vector space. `VectorSpace` may also be thought of
 as a "monorepresentable" class, similar to `Representable` but with a fixed
-element type.
+element type. A `VectorSpace` can be thought of as a fixed size tuple of variables
+@(x1,..,xn)@.
 -}
 class VectorSpace a v where
     {- | The `Basis` for a `VectorSpace`. More accurately, `Basis` will be a spanning
@@ -112,6 +113,9 @@ The type @FunctionSpace a f => f@ should be equal to some
 which via uncurrying is equivalent to
 
 @(VectorSpace a v0, .. ,VectorSpace a vN) => (vN :*: .. :*: v1) a -> v0 a@
+
+A `FunctionSpace` can be thought of as the space of functions of the form
+@(y1,..,yj) = f(x1,..,xi)@
 -}
 class
   ( VectorSpace a (InputSpace a f)


### PR DESCRIPTION
Makes the definition of `FunctionSpace` more symmetric by replacing the `InputBasis` type family by the `InputSpace` type family. The input basis can be recovered from `Basis a (InputSpace a f)`. Also changes the methods `coindexV` and `cotabulateV` to `uncurryV` and `curryV` which directly conveys the connection of these functions with `InputSpace`. Also adds a new combinator `composeFunctions`.

Motivation: This is anticipatory to considerations about structured inputs for arithmetic circuits. We wouldn't want to parametrize circuit inputs by an `i :: Type` with `acInputs :: i -> Natural` because functions are not so tractable. We would rather parametrize circuit inputs by an `i :: Type -> Type` with `acInputs :: i Natural`. Just one example of tractability, we can determine the `length` or `maximum` of the latter if `i` is `Foldable`.