### PR TITLE
Define Applicative/Maybe instances for Symbolic Maybe

### DIFF
--- a/src/ZkFold/Symbolic/Data/Maybe.hs
+++ b/src/ZkFold/Symbolic/Data/Maybe.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE UndecidableInstances  #-}
 {-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
 module ZkFold.Symbolic.Data.Maybe (
     Maybe, maybe, just, nothing, fromMaybe, isNothing, isJust, find
@@ -44,7 +44,7 @@ instance
      let Maybe y z = Haskell.traverse g f in
      Maybe (checkMaybe x y) (join z)
 
-checkMaybe :: forall a b p . 
+checkMaybe :: forall a b p .
    AdditiveMonoid a =>
    Conditional p a =>
    Conditional b a =>


### PR DESCRIPTION
In order to use `Symbolic` `Maybe` in `P2P` example as a regular `Haskell` one, I've tried to define these instances.

The interesting part here is that I force these `Maybe` values to have either `zero` or `one` status. Not sure if it's correct to do in circuits.