### PR TITLE
+ FFA stub

### DIFF
--- a/examples/Examples/FFA.hs
+++ b/examples/Examples/FFA.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+module Examples.FFA (examplesFFA) where
+
+import           Data.Function                               (($))
+import           Data.List                                   ((++))
+import           Data.String                                 (String)
+import           System.IO                                   (IO, putStrLn)
+import           Text.Show                                   (show)
+
+import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Base.Algebra.Basic.Field             (Zp)
+import           ZkFold.Base.Algebra.Basic.Number
+import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
+import           ZkFold.Symbolic.Compiler                    (ArithmeticCircuit, compileIO)
+import           ZkFold.Symbolic.Data.FFA                    (FFA)
+
+type Prime256_1 = 28948022309329048855892746252171976963363056481941560715954676764349967630337
+type Prime256_2 = 28948022309329048855892746252171976963363056481941647379679742748393362948097
+
+examplesFFA :: IO ()
+examplesFFA = do
+  exampleFFAadd @Prime256_1
+  exampleFFAadd @Prime256_2
+  exampleFFAmul @Prime256_1
+  exampleFFAmul @Prime256_2
+
+exampleFFAadd :: forall p. KnownNat p => IO ()
+exampleFFAadd = makeExample @p "+" "add" (+)
+
+exampleFFAmul :: forall p. KnownNat p => IO ()
+exampleFFAmul = makeExample @p "*" "mul" (*)
+
+type Binary a = a -> a -> a
+
+makeExample :: forall p. KnownNat p => String -> String -> Binary (FFA p ArithmeticCircuit (Zp BLS12_381_Scalar)) -> IO ()
+makeExample shortName name op = do
+    let p = show $ value @p
+    putStrLn $ "\nExample: (" ++ shortName ++ ") operation on FFA " ++ p
+    let file = "compiled_scripts/ffa_" ++ p ++ "_" ++ name ++ ".json"
+    compileIO @(Zp BLS12_381_Scalar) file op

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -30,7 +30,6 @@ main = do
     exampleUIntAdd @500
     exampleUIntMul @32
     exampleUIntMul @500
-    examplesFFA
     exampleUIntStrictAdd @32
     exampleUIntStrictAdd @500
     exampleUIntStrictMul @32
@@ -42,3 +41,4 @@ main = do
     exampleByteStringExtend @1 @512
 
     exampleBatchTransfer
+    examplesFFA

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -7,6 +7,7 @@ import           Examples.BatchTransfer (exampleBatchTransfer)
 import           Examples.ByteString    (exampleByteStringAnd, exampleByteStringExtend, exampleByteStringOr)
 import           Examples.Conditional   (exampleConditional)
 import           Examples.Eq            (exampleEq)
+import           Examples.FFA           (examplesFFA)
 import           Examples.Fibonacci     (exampleFibonacci)
 import           Examples.LEQ           (exampleLEQ)
 import           Examples.MiMCHash      (exampleMiMC)
@@ -29,6 +30,7 @@ main = do
     exampleUIntAdd @500
     exampleUIntMul @32
     exampleUIntMul @500
+    examplesFFA
     exampleUIntStrictAdd @32
     exampleUIntStrictAdd @500
     exampleUIntStrictMul @32

--- a/src/ZkFold/Base/Algebra/Basic/Class.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Class.hs
@@ -551,11 +551,8 @@ instance Field Rational where
     rootOfUnity 1 = Just (-1)
     rootOfUnity _ = Nothing
 
-truncate :: Rational -> Integer
-truncate = Haskell.truncate
-
-truncateN :: Rational -> Natural
-truncateN = Haskell.truncate
+floorN :: Rational -> Natural
+floorN = Haskell.floor
 
 --------------------------------------------------------------------------------
 

--- a/src/ZkFold/Base/Algebra/Basic/Class.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Class.hs
@@ -507,6 +507,58 @@ instance Ring Integer
 
 --------------------------------------------------------------------------------
 
