### PR TITLE
Use associated types for `BinaryExpansion` output

### DIFF
--- a/src/ZkFold/Base/Algebra/Basic/Class.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Class.hs
@@ -406,14 +406,16 @@ The following should hold:
 * @fromBinary . binaryExpansion == id@
 * @fromBinary xs == foldr (\x y -> x + y + y) zero xs@
 -}
-class Semiring a => BinaryExpansion a b | a -> b, b -> a where
-    binaryExpansion :: a -> b
+class Semiring a => BinaryExpansion a where
+    type Bits a :: Type
 
-    fromBinary :: b -> a
-    default fromBinary :: b ~ [a] => b -> a
+    binaryExpansion :: a -> Bits a
+
+    fromBinary :: Bits a -> a
+    default fromBinary :: Bits a ~ [a] => Bits a -> a
     fromBinary = foldr (\x y -> x + y + y) zero
 
-padBits :: forall a . BinaryExpansion a [a] => Natural -> [a] -> [a]
+padBits :: forall a . AdditiveMonoid a => Natural -> [a] -> [a]
 padBits n xs = xs ++ replicate (n -! length xs) zero
 
 castBits :: (Semiring a, Eq a, Semiring b) => [a] -> [b]
@@ -463,7 +465,8 @@ instance Semiring Natural
 instance EuclideanDomain Natural where
     divMod = Haskell.divMod
 
-instance BinaryExpansion Natural [Natural] where
+instance BinaryExpansion Natural where
+    type Bits Natural = [Natural]
     binaryExpansion 0 = []
     binaryExpansion x = (x `mod` 2) : binaryExpansion (x `div` 2)
 
@@ -540,7 +543,9 @@ instance FromConstant Integer Bool where
 
 instance Ring Bool
 
-instance BinaryExpansion Bool [Bool] where
+instance BinaryExpansion Bool where
+    type Bits Bool = [Bool]
+
     binaryExpansion = (:[])
 
     fromBinary []  = False

--- a/src/ZkFold/Base/Algebra/Basic/Field.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Field.hs
@@ -122,7 +122,8 @@ instance Prime p => Field (Zp p) where
                   x' = x ^ ((value @p -! 1) `Haskell.div` n)
               in bool (rootOfUnity' g') x' (x' ^ (n `Haskell.div` 2) /= one)
 
-instance Prime p => BinaryExpansion (Zp p) [Zp p] where
+instance Prime p => BinaryExpansion (Zp p) where
+    type Bits (Zp p) = [Zp p]
     binaryExpansion = map (Zp . fromConstant) . binaryExpansion . fromZp
 
 instance Prime p => DiscreteField' (Zp p)

--- a/src/ZkFold/Base/Algebra/Basic/Sources.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Sources.hs
@@ -46,8 +46,9 @@ instance Ord i => Semiring (Sources a i)
 instance Ord i => Ring (Sources a i)
 
 instance Ord i => Field (Sources a i) where
-    finv = id
-    rootOfUnity _ = Just (Sources mempty)
+  finv = id
+  rootOfUnity _ = Just (Sources mempty)
 
-instance (Finite a, Ord i) => BinaryExpansion (Sources a i) [Sources a i] where
+instance (Finite a, Ord i) => BinaryExpansion (Sources a i) where
+  type Bits (Sources a i) = [Sources a i]
   binaryExpansion = replicate (numberOfBits @a)

--- a/src/ZkFold/Base/Algebra/EllipticCurve/Class.hs
+++ b/src/ZkFold/Base/Algebra/EllipticCurve/Class.hs
@@ -13,7 +13,7 @@ import           Test.QuickCheck                 hiding (scale)
 import           ZkFold.Base.Algebra.Basic.Class
 
 
-data Point curve = Point { _x :: (BaseField curve), _y :: (BaseField curve) } | Inf
+data Point curve = Point { _x :: BaseField curve, _y :: BaseField curve } | Inf
 
 class EllipticCurve curve where
 
@@ -106,7 +106,8 @@ pointNegate (Point x y) = Point x (negate y)
 pointMul
     :: forall curve
     .  EllipticCurve curve
-    => BinaryExpansion (ScalarField curve) [ScalarField curve]
+    => BinaryExpansion (ScalarField curve)
+    => Bits (ScalarField curve) ~ [ScalarField curve]
     => Eq (ScalarField curve)
     => ScalarField curve
     -> Point curve

--- a/src/ZkFold/Base/Algebra/EllipticCurve/Ed25519.hs
+++ b/src/ZkFold/Base/Algebra/EllipticCurve/Ed25519.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module ZkFold.Base.Algebra.EllipticCurve.Ed25519  where

