### PR TITLE
fix: correct `Binary` instance of `LittleEndian` type

### DIFF
--- a/src/ZkFold/Base/Data/ByteString.hs
+++ b/src/ZkFold/Base/Data/ByteString.hs
@@ -37,8 +37,8 @@ newtype LittleEndian = LittleEndian {unLittleEndian :: Natural}
 instance Binary LittleEndian where
   get = do
     ns <- many getWord8
-    let accum n w8 = n * 256 + fromIntegral w8
-        littleEndian = LittleEndian (foldl' accum 0 (reverse ns))
+    let accum (!pw :: Natural, !acc :: Natural) w8 = (pw * 256, pw * fromIntegral w8 + acc)
+        littleEndian = LittleEndian (snd $ foldl' accum (1, 0) ns)
     return littleEndian
   put (LittleEndian n)
     | n == 0 = mempty

--- a/src/ZkFold/Base/Data/ByteString.hs
+++ b/src/ZkFold/Base/Data/ByteString.hs
@@ -38,12 +38,12 @@ instance Binary LittleEndian where
   get = do
     ns <- many getWord8
     let accum n w8 = n * 256 + fromIntegral w8
-        littleEndian = LittleEndian (foldl' accum 0 ns)
+        littleEndian = LittleEndian (foldl' accum 0 (reverse ns))
     return littleEndian
   put (LittleEndian n)
     | n == 0 = mempty
     | otherwise =
       let (n', r) = n `divMod` 256
-      in put (LittleEndian n') <> putWord8 (fromIntegral r)
+      in putWord8 (fromIntegral r) <> put (LittleEndian n')
 instance Arbitrary LittleEndian where
   arbitrary = fromInteger . abs <$> arbitrary


### PR DESCRIPTION
Related to https://github.com/zkFold/zkfold-base/issues/130.

Not sure if current behaviour is as expected, but this is what I had in mind.

"Binary instance" test pass by this modification. Use of `reverse` can be avoided by modifying `accum` function accordingly.