### PR TITLE
Change hashing in NIPs to blake2b-224

### DIFF
--- a/src/ZkFold/Base/Protocol/NonInteractiveProof.hs
+++ b/src/ZkFold/Base/Protocol/NonInteractiveProof.hs
@@ -6,7 +6,7 @@
 module ZkFold.Base.Protocol.NonInteractiveProof where
 
 import           Control.DeepSeq             (NFData)
-import           Crypto.Hash.SHA256          (hash)
+import           Crypto.Hash.BLAKE2.BLAKE2b  (hash)
 import           Data.Aeson
 import           Data.ByteString             (ByteString, cons)
 import qualified Data.ByteString.Base64      as B64
@@ -35,7 +35,7 @@ class Monoid t => FromTranscript t a where
 
 instance Binary a => FromTranscript ByteString a where
     newTranscript  = cons 0
-    fromTranscript = fromJust . fromByteString . hash
+    fromTranscript = fromJust . fromByteString . hash 28 mempty
 
 challenge :: forall t a . FromTranscript t a => t -> (a, t)
 challenge ts =

--- a/zkfold-base.cabal
+++ b/zkfold-base.cabal
@@ -165,6 +165,7 @@ library
       aeson                                 < 2.3,
       base64-bytestring                          ,
       binary                               < 0.11,
+      blake2                                < 0.4,
       bytestring                           < 0.12,
       containers                            < 0.7,
       cryptohash-sha256                    < 0.12,


### PR DESCRIPTION
For compatibility with Cardano's on-chain Plonk verifier, I propose to change the hash that we use in non-interactive proof protocols to blake2b-224. It should not affect the rest of the codebase or dependencies. Later on, we should refactor code in a way to make the hashing algorithm a parameter of the non-interactive proof protocol.