+-- TODO: Roll out our own Ratio type
+
+instance MultiplicativeSemigroup Rational where
+    (*) = (Haskell.*)
+
+instance Exponent Rational Natural where
+    (^) = (Haskell.^)
+
+instance MultiplicativeMonoid Rational where
+    one = 1
+
+instance AdditiveSemigroup Rational where
+    (+) = (Haskell.+)
+
+instance Scale Natural Rational
+
+instance AdditiveMonoid Rational where
+    zero = 0
+
+instance Scale Integer Rational
+
+instance AdditiveGroup Rational where
+    negate = Haskell.negate
+    (-) = (Haskell.-)
+
+instance FromConstant Natural Rational where
+    fromConstant = Haskell.fromIntegral
+
+instance Semiring Rational
+
+instance FromConstant Integer Rational where
+    fromConstant = Haskell.fromIntegral
+
+instance Ring Rational
+
+instance Exponent Rational Integer where
+    (^) = (Haskell.^^)
+
+instance Field Rational where
+    finv = Haskell.recip
+    rootOfUnity 0 = Just 1
+    rootOfUnity 1 = Just (-1)
+    rootOfUnity _ = Nothing
+
+truncate :: Rational -> Integer
+truncate = Haskell.truncate
+
+truncateN :: Rational -> Natural
+truncateN = Haskell.truncate
+
+--------------------------------------------------------------------------------
+
 instance MultiplicativeSemigroup Bool where
     (*) = (&&)
 

--- a/src/ZkFold/Base/Algebra/Basic/Field.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Field.hs
@@ -118,7 +118,7 @@ instance Prime p => Field (Zp p) where
               in bool (rootOfUnity' g') x' (x' ^ (n `Haskell.div` 2) /= one)
 
 inv :: Integer -> Natural -> Natural
-inv a p = fromIntegral $ snd $ egcd (a, 1) (fromConstant p, 0)
+inv a p = fromIntegral $ snd (egcd (a, 1) (fromConstant p, 0)) `Haskell.mod` fromConstant p
   where
     egcd (x, y) (0, _) = (x, y)
     egcd (x, y) (x', y') = egcd (x', y') (x - q * x', y - q * y')

--- a/src/ZkFold/Base/Algebra/Basic/Field.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Field.hs
@@ -23,7 +23,7 @@ import qualified Data.Vector                                as V
 import           GHC.Generics                               (Generic)
 import           GHC.TypeLits                               (Symbol)
 import           Numeric.Natural                            (Natural)
-import           Prelude                                    hiding (Fractional (..), Num (..), length, (^), div)
+import           Prelude                                    hiding (Fractional (..), Num (..), div, length, (^))
 import qualified Prelude                                    as Haskell
 import           System.Random                              (Random (..), RandomGen, mkStdGen, uniformR)
 import           Test.QuickCheck                            hiding (scale)
@@ -119,7 +119,7 @@ instance Prime p => Field (Zp p) where
 
 inv :: Integer -> Natural -> Natural
 inv a p = fromIntegral $ snd $ egcd (a, 1) (fromConstant p, 0)
-  where 
+  where
     egcd (x, y) (0, _) = (x, y)
     egcd (x, y) (x', y') = egcd (x', y') (x - q * x', y - q * y')
       where q = x `div` x'

--- a/src/ZkFold/Base/Data/Vector.hs
+++ b/src/ZkFold/Base/Data/Vector.hs
@@ -40,6 +40,9 @@ toVector as
 unsafeToVector :: forall size a . [a] -> Vector size a
 unsafeToVector = Vector
 
+unfold :: forall size a b. KnownNat size => (b -> (a, b)) -> b -> Vector size a
+unfold f = Vector . ZP.take (value @size) . List.unfoldr (Just . f)
+
 fromVector :: Vector size a -> [a]
 fromVector (Vector as) = as
 

--- a/src/ZkFold/Prelude.hs
+++ b/src/ZkFold/Prelude.hs
@@ -24,6 +24,10 @@ drop _ []     = error "ZkFold.Prelude.drop: empty list"
 splitAt :: Natural -> [a] -> ([a], [a])
 splitAt n xs = (take n xs, drop n xs)
 
+iterateM :: Monad m => Natural -> (a -> m a) -> a -> m a
+iterateM 0 _ x = return x
+iterateM n f x = f x >>= iterateM (n - 1) f
+
 replicate :: Natural -> a -> [a]
 replicate n x
     | n == 0    = []