--- a/src/ZkFold/Base/Algebra/Polynomials/Multivariate/Monomial.hs
+++ b/src/ZkFold/Base/Algebra/Polynomials/Multivariate/Monomial.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass               #-}
 {-# LANGUAGE NoGeneralisedNewtypeDeriving #-}
 {-# LANGUAGE TypeApplications             #-}
-{-# LANGUAGE UndecidableInstances         #-}
 
 module ZkFold.Base.Algebra.Polynomials.Multivariate.Monomial where
 
@@ -77,7 +76,7 @@ instance Monomial i j => Ord (Mono i j) where
                 | k1 == k2  = if a1 == a2 then go xs ys else compare a1 a2
                 | otherwise = compare k2 k1
 
-instance (Monomial i j, Arbitrary (Map i j)) => Arbitrary (Mono i j) where
+instance (Monomial i j, Arbitrary i, Arbitrary j) => Arbitrary (Mono i j) where
     arbitrary = M <$> arbitrary
 
 instance Monomial i j => MultiplicativeSemigroup (Mono i j) where

--- a/src/ZkFold/Base/Protocol/ARK/Protostar/Gate.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Protostar/Gate.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
-
 module ZkFold.Base.Protocol.ARK.Protostar.Gate where
 
 import           Data.Zip                                        (zipWith)

--- a/src/ZkFold/Base/Protocol/ARK/Protostar/Permutation.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Protostar/Permutation.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
-
 module ZkFold.Base.Protocol.ARK.Protostar.Permutation where
 
 import           Data.Zip                                        (Zip (..))
@@ -52,4 +50,3 @@ instance Arithmetic f => SpecialSoundProtocol f (ProtostarPermutation n) where
              -> Bool
     verifier _ sigma [(w, _)] = applyPermutation sigma w == w
     verifier _ _     _        = error "Invalid transcript"
-

--- a/src/ZkFold/Symbolic/Cardano/Contracts/BatchTransfer.hs
+++ b/src/ZkFold/Symbolic/Cardano/Contracts/BatchTransfer.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
-
 module ZkFold.Symbolic.Cardano.Contracts.BatchTransfer where
 
 import           Data.Maybe                                             (fromJust)

--- a/src/ZkFold/Symbolic/Cardano/Contracts/RandomOracle.hs
+++ b/src/ZkFold/Symbolic/Cardano/Contracts/RandomOracle.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeOperators #-}
+
 module ZkFold.Symbolic.Cardano.Contracts.RandomOracle where
 
 import           Prelude                                                hiding (Bool, Eq (..), all, length, maybe,
@@ -42,7 +44,7 @@ type Sig b a = (StrictConv a (UInt 256 b a),
     Eq (Bool (b 1 a)) (ByteString 256 b a),
     Iso (UInt 256 b a) (ByteString 256 b a),
     Extend (ByteString 224 b a) (ByteString 256 b a),
-    BinaryExpansion a (b 256 a),
+    BinaryExpansion a, Bits a ~ b 256 a,
     Hash a (ByteString 256 b a),
     Hash a (OutputRef b a))
 

--- a/src/ZkFold/Symbolic/Cardano/UPLC.hs
+++ b/src/ZkFold/Symbolic/Cardano/UPLC.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE AllowAmbiguousTypes  #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications    #-}
 
 {-# OPTIONS_GHC -Wno-orphans     #-}
 

--- a/src/ZkFold/Symbolic/Cardano/UPLC/Builtins.hs
+++ b/src/ZkFold/Symbolic/Cardano/UPLC/Builtins.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE AllowAmbiguousTypes  #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications    #-}
 
 module ZkFold.Symbolic.Cardano.UPLC.Builtins where
 

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
@@ -94,7 +94,7 @@ bitsOf :: MonadBlueprint i a m => Natural -> i -> m [i]
 bitsOf n k = for [0 .. n -! 1] $ \j ->
     newConstrained (\x i -> let xi = x i in xi * (xi - one)) ((!! j) . repr . ($ k))
     where
-        repr :: forall b . (BinaryExpansion b [b], Finite b) => b -> [b]
+        repr :: forall b . (BinaryExpansion b, Bits b ~ [b], Finite b) => b -> [b]
         repr = padBits (numberOfBits @b) . binaryExpansion
 
 horner :: MonadBlueprint i a m => [i] -> m i

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -111,7 +111,8 @@ instance (Arithmetic a, KnownNat n) => Field (ArithmeticCircuit n a) where
 --
 -- Ideally, we want to return another ArithmeticCircuit with a number of outputs corresponding to the number of bits.
 -- This does not align well with the type of @binaryExpansion@
-instance (Arithmetic a, bits ~ NumberOfBits a) => BinaryExpansion (ArithmeticCircuit 1 a) (ArithmeticCircuit bits a) where
+instance Arithmetic a => BinaryExpansion (ArithmeticCircuit 1 a) where
+    type Bits (ArithmeticCircuit 1 a) = ArithmeticCircuit (NumberOfBits a) a
     binaryExpansion r = circuitN $ do
         output <- runCircuit r
         bits <- expansion (numberOfBits @a) . V.item $ output

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
@@ -121,7 +121,7 @@ joinCircuits r1 r2 =
     ArithmeticCircuit
         {
             acCircuit = acCircuit r1 <> acCircuit r2
-        ,   acOutput = (acOutput r1 `V.append` acOutput r2)
+        ,   acOutput = acOutput r1 `V.append` acOutput r2
         }
 
 concatCircuits :: (Eq a, MultiplicativeMonoid a) => Vector n (ArithmeticCircuit m a) -> ArithmeticCircuit (n * m) a
@@ -141,7 +141,7 @@ type VarField = Zp BLS12_381_Scalar
 toField :: Arithmetic a => a -> VarField
 toField = toZp . fromConstant . fromBinary @Natural . castBits . binaryExpansion
 
-type Arithmetic a = (FiniteField a, Eq a, BinaryExpansion a [a])
+type Arithmetic a = (FiniteField a, Eq a, BinaryExpansion a, Bits a ~ [a])
 
 -- TODO: Remove the hardcoded constant.
 toVar :: forall a . Arithmetic a => [Natural] -> Constraint a -> Natural

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE TypeOperators      #-}
 
 {-# OPTIONS_GHC -Wno-orphans    #-}
 
@@ -33,7 +34,7 @@ import           ZkFold.Symbolic.Data.Bool                           (Bool (..))
 import           ZkFold.Symbolic.Data.Conditional                    (Conditional (..))
 import           ZkFold.Symbolic.Data.Eq                             (Eq (..))
 
-type WitnessField a x = (Algebra a x, FiniteField x, BinaryExpansion x [x],
+type WitnessField a x = (Algebra a x, FiniteField x, BinaryExpansion x, Bits x ~ [x],
     Eq (Bool x) x, Conditional (Bool x) x, Conditional (Bool x) (Bool x))
 -- ^ DSL for constructing witnesses in an arithmetic circuit. @a@ is a base
 -- field; @x@ is a "field of witnesses over @a@" which you can safely assume to

--- a/src/ZkFold/Symbolic/Data/Ord.hs
+++ b/src/ZkFold/Symbolic/Data/Ord.hs
@@ -85,10 +85,10 @@ instance (SymbolicData a x, TypeSize a x ~ 1) => Ord (Bool (ArithmeticCircuit 1 
 
     min x y = bool @(Bool (ArithmeticCircuit 1 a)) x y $ x > y
 
-getBitsBE :: (SymbolicData a x, TypeSize a x ~ 1, bits ~ NumberOfBits a) => x -> ArithmeticCircuit bits a
+getBitsBE :: forall a x . (SymbolicData a x, TypeSize a x ~ 1) => x -> ArithmeticCircuit (NumberOfBits a) a
 -- ^ @getBitsBE x@ returns a list of circuits computing bits of @x@, eldest to
 -- youngest.
-getBitsBE x = let expansion = binaryExpansion $ pieces x
+getBitsBE x = let expansion = binaryExpansion $ pieces @a @x x
                in expansion { acOutput = V.reverse $ acOutput expansion }
 
 circuitGE :: forall a n . Arithmetic a => ArithmeticCircuit n a -> ArithmeticCircuit n a -> Bool (ArithmeticCircuit 1 a)

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes  #-}
-{-# LANGUAGE DerivingStrategies   #-}
 {-# LANGUAGE DerivingVia          #-}
 {-# LANGUAGE NoDeriveAnyClass     #-}
 {-# LANGUAGE TypeApplications     #-}

--- a/src/ZkFold/Symbolic/Data/UTCTime.hs
+++ b/src/ZkFold/Symbolic/Data/UTCTime.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DerivingStrategies   #-}
-{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -freduction-depth=0 #-} -- This is what our life will look like from now on if we keep using NumberOfRegisters
 

--- a/tests/Tests/ByteString.hs
+++ b/tests/Tests/ByteString.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes  #-}
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Tests.ByteString (specByteString) where
 

--- a/tests/Tests/ByteString.hs
+++ b/tests/Tests/ByteString.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE AllowAmbiguousTypes  #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
 
 module Tests.ByteString (specByteString) where
 

--- a/tests/Tests/NonInteractiveProof.hs
+++ b/tests/Tests/NonInteractiveProof.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE AllowAmbiguousTypes  #-}
-{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications    #-}
 
 module Tests.NonInteractiveProof (specNonInteractiveProof) where
 

--- a/tests/Tests/NonInteractiveProof.hs
+++ b/tests/Tests/NonInteractiveProof.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes  #-}
 {-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Tests.NonInteractiveProof (specNonInteractiveProof) where
 

--- a/tests/Tests/SHA2.hs
+++ b/tests/Tests/SHA2.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes  #-}
 {-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Tests.SHA2 (specSHA2Natural, specSHA2) where
 

--- a/tests/Tests/SHA2.hs
+++ b/tests/Tests/SHA2.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE AllowAmbiguousTypes  #-}
-{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications    #-}
 
 module Tests.SHA2 (specSHA2Natural, specSHA2) where
 


### PR DESCRIPTION
As there is always a single (the most efficient and the most correct) implementation of `BinaryExpansion` for an input type, I propose to turn the second parameter into an associated type. Most importantly, this way usage of `Arithmetic a` constraint does not force to turn on an `UndecidableInstances` language extension.