### PR TITLE
feat: use `foldl'` instead of `foldl` in `length` prelude function

### DIFF
--- a/src/ZkFold/Prelude.hs
+++ b/src/ZkFold/Prelude.hs
@@ -2,14 +2,14 @@ module ZkFold.Prelude where
 
 import           Data.Aeson           (FromJSON, ToJSON, decode, encode)
 import           Data.ByteString.Lazy (readFile, writeFile)
-import           Data.List            (genericIndex)
+import           Data.List            (foldl', genericIndex)
 import           Data.Map             (Map, lookup)
 import           GHC.Num              (Natural, integerToNatural)
 import           Prelude              hiding (drop, lookup, readFile, replicate, take, writeFile, (!!))
 import           Test.QuickCheck      (Gen, chooseInteger)
 
 length :: Foldable t => t a -> Natural
-length = foldl (\c _ -> c + 1) 0
+length = foldl' (\c _ -> c + 1) 0
 
 take :: Natural -> [a] -> [a]
 take 0 _      = []


### PR DESCRIPTION
Just started studying the codebase of this awesome project :D. Not sure if there's a good reason of keeping `foldl` here 🤔.