--- a/src/ZkFold/Symbolic/Data/FFA.hs
+++ b/src/ZkFold/Symbolic/Data/FFA.hs
@@ -55,7 +55,7 @@ instance (KnownNat p, Finite (Zp q), ToConstant (Zp p) c) => ToConstant (FFA p V
             gs = zipWith mod gs0 mods
             sigma = ceiling (log2 $ value @Size) + 1 :: Natural
             binary g m = (fromConstant g * 2 ^ sigma) `div` fromConstant m
-            residue = truncateN (3 % 4 + sum (zipWith binary gs mods) % 2 ^ sigma)
+            residue = floorN (3 % 4 + sum (zipWith binary gs mods) % 2 ^ sigma)
          in vectorDotProduct gs (mis @(Zp q) @p) -! mprod @(Zp q) @p * residue
 
 instance (FromConstant c (Zp p), Finite (Zp q)) => FromConstant c (FFA p Vector (Zp q)) where

--- a/src/ZkFold/Symbolic/Data/FFA.hs
+++ b/src/ZkFold/Symbolic/Data/FFA.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+module ZkFold.Symbolic.Data.FFA where
+
+import           Control.Monad                                             (return)
+import           Data.Function                                             (($), (.))
+import           Numeric.Natural                                           (Natural)
+import           Prelude                                                   (Integer, error)
+
+import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Base.Algebra.Basic.Field                           (Zp)
+import           ZkFold.Base.Algebra.Basic.Number                          (KnownNat, value)
+import           ZkFold.Base.Data.Vector                                   (Vector (..), zipWithM)
+import           ZkFold.Symbolic.Compiler                                  (Arithmetic, ArithmeticCircuit)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (circuitN, newAssigned, runCircuit)
+import           ZkFold.Symbolic.Data.Combinators                          (maxBitsPerFieldElement)
+
+newtype FFA (p :: Natural) b a = FFA (b 3 a)
+
+coprimes :: forall a. Finite a => (Natural, Natural, Natural)
+coprimes = let n = 2 ^ (maxBitsPerFieldElement @a `div` 2) in (n, n -! 1, n -! 3)
+
+instance (KnownNat p, ToConstant (Zp p) c) => ToConstant (FFA p Vector (Zp q)) c where
+  toConstant = (toConstant :: Zp p -> c) . fromConstant . impl
+    where
+      impl :: FFA p Vector (Zp q) -> Natural
+      impl = error "TODO"
+
+instance (FromConstant c (Zp p), Finite (Zp q)) => FromConstant c (FFA p Vector (Zp q)) where
+  fromConstant = impl . toConstant . (fromConstant :: c -> Zp p)
+    where
+      (a, b, c) = coprimes @(Zp q)
+      impl :: Natural -> FFA p Vector (Zp q)
+      impl x = FFA $ Vector [
+        fromConstant (x `mod` a),
+        fromConstant (x `mod` b),
+        fromConstant (x `mod` c)
+        ]
+
+instance (FromConstant c (Zp p), Arithmetic a) => FromConstant c (FFA p ArithmeticCircuit a) where
+  fromConstant = impl . toConstant . (fromConstant :: c -> Zp p)
+    where
+      (a, b, c) = coprimes @a
+      impl :: Natural -> FFA p ArithmeticCircuit a
+      impl x = FFA $ circuitN $ do
+        i <- newAssigned (\_ -> fromConstant (x `mod` a))
+        j <- newAssigned (\_ -> fromConstant (x `mod` b))
+        k <- newAssigned (\_ -> fromConstant (x `mod` c))
+        return $ Vector [i, j, k]
+
+cast :: Vector 3 i -> m (Vector 3 i)
+cast = error "TODO"
+
+instance (Finite (Zp p), Finite (Zp q)) => MultiplicativeSemigroup (FFA p Vector (Zp q)) where
+  x * y = fromConstant (toConstant x * toConstant y :: Zp p)
+
+instance Arithmetic a => MultiplicativeSemigroup (FFA p ArithmeticCircuit a) where
+  FFA q * FFA r = FFA $ circuitN $ do
+    xs <- runCircuit q
+    ys <- runCircuit r
+    zs <- zipWithM (\i j -> newAssigned (($ i) * ($ j))) xs ys
+    cast zs
+
+instance (Finite (Zp p), Finite (Zp q)) => Exponent (FFA p Vector (Zp q)) Natural where
+  x ^ a = fromConstant (toConstant x ^ a :: Zp p)
+
+instance (Finite (Zp p), Arithmetic a) => Exponent (FFA p ArithmeticCircuit a) Natural where
+  (^) = natPow
+
+instance (Finite (Zp p), Finite (Zp q)) => MultiplicativeMonoid (FFA p Vector (Zp q)) where
+  one = fromConstant (one :: Zp p)
+
+instance (Finite (Zp p), Arithmetic a) => MultiplicativeMonoid (FFA p ArithmeticCircuit a) where
+  one = fromConstant (one :: Zp p)
+
+instance (Finite (Zp p), Finite (Zp q)) => AdditiveSemigroup (FFA p Vector (Zp q)) where
+  x + y = fromConstant (toConstant x + toConstant y :: Zp p)
+
+instance Arithmetic a => AdditiveSemigroup (FFA p ArithmeticCircuit a) where
+  FFA q + FFA r = FFA $ circuitN $ do
+    xs <- runCircuit q
+    ys <- runCircuit r
+    zs <- zipWithM (\i j -> newAssigned (($ i) + ($ j))) xs ys
+    cast zs
+
+instance (Finite (Zp p), Scale c (Zp p), Finite (Zp q)) => Scale c (FFA p Vector (Zp q)) where
+  scale k x = fromConstant (scale k one :: Zp p) * x
+
+instance (Finite (Zp p), Scale c (Zp p), Arithmetic a) => Scale c (FFA p ArithmeticCircuit a) where
+  scale k x = fromConstant (scale k one :: Zp p) * x
+
+instance (Finite (Zp p), FromConstant (Zp p) (FFA p b a), Scale Natural (FFA p b a), AdditiveSemigroup (FFA p b a)) => AdditiveMonoid (FFA p b a) where
+  zero = fromConstant (zero :: Zp p)
+
+instance (Finite (Zp p), Finite (Zp q)) => AdditiveGroup (FFA p Vector (Zp q)) where
+  negate = fromConstant . negate @(Zp p) . toConstant
+
+instance (Finite (Zp p), Arithmetic a) => AdditiveGroup (FFA p ArithmeticCircuit a) where
+  negate (FFA q) = FFA $ circuitN $ do
+    Vector xs <- runCircuit q
+    let (x, y, z) = case xs of { [u, v, w] -> (u, v, w); _ -> error "negate: impossible" }
+        (a, b, c) = coprimes @a
+    i <- newAssigned (\w -> fromConstant a - w x)
+    j <- newAssigned (\w -> fromConstant b - w y)
+    k <- newAssigned (\w -> fromConstant c - w z)
+    cast $ Vector [i, j, k]
+
+instance (MultiplicativeMonoid (FFA p b a), AdditiveMonoid (FFA p b a), FromConstant Natural (FFA p b a)) => Semiring (FFA p b a)
+
+instance (Semiring (FFA p b a), AdditiveGroup (FFA p b a), FromConstant Integer (FFA p b a)) => Ring (FFA p b a)
+
+instance (PrimeField (Zp p), Finite (Zp q)) => Exponent (FFA p Vector (Zp q)) Integer where
+  x ^ a = fromConstant (toConstant x ^ a :: Zp p)
+
+instance (PrimeField (Zp p), Arithmetic a) => Exponent (FFA p ArithmeticCircuit a) Integer where
+  x ^ a = x `intPowF` (a `mod` fromConstant (value @p -! 1))
+
+instance (PrimeField (Zp p), Finite (Zp q)) => Field (FFA p Vector (Zp q)) where
+  finv = fromConstant . finv @(Zp p) . toConstant
+
+instance (PrimeField (Zp p), Arithmetic a) => Field (FFA p ArithmeticCircuit a) where
+  finv x = x ^ (value @p -! 2)
+
+instance Finite (Zp p) => Finite (FFA p b a) where
+  type Order (FFA p b a) = p

--- a/src/ZkFold/Symbolic/Data/FFA.hs
+++ b/src/ZkFold/Symbolic/Data/FFA.hs
@@ -95,7 +95,7 @@ smallCut = zipWithM condSub $ coprimes @a
 
 bigSub :: forall i a m. (Arithmetic a, MonadBlueprint i a m) => Natural -> i -> m i
 bigSub m j = trimPow j >>= trimPow >>= condSub m
-  where 
+  where
     s = ceiling (log2 m) :: Natural
     trimPow i = do
       (l, h) <- splitExpansion s (numberOfBits @a -! s) i

--- a/src/ZkFold/Symbolic/Data/Ord.hs
+++ b/src/ZkFold/Symbolic/Data/Ord.hs
@@ -98,7 +98,7 @@ circuitGE xs ys = Bool $ circuit $ do
   js <- runCircuit ys
   blueprintGE is js
 
-blueprintGE :: MonadBlueprint i a m => V.Vector n i -> V.Vector n i -> m i
+blueprintGE :: (MonadBlueprint i a m, Z.Zip f, Haskell.Foldable f) => f i -> f i -> m i
 blueprintGE xs ys = do
   (_, hasNegOne) <- circuitDelta xs ys
   newAssigned $ \p -> one - p hasNegOne
@@ -111,7 +111,7 @@ circuitGT xs ys = Bool $ circuit $ do
   (hasOne, hasNegOne) <- circuitDelta is js
   newAssigned $ \p -> p hasOne * (one - p hasNegOne)
 
-circuitDelta :: forall i a m n . MonadBlueprint i a m => V.Vector n i -> V.Vector n i -> m (i, i)
+circuitDelta :: forall i a m f . (MonadBlueprint i a m, Z.Zip f, Haskell.Foldable f) => f i -> f i -> m (i, i)
 circuitDelta l r = do
     z1 <- newAssigned (Haskell.const zero)
     z2 <- newAssigned (Haskell.const zero)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -6,6 +6,7 @@ import           Tests.Arithmetization     (specArithmetization)
 import           Tests.Binary              (specBinary)
 import           Tests.Blake2b             (specBlake2b)
 import           Tests.ByteString          (specByteString)
+import           Tests.FFA                 (specFFA)
 import           Tests.Field               (specField)
 import           Tests.GroebnerBasis       (specGroebner)
 import           Tests.Group               (specAdditiveGroup)
@@ -31,6 +32,7 @@ main = do
 
     -- Symbolic types and operations
     specUInt
+    specFFA
     specByteString
     --TODO: implement a proper blake2b test
     specBlake2b

--- a/tests/Tests/FFA.hs
+++ b/tests/Tests/FFA.hs
@@ -1,7 +1,60 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Tests.FFA (specFFA) where
 
-import           Control.Monad (return)
-import           System.IO     (IO)
+import           Data.Function                               (($))
+import           Data.List                                   ((++))
+import           System.IO                                   (IO)
+import           Test.Hspec                                  (describe, hspec)
+import           Test.QuickCheck                             (Property, (===), withMaxSuccess)
+import           Tests.ArithmeticCircuit                     (it)
+import           Text.Show                                   (show)
+
+import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Base.Algebra.Basic.Field             (Zp)
+import           ZkFold.Base.Algebra.Basic.Number            (Prime, value)
+import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
+import           ZkFold.Base.Data.Vector                     (Vector)
+import           ZkFold.Symbolic.Compiler                    (ArithmeticCircuit, exec)
+import           ZkFold.Symbolic.Data.FFA                    (FFA (FFA))
+
+type Prime256_1 = 28948022309329048855892746252171976963363056481941560715954676764349967630337
+type Prime256_2 = 28948022309329048855892746252171976963363056481941647379679742748393362948097
+
+instance Prime Prime256_1
+instance Prime Prime256_2
 
 specFFA :: IO ()
-specFFA = return ()
+specFFA = do
+  specFFA' @BLS12_381_Scalar @Prime256_1
+  specFFA' @BLS12_381_Scalar @Prime256_2
+
+specFFA' :: forall p q. (PrimeField (Zp p), PrimeField (Zp q)) => IO ()
+specFFA' = hspec $ do
+  let q = value @q
+  describe ("FFA " ++ show q ++ " specification") $ do
+    it "FFA(Zp) embeds Zq" $ \(x :: Zp q) ->
+      toConstant (fromConstant x :: FFA q Vector (Zp p)) === x
+    it "FFA(AC) embeds Zq" $ \(x :: Zp q) ->
+      execAcFFA @p @q (fromConstant x) === x
+    it "has zero" $ execAcFFA @p @q zero === execZpFFA @p @q zero
+    it "has one" $ execAcFFA @p @q one === execZpFFA @p @q one
+    -- TODO: increase limits once we have range constraints
+    it "adds correctly" $ withMaxSuccess 1 $ isHom @p @q (+) (+)
+    it "negates correctly" $ withMaxSuccess 1 $ \(x :: Zp q) ->
+      execAcFFA @p @q (negate $ fromConstant x) === execZpFFA @p @q (negate $ fromConstant x)
+    it "multiplies correctly" $ withMaxSuccess 1 $ isHom @p @q (*) (*)
+
+execAcFFA :: (PrimeField (Zp p), PrimeField (Zp q)) => FFA q ArithmeticCircuit (Zp p) -> Zp q
+execAcFFA (FFA v) = execZpFFA $ FFA (exec v)
+
+execZpFFA :: (PrimeField (Zp p), PrimeField (Zp q)) => FFA q Vector (Zp p) -> Zp q
+execZpFFA = toConstant
+
+type Binary a = a -> a -> a
+type Predicate a = a -> a -> Property
+
+isHom :: (PrimeField (Zp p), PrimeField (Zp q)) => Binary (FFA q Vector (Zp p)) -> Binary (FFA q ArithmeticCircuit (Zp p)) -> Predicate (Zp q)
+isHom f g x y = execAcFFA (fromConstant x `g` fromConstant y) === execZpFFA (fromConstant x `f` fromConstant y)

--- a/tests/Tests/FFA.hs
+++ b/tests/Tests/FFA.hs
@@ -1,0 +1,7 @@
+module Tests.FFA (specFFA) where
+
+import           Control.Monad (return)
+import           System.IO     (IO)
+
+specFFA :: IO ()
+specFFA = return ()

--- a/tests/Tests/FFA.hs
+++ b/tests/Tests/FFA.hs
@@ -8,7 +8,7 @@ import           Data.Function                               (($))
 import           Data.List                                   ((++))
 import           System.IO                                   (IO)
 import           Test.Hspec                                  (describe, hspec)
-import           Test.QuickCheck                             (Property, (===), withMaxSuccess)
+import           Test.QuickCheck                             (Property, withMaxSuccess, (===))
 import           Tests.ArithmeticCircuit                     (it)
 import           Text.Show                                   (show)
 

--- a/zkfold-base.cabal
+++ b/zkfold-base.cabal
@@ -272,6 +272,7 @@ test-suite zkfold-base-examples
       Examples.ByteString
       Examples.Conditional
       Examples.Eq
+      Examples.FFA
       Examples.Fibonacci
       Examples.LEQ
       Examples.MiMCHash

--- a/zkfold-base.cabal
+++ b/zkfold-base.cabal
@@ -156,6 +156,7 @@ library
       ZkFold.Symbolic.Data.Ed25519
       ZkFold.Symbolic.Data.Eq
       ZkFold.Symbolic.Data.Eq.Structural
+      ZkFold.Symbolic.Data.FFA
       ZkFold.Symbolic.Data.Maybe
       ZkFold.Symbolic.Data.Ord
       ZkFold.Symbolic.Data.UInt

--- a/zkfold-base.cabal
+++ b/zkfold-base.cabal
@@ -230,6 +230,7 @@ test-suite zkfold-base-test
       Tests.Binary
       Tests.Blake2b
       Tests.ByteString
+      Tests.FFA
       Tests.Field
       Tests.GroebnerBasis
       Tests.Group


### PR DESCRIPTION
A stub of an implementation of foreign-field arithmetic via Residue Number System as in https://cr.yp.to/papers/mmecrt.pdf with only 7 residues for now. It is enough for our current goals; once we have circuits indexed by functors, will update to general solution.