### PR TITLE
Plonk + type aliases refactor

### DIFF
--- a/src/ZkFold/Base/Algebra/EllipticCurve/BLS12_381.hs
+++ b/src/ZkFold/Base/Algebra/EllipticCurve/BLS12_381.hs
@@ -266,7 +266,8 @@ deriving via (NonZero Fq12) instance MultiplicativeGroup BLS12_381_GT
 instance Finite BLS12_381_GT where
     type Order BLS12_381_GT = BLS12_381_Scalar
 
-instance Pairing BLS12_381_G1 BLS12_381_G2 BLS12_381_GT where
+instance Pairing BLS12_381_G1 BLS12_381_G2 where
+    type TargetGroup BLS12_381_G1 BLS12_381_G2 = BLS12_381_GT
     pairing a b = BLS12_381_GT (pairingBLS a b)
 
 -- Adapted from https://github.com/nccgroup/pairing-bls12381/blob/master/Crypto/Pairing_bls12381.hs

--- a/src/ZkFold/Base/Algebra/EllipticCurve/Class.hs
+++ b/src/ZkFold/Base/Algebra/EllipticCurve/Class.hs
@@ -57,8 +57,10 @@ instance (EllipticCurve curve, Arbitrary (ScalarField curve)) => Arbitrary (Poin
     arbitrary = arbitrary <&> (`mul` gen)
 
 class (EllipticCurve curve1, EllipticCurve curve2, ScalarField curve1 ~ ScalarField curve2,
-        Eq t, MultiplicativeGroup t, Exponent t (ScalarField curve1)) => Pairing curve1 curve2 t | curve1 curve2 -> t where
-    pairing :: Point curve1 -> Point curve2 -> t
+        Eq (TargetGroup curve1 curve2), MultiplicativeGroup (TargetGroup curve1 curve2),
+        Exponent (TargetGroup curve1 curve2) (ScalarField curve1)) => Pairing curve1 curve2 where
+    type TargetGroup curve1 curve2 :: Type
+    pairing :: Point curve1 -> Point curve2 -> TargetGroup curve1 curve2
 
 pointAdd
     :: Field (BaseField curve)

--- a/src/ZkFold/Base/Algebra/Polynomials/Univariate.hs
+++ b/src/ZkFold/Base/Algebra/Polynomials/Univariate.hs
@@ -312,19 +312,19 @@ castPolyVec (PV cs)
     | otherwise = error "castPolyVec: Cannot cast polynomial vector to smaller size!"
 
 -- p(x) = x^n - 1
-polyVecZero :: forall c size size' . (Field c, KnownNat size, KnownNat size', Eq c) => PolyVec c size'
-polyVecZero = poly2vec $ scaleP one (value @size) one - one
+polyVecZero :: forall c n size . (Field c, KnownNat n, KnownNat size, Eq c) => PolyVec c size
+polyVecZero = poly2vec $ scaleP one (value @n) one - one
 
 -- L_i(x) : p(omega^i) = 1, p(omega^j) = 0, j /= i, 1 <= i <= n, 1 <= j <= n
-polyVecLagrange :: forall c size size' . (Field c, Eq c, KnownNat size, KnownNat size') =>
-    Natural -> c -> PolyVec c size'
-polyVecLagrange i omega = scalePV (omega^i // fromConstant (value @size)) $ (polyVecZero @c @size @size' - one) `polyVecDiv` polyVecLinear (negate $ omega^i) one
+polyVecLagrange :: forall c n size . (Field c, Eq c, KnownNat n, KnownNat size) =>
+    Natural -> c -> PolyVec c size
+polyVecLagrange i omega = scalePV (omega^i // fromConstant (value @n)) $ (polyVecZero @c @n @size - one) `polyVecDiv` polyVecLinear (negate $ omega^i) one
 
 -- p(x) = c_1 * L_1(x) + c_2 * L_2(x) + ... + c_n * L_n(x)
-polyVecInLagrangeBasis :: forall c size size' . (Field c, Eq c, KnownNat size, KnownNat size') =>
-    c -> PolyVec c size -> PolyVec c size'
+polyVecInLagrangeBasis :: forall c n size . (Field c, Eq c, KnownNat n, KnownNat size) =>
+    c -> PolyVec c n -> PolyVec c size
 polyVecInLagrangeBasis omega (PV cs) =
-    let ls = fmap (\i -> polyVecLagrange @c @size @size' i omega) (V.generate (V.length cs) (fromIntegral . succ))
+    let ls = fmap (\i -> polyVecLagrange @c @n @size i omega) (V.generate (V.length cs) (fromIntegral . succ))
     in sum $ V.zipWith scalePV cs ls
 
 polyVecGrandProduct :: forall c size . (Field c, KnownNat size) =>

--- a/src/ZkFold/Base/Protocol/ARK/Plonk.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Plonk.hs
@@ -3,9 +3,14 @@
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module ZkFold.Base.Protocol.ARK.Plonk where
+module ZkFold.Base.Protocol.ARK.Plonk (
+    module ZkFold.Base.Protocol.ARK.Plonk.Internal,
+    Plonk(..),
+    plonkPermutation,
+    plonkCircuitPolynomials,
+    plonkVerifierInput
+) where
 
-import qualified Data.Map                                            as Map
 import           Data.Maybe                                          (fromJust)
 import qualified Data.Vector                                         as V
 import           GHC.IsList                                          (IsList (..))
@@ -13,28 +18,20 @@ import           Numeric.Natural                                     (Natural)
 import           Prelude                                             hiding (Num (..), div, drop, length, replicate,
                                                                       sum, take, (!!), (/), (^))
 import qualified Prelude                                             as P hiding (length)
-import           Test.QuickCheck                                     (Arbitrary (..), Gen, shuffle)
+import           Test.QuickCheck                                     (Arbitrary (..))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.Basic.Field                     (Zp)
 import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Base.Algebra.Basic.Permutations              (fromPermutation)
-import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381         (BLS12_381_G1, BLS12_381_G2, BLS12_381_Scalar)
 import           ZkFold.Base.Algebra.EllipticCurve.Class             (EllipticCurve (..), Pairing (..), Point)
 import           ZkFold.Base.Algebra.Polynomials.Univariate          hiding (qr)
 import           ZkFold.Base.Data.Vector                             (Vector (..), fromVector)
-import           ZkFold.Base.Protocol.ARK.Plonk.Internal             (getParams)
+import           ZkFold.Base.Protocol.ARK.Plonk.Internal
 import           ZkFold.Base.Protocol.ARK.Plonk.Relation             (PlonkRelation (..), toPlonkRelation)
 import           ZkFold.Base.Protocol.Commitment.KZG                 (com)
 import           ZkFold.Base.Protocol.NonInteractiveProof
-import           ZkFold.Prelude                                      (length, take, (!))
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (ArithmeticCircuit (..), inputVariables)
-
--- TODO (Issue #25): make this module generic in the elliptic curve with pairing
-
-type F = Zp BLS12_381_Scalar
-type G1 = Point BLS12_381_G1
-type G2 = Point BLS12_381_G2
+import           ZkFold.Prelude                                      (length, (!))
+import           ZkFold.Symbolic.Compiler                            (Arithmetic, ArithmeticCircuit, inputVariables)
 
 {-
     NOTE: we need to parametrize the type of transcripts because we use BuiltinByteString on-chain and ByteString off-chain.
@@ -42,11 +39,20 @@ type G2 = Point BLS12_381_G2
 -}
 
 -- TODO: disallow `d` that are not powers of 2
-data Plonk (d :: Natural) (n :: Natural) t = Plonk F F F (Vector n Natural) (ArithmeticCircuit 1 F) F
-    deriving (Show)
+data Plonk (d :: Natural) (n :: Natural) curve1 curve2 t = Plonk {
+        omega :: ScalarField curve1,
+        k1    :: ScalarField curve1,
+        k2    :: ScalarField curve1,
+        iPub  :: Vector n Natural,
+        ac    :: ArithmeticCircuit 1 (ScalarField curve1),
+        x     :: ScalarField curve1
+    }
+instance (Show (ScalarField c1), Arithmetic (ScalarField c1)) => Show (Plonk d n c1 c2 t) where
+    show (Plonk omega k1 k2 iPub ac x) =
+        "Plonk: " ++ show omega ++ " " ++ show k1 ++ " " ++ show k2 ++ " " ++ show iPub ++ " " ++ show ac ++ " " ++ show x
 
--- TODO (Issue #25): make a proper implementation of Arbitrary
-instance (KnownNat d, KnownNat n) => Arbitrary (Plonk d n t) where
+instance (KnownNat d, KnownNat n, Arithmetic (ScalarField c1), Arbitrary (ScalarField c1))
+        => Arbitrary (Plonk d n c1 c2 t) where
     arbitrary = do
         ac <- arbitrary
         let fullInp = length . inputVariables $ ac
@@ -54,95 +60,8 @@ instance (KnownNat d, KnownNat n) => Arbitrary (Plonk d n t) where
         let (omega, k1, k2) = getParams $ ceiling @Double @Natural $ logBase 2 $ fromIntegral (value @d)
         Plonk omega k1 k2 (Vector vecPubInp) ac <$> arbitrary
 
-genSubset :: Natural -> Natural -> Gen [Natural]
-genSubset maxLength maxValue = take maxLength <$> shuffle [1..maxValue]
-
-type PlonkPermutationSize d = 3 * d
-
--- TODO (Issue #25): check that the extended polynomials are of the right size
-type PlonkMaxPolyDegree d = 4 * d + 7
-
-type PlonkPolyExtended d = PolyVec F (PlonkMaxPolyDegree d)
-
-data PlonkSetupParamsProve = PlonkSetupParamsProve {
-        omega' :: F,
-        k1'    :: F,
-        k2'    :: F,
-        gs'    :: V.Vector G1,
-        h0'    :: G2,
-        h1'    :: G2,
-        iPub'  :: V.Vector Natural
-    }
-    deriving (Show)
-
-data PlonkSetupParamsVerify = PlonkSetupParamsVerify {
-        omega :: F,
-        k1    :: F,
-        k2    :: F,
-        g0    :: G1,
-        h0    :: G2,
-        h1    :: G2,
-        pow   :: Integer
-    }
-    deriving (Show)
-
-data PlonkPermutation d = PlonkPermutation {
-        s1 :: PolyVec F d,
-        s2 :: PolyVec F d,
-        s3 :: PolyVec F d
-    }
-    deriving (Show)
-
-data PlonkCircuitPolynomials d = PlonkCircuitPolynomials {
-        ql     :: PlonkPolyExtended d,
-        qr     :: PlonkPolyExtended d,
-        qo     :: PlonkPolyExtended d,
-        qm     :: PlonkPolyExtended d,
-        qc     :: PlonkPolyExtended d,
-        sigma1 :: PlonkPolyExtended d,
-        sigma2 :: PlonkPolyExtended d,
-        sigma3 :: PlonkPolyExtended d
-    }
-    deriving (Show)
-
-data PlonkCircuitCommitments = PlonkCircuitCommitments {
-        cmQl :: G1,
-        cmQr :: G1,
-        cmQo :: G1,
-        cmQm :: G1,
-        cmQc :: G1,
-        cmS1 :: G1,
-        cmS2 :: G1,
-        cmS3 :: G1
-    }
-    deriving (Show)
-
-newtype PlonkWitnessMap d = PlonkWitnessMap (Map.Map Natural F -> (PolyVec F d, PolyVec F d, PolyVec F d))
-
-newtype PlonkWitnessInput = PlonkWitnessInput (Map.Map Natural F)
--- TODO (Issue #25): make a proper implementation of Show
-instance Show PlonkWitnessInput where
-    show (PlonkWitnessInput m) = "Witness Input: " ++ show m
-
-data PlonkProverSecret = PlonkProverSecret F F F F F F F F F F F
-    deriving (Show)
-instance Arbitrary PlonkProverSecret where
-    arbitrary = PlonkProverSecret <$>
-        arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-        <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-
-newtype PlonkInput = PlonkInput (V.Vector F)
-    deriving (Show)
-
-instance Arbitrary PlonkInput where
-    arbitrary = do
-        PlonkInput . fromList <$> arbitrary
-
-data PlonkProof = PlonkProof G1 G1 G1 G1 G1 G1 G1 G1 G1 F F F F F F
-    deriving (Show)
-
-plonkPermutation :: forall d n t .
-    (KnownNat d) => Plonk d n t -> PlonkRelation d n F -> PlonkPermutation d
+plonkPermutation :: forall d n c1 c2 t .
+    (KnownNat d, FiniteField (ScalarField c1)) => Plonk d n c1 c2 t -> PlonkRelation d n (ScalarField c1) -> PlonkPermutation d c1
 plonkPermutation (Plonk omega k1 k2 _ _ _) PlonkRelation {..} = PlonkPermutation {..}
     where
         s = fromPermutation @(PlonkPermutationSize d) sigma
@@ -158,45 +77,56 @@ plonkPermutation (Plonk omega k1 k2 _ _ _) PlonkRelation {..} = PlonkPermutation
         s2 = toPolyVec $ V.take (fromIntegral $ value @d) $ V.drop (fromIntegral $ value @d) s'
         s3 = toPolyVec $ V.take (fromIntegral $ value @d) $ V.drop (fromIntegral $ 2 * value @d) s'
 
-plonkCircuitPolynomials :: forall d n t .
-    (KnownNat d, KnownNat (PlonkMaxPolyDegree d))
-    => Plonk d n t
-    -> PlonkPermutation d
-    -> PlonkRelation d n F
-    -> PlonkCircuitPolynomials d
+plonkCircuitPolynomials :: forall d n c1 c2 t .
+    (KnownNat d, KnownNat (PlonkMaxPolyDegree d), Eq (ScalarField c1), Field (ScalarField c1))
+    => Plonk d n c1 c2 t
+    -> PlonkPermutation d c1
+    -> PlonkRelation d n (ScalarField c1)
+    -> PlonkCircuitPolynomials d c1
 plonkCircuitPolynomials
    (Plonk omega _ _ _ _ _)
    PlonkPermutation {..}
    PlonkRelation {..} = PlonkCircuitPolynomials {..}
     where
-        qm     = polyVecInLagrangeBasis @F @d @(PlonkMaxPolyDegree d) omega qM
-        ql     = polyVecInLagrangeBasis @F @d @(PlonkMaxPolyDegree d) omega qL
-        qr     = polyVecInLagrangeBasis @F @d @(PlonkMaxPolyDegree d) omega qR
-        qo     = polyVecInLagrangeBasis @F @d @(PlonkMaxPolyDegree d) omega qO
-        qc     = polyVecInLagrangeBasis @F @d @(PlonkMaxPolyDegree d) omega qC
-        sigma1 = polyVecInLagrangeBasis @F @d @(PlonkMaxPolyDegree d) omega s1
-        sigma2 = polyVecInLagrangeBasis @F @d @(PlonkMaxPolyDegree d) omega s2
-        sigma3 = polyVecInLagrangeBasis @F @d @(PlonkMaxPolyDegree d) omega s3
+        qm     = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega qM
+        ql     = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega qL
+        qr     = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega qR
+        qo     = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega qO
+        qc     = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega qC
+        sigma1 = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega s1
+        sigma2 = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega s2
+        sigma3 = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega s3
 
-plonkVerifierInput :: Vector n F -> PlonkInput
+plonkVerifierInput :: Field (ScalarField c) => Vector n (ScalarField c) -> PlonkInput c
 plonkVerifierInput input = PlonkInput $ fromList $ map negate $ fromVector input
 
-instance forall d n t .
-        (KnownNat d,
-         KnownNat n,
-         KnownNat (PlonkPermutationSize d),
-         KnownNat (PlonkMaxPolyDegree d),
-         ToTranscript t F,
-         ToTranscript t G1,
-         FromTranscript t F) => NonInteractiveProof (Plonk d n t) where
-    type Transcript (Plonk d n t)  = t
-    type SetupProve (Plonk d n t)  = (PlonkSetupParamsProve, PlonkPermutation d, PlonkCircuitPolynomials d, PlonkWitnessMap d)
-    type SetupVerify (Plonk d n t) = (PlonkSetupParamsVerify, PlonkCircuitCommitments)
-    type Witness (Plonk d n t)     = (PlonkWitnessInput, PlonkProverSecret)
-    type Input (Plonk d n t)       = PlonkInput
-    type Proof (Plonk d n t)       = PlonkProof
+instance forall d n c1 c2 t plonk f g1.
+        ( Plonk d n c1 c2 t ~ plonk
+        , ScalarField c1 ~ f
+        , Point c1 ~ g1
+        , KnownNat d
+        , KnownNat n
+        , KnownNat (PlonkPermutationSize d)
+        , KnownNat (PlonkMaxPolyDegree d)
+        , Eq (ScalarField c1)
+        , Scale (ScalarField c1) (ScalarField c1)
+        , BinaryExpansion (ScalarField c1)
+        , Bits (ScalarField c1) ~ [ScalarField c1]
+        , FiniteField (ScalarField c1)
+        , AdditiveGroup (BaseField c1)
+        , Pairing c1 c2
+        , ToTranscript t (ScalarField c1)
+        , ToTranscript t (Point c1)
+        , FromTranscript t (ScalarField c1)
+        ) => NonInteractiveProof (Plonk d n c1 c2 t) where
+    type Transcript (Plonk d n c1 c2 t)  = t
+    type SetupProve (Plonk d n c1 c2 t)  = (PlonkSetupParamsProve c1 c2, PlonkPermutation d c1, PlonkCircuitPolynomials d c1 , PlonkWitnessMap d c1)
+    type SetupVerify (Plonk d n c1 c2 t) = (PlonkSetupParamsVerify c1 c2, PlonkCircuitCommitments c1)
+    type Witness (Plonk d n c1 c2 t)     = (PlonkWitnessInput c1, PlonkProverSecret c1)
+    type Input (Plonk d n c1 c2 t)       = PlonkInput c1
+    type Proof (Plonk d n c1 c2 t)       = PlonkProof c1
 
-    setupProve :: Plonk d n t -> SetupProve (Plonk d n t)
+    setupProve :: plonk -> SetupProve plonk
     setupProve plonk@(Plonk omega' k1' k2' iPub ac x) =
         (PlonkSetupParamsProve {..}, PlonkPermutation {..}, PlonkCircuitPolynomials {..}, PlonkWitnessMap $ wmap pr)
         where
@@ -207,23 +137,26 @@ instance forall d n t .
             h1'   = x `mul` gen
             iPub' = fromList . fromVector $ iPub
 
-            pr    = fromJust $ toPlonkRelation @d @n @F iPub ac
+            pr    = fromJust $ toPlonkRelation @d @n @f iPub ac
 
             perm@PlonkPermutation {..}   = plonkPermutation plonk pr
             PlonkCircuitPolynomials {..} = plonkCircuitPolynomials plonk perm pr
 
-    setupVerify :: Plonk d n t -> SetupVerify (Plonk d n t)
+    setupVerify :: plonk -> SetupVerify plonk
     setupVerify plonk@(Plonk omega k1 k2 iPub ac x) = (PlonkSetupParamsVerify {..}, PlonkCircuitCommitments {..})
         where
             d = value @d + 6
             xs = fromList $ map (x^) [0..d-!1]
             gs = fmap (`mul` gen) xs
-            g0 = V.head gs
-            h0 = gen
-            h1 = x `mul` gen
-            pow = floor @Double . logBase 2.0 . fromIntegral $ value @d
+            omega'' = omega
+            k1''    = k1
+            k2''    = k2
+            g0''    = gen
+            h0''    = gen
+            h1''    = x `mul` gen
+            pow''   = floor @Double . logBase 2.0 . fromIntegral $ value @d
 
-            pr   = fromJust $ toPlonkRelation @d @n @F iPub ac
+            pr   = fromJust $ toPlonkRelation @d @n @f iPub ac
             perm = plonkPermutation plonk pr
             PlonkCircuitPolynomials {..} = plonkCircuitPolynomials plonk perm pr
 
@@ -236,19 +169,19 @@ instance forall d n t .
             cmS2 = gs `com` sigma2
             cmS3 = gs `com` sigma3
 
-    prove :: SetupProve (Plonk d n t) -> Witness (Plonk d n t) -> (Input (Plonk d n t), Proof (Plonk d n t))
+    prove :: SetupProve plonk -> Witness plonk -> (Input plonk, Proof plonk)
     prove (PlonkSetupParamsProve {..}, PlonkPermutation {..}, PlonkCircuitPolynomials {..}, PlonkWitnessMap wmap)
-          (PlonkWitnessInput wInput, PlonkProverSecret b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11)
-        = (PlonkInput wPub, PlonkProof cmA cmB cmC cmZ cmT1 cmT2 cmT3 proof1 proof2 a_xi b_xi c_xi s1_xi s2_xi z_xi)
+          (PlonkWitnessInput wInput, PlonkProverSecret {..})
+        = (PlonkInput wPub, PlonkProof {..})
         where
             d = value @d
-            zH = polyVecZero @F @d @(PlonkMaxPolyDegree d)
+            zH = polyVecZero @f @d @(PlonkMaxPolyDegree d)
 
             (w1, w2, w3) = wmap wInput
 
             wPub = fmap (negate . (wInput !)) iPub'
 
-            pubPoly = polyVecInLagrangeBasis omega' $ toPolyVec @F @d wPub
+            pubPoly = polyVecInLagrangeBasis omega' $ toPolyVec @f @d wPub
 
             a = polyVecLinear b2 b1 * zH + polyVecInLagrangeBasis omega' w1
             b = polyVecLinear b4 b3 * zH + polyVecInLagrangeBasis omega' w2
@@ -270,11 +203,11 @@ instance forall d n t .
             zs2 = polyVecGrandProduct w2 (scalePV k1' omegas) s2 beta gamma
             zs3 = polyVecGrandProduct w3 (scalePV k2' omegas) s3 beta gamma
             gp = rewrapPolyVec (V.zipWith (*) (V.zipWith (*) (fromPolyVec zs1) (fromPolyVec zs2))) zs3
-            z  = polyVecQuadratic b9 b8 b7 * zH + polyVecInLagrangeBasis @F @d @(PlonkMaxPolyDegree d) omega' gp
+            z  = polyVecQuadratic b9 b8 b7 * zH + polyVecInLagrangeBasis @f @d @(PlonkMaxPolyDegree d) omega' gp
             zo = toPolyVec $ V.zipWith (*) (fromPolyVec z) omegas'
             cmZ = gs' `com` z
 
-            (alpha, ts'') = challenge $ ts' `transcript` cmZ :: (F, Transcript (Plonk d n t))
+            (alpha, ts'') = challenge $ ts' `transcript` cmZ :: (f, Transcript plonk)
 
             t1  = a * b * qm + a * ql + b * qr + c * qo + pubPoly + qc
             t2  = (a + polyVecLinear gamma beta)
@@ -285,14 +218,14 @@ instance forall d n t .
                 * (b + scalePV beta sigma2 + scalePV gamma one)
                 * (c + scalePV beta sigma3 + scalePV gamma one)
                 * zo
-            t4 = (z - one) * polyVecLagrange @F @d @(PlonkMaxPolyDegree d) 1 omega'
+            t4 = (z - one) * polyVecLagrange @f @d @(PlonkMaxPolyDegree d) 1 omega'
             t = (t1 + scalePV alpha (t2 - t3) + scalePV (alpha * alpha) t4) `polyVecDiv` zH
 
             t_lo'  = toPolyVec $ V.take (fromIntegral d) $ fromPolyVec t
             t_mid' = toPolyVec $ V.take (fromIntegral d) $ V.drop (fromIntegral d) $ fromPolyVec t
             t_hi'  = toPolyVec $ V.drop (fromIntegral $ 2*d) $ fromPolyVec t
-            t_lo   = t_lo' + scalePV b10 (polyVecZero @F @d @(PlonkMaxPolyDegree d) + one)
-            t_mid  = t_mid' + scalePV b11 (polyVecZero @F @d @(PlonkMaxPolyDegree d) + one) - scalePV b10 one
+            t_lo   = t_lo' + scalePV b10 (polyVecZero @f @d @(PlonkMaxPolyDegree d) + one)
+            t_mid  = t_mid' + scalePV b11 (polyVecZero @f @d @(PlonkMaxPolyDegree d) + one) - scalePV b10 one
             t_hi   = t_hi' - scalePV b11 one
             cmT1   = gs' `com` t_lo
             cmT2   = gs' `com` t_mid
@@ -318,7 +251,7 @@ instance forall d n t .
                 `transcript` s2_xi
                 `transcript` z_xi
 
-            lagrange1_xi = polyVecLagrange @F @d @(PlonkMaxPolyDegree d) 1 omega' `evalPolyVec` xi
+            lagrange1_xi = polyVecLagrange @f @d @(PlonkMaxPolyDegree d) 1 omega' `evalPolyVec` xi
             zH_xi = zH `evalPolyVec` xi
             r   = scalePV (a_xi * b_xi) qm
                 + scalePV a_xi ql
@@ -354,7 +287,7 @@ instance forall d n t .
             proof1 = gs' `com` proof1Poly
             proof2 = gs' `com` proof2Poly
 
-    verify :: SetupVerify (Plonk d n t) -> Input (Plonk d n t) -> Proof (Plonk d n t) -> Bool
+    verify :: SetupVerify plonk -> Input plonk -> Proof plonk -> Bool
     verify
         (PlonkSetupParamsVerify {..}, PlonkCircuitCommitments {..})
         (PlonkInput wPub)
@@ -365,7 +298,7 @@ instance forall d n t .
             (beta, ts) = challenge $ mempty
                 `transcript` cmA
                 `transcript` cmB
-                `transcript` cmC :: (F, Transcript (Plonk d n t))
+                `transcript` cmC :: (f, Transcript plonk)
             (gamma, ts') = challenge ts
 
             (alpha, ts'') = challenge $ ts' `transcript` cmZ
@@ -387,9 +320,9 @@ instance forall d n t .
                 `transcript` proof1
                 `transcript` proof2
 
-            zH_xi        = polyVecZero @F @d @(PlonkMaxPolyDegree d) `evalPolyVec` xi
-            lagrange1_xi = polyVecLagrange @F @d @(PlonkMaxPolyDegree d) 1 omega `evalPolyVec` xi
-            pubPoly_xi   = polyVecInLagrangeBasis @F @d @(PlonkMaxPolyDegree d) omega (toPolyVec wPub) `evalPolyVec` xi
+            zH_xi        = polyVecZero @f @d @(PlonkMaxPolyDegree d) `evalPolyVec` xi
+            lagrange1_xi = polyVecLagrange @f @d @(PlonkMaxPolyDegree d) 1 omega'' `evalPolyVec` xi
+            pubPoly_xi   = polyVecInLagrangeBasis @f @d @(PlonkMaxPolyDegree d) omega'' (toPolyVec wPub) `evalPolyVec` xi
 
             r0 =
                   pubPoly_xi
@@ -408,8 +341,8 @@ instance forall d n t .
                 + mul (
                           alpha
                         * (a_xi + beta * xi + gamma)
-                        * (b_xi + beta * k1 * xi + gamma)
-                        * (c_xi + beta * k2 * xi + gamma)
+                        * (b_xi + beta * k1'' * xi + gamma)
+                        * (c_xi + beta * k2'' * xi + gamma)
                     +     alpha * alpha * lagrange1_xi
                     +     u
                     ) cmZ
@@ -429,14 +362,14 @@ instance forall d n t .
                 + (v * v * v * v) `mul` cmS1
                 + (v * v * v * v * v) `mul` cmS2
             e  = (
-                - r0
+                negate r0
                 + v * a_xi
                 + v * v * b_xi
                 + v * v * v * c_xi
                 + v * v * v * v * s1_xi
                 + v * v * v * v * v * s2_xi
                 + u * z_xi
-                ) `mul` g0
+                ) `mul` g0''
 
-            p1 = pairing (xi `mul` proof1 + (u * xi * omega) `mul` proof2 + f - e) h0
-            p2 = pairing (proof1 + u `mul` proof2) h1
+            p1 = pairing @c1 @c2 (xi `mul` proof1 + (u * xi * omega'') `mul` proof2 + f - e) h0''
+            p2 = pairing (proof1 + u `mul` proof2) h1''

--- a/src/ZkFold/Base/Protocol/ARK/Plonk.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Plonk.hs
@@ -38,76 +38,73 @@ import           ZkFold.Symbolic.Compiler                            (Arithmetic
     Additionally, we don't want this library to depend on Cardano libraries.
 -}
 
--- TODO: disallow `d` that are not powers of 2
-data Plonk (d :: Natural) (n :: Natural) curve1 curve2 t = Plonk {
+data Plonk (n :: Natural) (l :: Natural) curve1 curve2 transcript = Plonk {
         omega :: ScalarField curve1,
         k1    :: ScalarField curve1,
         k2    :: ScalarField curve1,
-        iPub  :: Vector n Natural,
+        iPub  :: Vector l Natural,
         ac    :: ArithmeticCircuit 1 (ScalarField curve1),
         x     :: ScalarField curve1
     }
-instance (Show (ScalarField c1), Arithmetic (ScalarField c1)) => Show (Plonk d n c1 c2 t) where
+instance (Show (ScalarField c1), Arithmetic (ScalarField c1)) => Show (Plonk n l c1 c2 t) where
     show (Plonk omega k1 k2 iPub ac x) =
         "Plonk: " ++ show omega ++ " " ++ show k1 ++ " " ++ show k2 ++ " " ++ show iPub ++ " " ++ show ac ++ " " ++ show x
 
-instance (KnownNat d, KnownNat n, Arithmetic (ScalarField c1), Arbitrary (ScalarField c1))
-        => Arbitrary (Plonk d n c1 c2 t) where
+instance (KnownNat n, KnownNat l, Arithmetic (ScalarField c1), Arbitrary (ScalarField c1))
+        => Arbitrary (Plonk n l c1 c2 t) where
     arbitrary = do
         ac <- arbitrary
         let fullInp = length . inputVariables $ ac
-        vecPubInp <- genSubset (value @n) fullInp
-        let (omega, k1, k2) = getParams $ ceiling @Double @Natural $ logBase 2 $ fromIntegral (value @d)
+        vecPubInp <- genSubset (value @l) fullInp
+        let (omega, k1, k2) = getParams (value @n)
         Plonk omega k1 k2 (Vector vecPubInp) ac <$> arbitrary
 
-plonkPermutation :: forall d n c1 c2 t .
-    (KnownNat d, FiniteField (ScalarField c1)) => Plonk d n c1 c2 t -> PlonkRelation d n (ScalarField c1) -> PlonkPermutation d c1
+plonkPermutation :: forall n l c1 c2 t .
+    (KnownNat n, FiniteField (ScalarField c1)) => Plonk n l c1 c2 t -> PlonkRelation n l (ScalarField c1) -> PlonkPermutation n c1
 plonkPermutation (Plonk omega k1 k2 _ _ _) PlonkRelation {..} = PlonkPermutation {..}
     where
-        s = fromPermutation @(PlonkPermutationSize d) sigma
-
-        f i = case (i-!1) `div` value @d of
+        f i = case (i-!1) `div` value @n of
             0 -> omega^i
             1 -> k1 * (omega^i)
             2 -> k2 * (omega^i)
             _ -> error "setup: invalid index"
 
-        s' = fromList $ map f s
-        s1 = toPolyVec $ V.take (fromIntegral $ value @d) s'
-        s2 = toPolyVec $ V.take (fromIntegral $ value @d) $ V.drop (fromIntegral $ value @d) s'
-        s3 = toPolyVec $ V.take (fromIntegral $ value @d) $ V.drop (fromIntegral $ 2 * value @d) s'
+        s = fromList $ map f $ fromPermutation @(PlonkPermutationSize n) sigma
+        s1 = toPolyVec $ V.take (fromIntegral $ value @n) s
+        s2 = toPolyVec $ V.take (fromIntegral $ value @n) $ V.drop (fromIntegral $ value @n) s
+        s3 = toPolyVec $ V.take (fromIntegral $ value @n) $ V.drop (fromIntegral $ 2 * value @n) s
 
-plonkCircuitPolynomials :: forall d n c1 c2 t .
-    (KnownNat d, KnownNat (PlonkMaxPolyDegree d), Eq (ScalarField c1), Field (ScalarField c1))
-    => Plonk d n c1 c2 t
-    -> PlonkPermutation d c1
-    -> PlonkRelation d n (ScalarField c1)
-    -> PlonkCircuitPolynomials d c1
+plonkCircuitPolynomials :: forall n l c1 c2 t .
+    (KnownNat n, KnownNat (PlonkPolyExtendedLength n), Eq (ScalarField c1), Field (ScalarField c1))
+    => Plonk n l c1 c2 t
+    -> PlonkPermutation n c1
+    -> PlonkRelation n l (ScalarField c1)
+    -> PlonkCircuitPolynomials n c1
 plonkCircuitPolynomials
    (Plonk omega _ _ _ _ _)
    PlonkPermutation {..}
    PlonkRelation {..} = PlonkCircuitPolynomials {..}
     where
-        qm     = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega qM
-        ql     = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega qL
-        qr     = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega qR
-        qo     = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega qO
-        qc     = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega qC
-        sigma1 = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega s1
-        sigma2 = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega s2
-        sigma3 = polyVecInLagrangeBasis @(ScalarField c1) @d @(PlonkMaxPolyDegree d) omega s3
+        qm     = polyVecInLagrangeBasis @(ScalarField c1) @n @(PlonkPolyExtendedLength n) omega qM
+        ql     = polyVecInLagrangeBasis @(ScalarField c1) @n @(PlonkPolyExtendedLength n) omega qL
+        qr     = polyVecInLagrangeBasis @(ScalarField c1) @n @(PlonkPolyExtendedLength n) omega qR
+        qo     = polyVecInLagrangeBasis @(ScalarField c1) @n @(PlonkPolyExtendedLength n) omega qO
+        qc     = polyVecInLagrangeBasis @(ScalarField c1) @n @(PlonkPolyExtendedLength n) omega qC
+        sigma1 = polyVecInLagrangeBasis @(ScalarField c1) @n @(PlonkPolyExtendedLength n) omega s1
+        sigma2 = polyVecInLagrangeBasis @(ScalarField c1) @n @(PlonkPolyExtendedLength n) omega s2
+        sigma3 = polyVecInLagrangeBasis @(ScalarField c1) @n @(PlonkPolyExtendedLength n) omega s3
 
 plonkVerifierInput :: Field (ScalarField c) => Vector n (ScalarField c) -> PlonkInput c
 plonkVerifierInput input = PlonkInput $ fromList $ map negate $ fromVector input
 
-instance forall d n c1 c2 t plonk f g1.
-        ( Plonk d n c1 c2 t ~ plonk
+instance forall n l c1 c2 t plonk f g1.
+        ( Plonk n l c1 c2 t ~ plonk
         , ScalarField c1 ~ f
         , Point c1 ~ g1
-        , KnownNat d
         , KnownNat n
-        , KnownNat (PlonkPermutationSize d)
-        , KnownNat (PlonkMaxPolyDegree d)
+        , KnownNat l
+        , KnownNat (PlonkPermutationSize n)
+        , KnownNat (PlonkPolyExtendedLength n)
         , Eq (ScalarField c1)
         , Scale (ScalarField c1) (ScalarField c1)
         , BinaryExpansion (ScalarField c1)
@@ -118,26 +115,26 @@ instance forall d n c1 c2 t plonk f g1.
         , ToTranscript t (ScalarField c1)
         , ToTranscript t (Point c1)
         , FromTranscript t (ScalarField c1)
-        ) => NonInteractiveProof (Plonk d n c1 c2 t) where
-    type Transcript (Plonk d n c1 c2 t)  = t
-    type SetupProve (Plonk d n c1 c2 t)  = (PlonkSetupParamsProve c1 c2, PlonkPermutation d c1, PlonkCircuitPolynomials d c1 , PlonkWitnessMap d c1)
-    type SetupVerify (Plonk d n c1 c2 t) = (PlonkSetupParamsVerify c1 c2, PlonkCircuitCommitments c1)
-    type Witness (Plonk d n c1 c2 t)     = (PlonkWitnessInput c1, PlonkProverSecret c1)
-    type Input (Plonk d n c1 c2 t)       = PlonkInput c1
-    type Proof (Plonk d n c1 c2 t)       = PlonkProof c1
+        ) => NonInteractiveProof (Plonk n l c1 c2 t) where
+    type Transcript (Plonk n l c1 c2 t)  = t
+    type SetupProve (Plonk n l c1 c2 t)  = (PlonkSetupParamsProve c1 c2, PlonkPermutation n c1, PlonkCircuitPolynomials n c1 , PlonkWitnessMap n c1)
+    type SetupVerify (Plonk n l c1 c2 t) = (PlonkSetupParamsVerify c1 c2, PlonkCircuitCommitments c1)
+    type Witness (Plonk n l c1 c2 t)     = (PlonkWitnessInput c1, PlonkProverSecret c1)
+    type Input (Plonk n l c1 c2 t)       = PlonkInput c1
+    type Proof (Plonk n l c1 c2 t)       = PlonkProof c1
 
     setupProve :: plonk -> SetupProve plonk
     setupProve plonk@(Plonk omega' k1' k2' iPub ac x) =
         (PlonkSetupParamsProve {..}, PlonkPermutation {..}, PlonkCircuitPolynomials {..}, PlonkWitnessMap $ wmap pr)
         where
-            d     = value @d + 6
+            d     = value @n + 6
             xs    = fromList $ map (x^) [0..d-!1]
             gs'   = fmap (`mul` gen) xs
             h0'   = gen
             h1'   = x `mul` gen
             iPub' = fromList . fromVector $ iPub
 
-            pr    = fromJust $ toPlonkRelation @d @n @f iPub ac
+            pr    = fromJust $ toPlonkRelation @n @l @f iPub ac
 
             perm@PlonkPermutation {..}   = plonkPermutation plonk pr
             PlonkCircuitPolynomials {..} = plonkCircuitPolynomials plonk perm pr
@@ -145,7 +142,7 @@ instance forall d n c1 c2 t plonk f g1.
     setupVerify :: plonk -> SetupVerify plonk
     setupVerify plonk@(Plonk omega k1 k2 iPub ac x) = (PlonkSetupParamsVerify {..}, PlonkCircuitCommitments {..})
         where
-            d = value @d + 6
+            d = value @n + 6
             xs = fromList $ map (x^) [0..d-!1]
             gs = fmap (`mul` gen) xs
             omega'' = omega
@@ -154,9 +151,9 @@ instance forall d n c1 c2 t plonk f g1.
             g0''    = gen
             h0''    = gen
             h1''    = x `mul` gen
-            pow''   = floor @Double . logBase 2.0 . fromIntegral $ value @d
+            pow''   = floor @Double . logBase 2.0 . fromIntegral $ value @n
 
-            pr   = fromJust $ toPlonkRelation @d @n @f iPub ac
+            pr   = fromJust $ toPlonkRelation @n @l @f iPub ac
             perm = plonkPermutation plonk pr
             PlonkCircuitPolynomials {..} = plonkCircuitPolynomials plonk perm pr
 
@@ -174,14 +171,14 @@ instance forall d n c1 c2 t plonk f g1.
           (PlonkWitnessInput wInput, PlonkProverSecret {..})
         = (PlonkInput wPub, PlonkProof {..})
         where
-            d = value @d
-            zH = polyVecZero @f @d @(PlonkMaxPolyDegree d)
+            n = value @n
+            zH = polyVecZero @f @n @(PlonkPolyExtendedLength n)
 
             (w1, w2, w3) = wmap wInput
 
             wPub = fmap (negate . (wInput !)) iPub'
 
-            pubPoly = polyVecInLagrangeBasis omega' $ toPolyVec @f @d wPub
+            pubPoly = polyVecInLagrangeBasis omega' $ toPolyVec @f @n wPub
 
             a = polyVecLinear b2 b1 * zH + polyVecInLagrangeBasis omega' w1
             b = polyVecLinear b4 b3 * zH + polyVecInLagrangeBasis omega' w2
@@ -197,13 +194,13 @@ instance forall d n c1 c2 t plonk f g1.
                 `transcript` cmC
             (gamma, ts') = challenge ts
 
-            omegas  = toPolyVec $ V.iterateN (fromIntegral d) (* omega') omega'
+            omegas  = toPolyVec $ V.iterateN (fromIntegral n) (* omega') omega'
             omegas' =  V.iterateN (V.length (fromPolyVec z) P.+ 1) (* omega') one
             zs1 = polyVecGrandProduct w1 omegas s1 beta gamma
             zs2 = polyVecGrandProduct w2 (scalePV k1' omegas) s2 beta gamma
             zs3 = polyVecGrandProduct w3 (scalePV k2' omegas) s3 beta gamma
             gp = rewrapPolyVec (V.zipWith (*) (V.zipWith (*) (fromPolyVec zs1) (fromPolyVec zs2))) zs3
-            z  = polyVecQuadratic b9 b8 b7 * zH + polyVecInLagrangeBasis @f @d @(PlonkMaxPolyDegree d) omega' gp
+            z  = polyVecQuadratic b9 b8 b7 * zH + polyVecInLagrangeBasis @f @n @(PlonkPolyExtendedLength n) omega' gp
             zo = toPolyVec $ V.zipWith (*) (fromPolyVec z) omegas'
             cmZ = gs' `com` z
 
@@ -218,14 +215,14 @@ instance forall d n c1 c2 t plonk f g1.
                 * (b + scalePV beta sigma2 + scalePV gamma one)
                 * (c + scalePV beta sigma3 + scalePV gamma one)
                 * zo
-            t4 = (z - one) * polyVecLagrange @f @d @(PlonkMaxPolyDegree d) 1 omega'
+            t4 = (z - one) * polyVecLagrange @f @n @(PlonkPolyExtendedLength n) 1 omega'
             t = (t1 + scalePV alpha (t2 - t3) + scalePV (alpha * alpha) t4) `polyVecDiv` zH
 
-            t_lo'  = toPolyVec $ V.take (fromIntegral d) $ fromPolyVec t
-            t_mid' = toPolyVec $ V.take (fromIntegral d) $ V.drop (fromIntegral d) $ fromPolyVec t
-            t_hi'  = toPolyVec $ V.drop (fromIntegral $ 2*d) $ fromPolyVec t
-            t_lo   = t_lo' + scalePV b10 (polyVecZero @f @d @(PlonkMaxPolyDegree d) + one)
-            t_mid  = t_mid' + scalePV b11 (polyVecZero @f @d @(PlonkMaxPolyDegree d) + one) - scalePV b10 one
+            t_lo'  = toPolyVec $ V.take (fromIntegral n) $ fromPolyVec t
+            t_mid' = toPolyVec $ V.take (fromIntegral n) $ V.drop (fromIntegral n) $ fromPolyVec t
+            t_hi'  = toPolyVec $ V.drop (fromIntegral $ 2*n) $ fromPolyVec t
+            t_lo   = t_lo' + scalePV b10 (polyVecZero @f @n @(PlonkPolyExtendedLength n) + one)
+            t_mid  = t_mid' + scalePV b11 (polyVecZero @f @n @(PlonkPolyExtendedLength n) + one) - scalePV b10 one
             t_hi   = t_hi' - scalePV b11 one
             cmT1   = gs' `com` t_lo
             cmT2   = gs' `com` t_mid
@@ -251,7 +248,7 @@ instance forall d n c1 c2 t plonk f g1.
                 `transcript` s2_xi
                 `transcript` z_xi
 
-            lagrange1_xi = polyVecLagrange @f @d @(PlonkMaxPolyDegree d) 1 omega' `evalPolyVec` xi
+            lagrange1_xi = polyVecLagrange @f @n @(PlonkPolyExtendedLength n) 1 omega' `evalPolyVec` xi
             zH_xi = zH `evalPolyVec` xi
             r   = scalePV (a_xi * b_xi) qm
                 + scalePV a_xi ql
@@ -272,7 +269,7 @@ instance forall d n c1 c2 t plonk f g1.
                         ) (scalePV beta sigma3 + scalePV (c_xi + gamma) one)
                     )
                 + scalePV (alpha * alpha * lagrange1_xi) (z - one)
-                - scalePV zH_xi (scalePV (xi^(2 * d)) t_hi + scalePV (xi^d) t_mid + t_lo)
+                - scalePV zH_xi (scalePV (xi^(2 * n)) t_hi + scalePV (xi^n) t_mid + t_lo)
 
             proof1Poly = (r
                     + scalePV v (a - scalePV a_xi one)
@@ -293,7 +290,7 @@ instance forall d n c1 c2 t plonk f g1.
         (PlonkInput wPub)
         (PlonkProof cmA cmB cmC cmZ cmT1 cmT2 cmT3 proof1 proof2 a_xi b_xi c_xi s1_xi s2_xi z_xi) = p1 == p2
         where
-            n = value @d
+            n = value @n
 
             (beta, ts) = challenge $ mempty
                 `transcript` cmA
@@ -320,9 +317,9 @@ instance forall d n c1 c2 t plonk f g1.
                 `transcript` proof1
                 `transcript` proof2
 
-            zH_xi        = polyVecZero @f @d @(PlonkMaxPolyDegree d) `evalPolyVec` xi
-            lagrange1_xi = polyVecLagrange @f @d @(PlonkMaxPolyDegree d) 1 omega'' `evalPolyVec` xi
-            pubPoly_xi   = polyVecInLagrangeBasis @f @d @(PlonkMaxPolyDegree d) omega'' (toPolyVec wPub) `evalPolyVec` xi
+            zH_xi        = polyVecZero @f @n @(PlonkPolyExtendedLength n) `evalPolyVec` xi
+            lagrange1_xi = polyVecLagrange @f @n @(PlonkPolyExtendedLength n) 1 omega'' `evalPolyVec` xi
+            pubPoly_xi   = polyVecInLagrangeBasis @f @n @(PlonkPolyExtendedLength n) omega'' (toPolyVec wPub) `evalPolyVec` xi
 
             r0 =
                   pubPoly_xi

--- a/src/ZkFold/Base/Protocol/ARK/Plonk.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Plonk.hs
@@ -11,27 +11,27 @@ module ZkFold.Base.Protocol.ARK.Plonk (
     plonkVerifierInput
 ) where
 
-import           Data.Maybe                                          (fromJust)
-import qualified Data.Vector                                         as V
-import           GHC.IsList                                          (IsList (..))
-import           Numeric.Natural                                     (Natural)
-import           Prelude                                             hiding (Num (..), div, drop, length, replicate,
-                                                                      sum, take, (!!), (/), (^))
-import qualified Prelude                                             as P hiding (length)
-import           Test.QuickCheck                                     (Arbitrary (..))
+import           Data.Maybe                                 (fromJust)
+import qualified Data.Vector                                as V
+import           GHC.IsList                                 (IsList (..))
+import           Numeric.Natural                            (Natural)
+import           Prelude                                    hiding (Num (..), div, drop, length, replicate, sum, take,
+                                                             (!!), (/), (^))
+import qualified Prelude                                    as P hiding (length)
+import           Test.QuickCheck                            (Arbitrary (..))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Number
-import           ZkFold.Base.Algebra.Basic.Permutations              (fromPermutation)
-import           ZkFold.Base.Algebra.EllipticCurve.Class             (EllipticCurve (..), Pairing (..), Point)
-import           ZkFold.Base.Algebra.Polynomials.Univariate          hiding (qr)
-import           ZkFold.Base.Data.Vector                             (Vector (..), fromVector)
+import           ZkFold.Base.Algebra.Basic.Permutations     (fromPermutation)
+import           ZkFold.Base.Algebra.EllipticCurve.Class    (EllipticCurve (..), Pairing (..), Point)
+import           ZkFold.Base.Algebra.Polynomials.Univariate hiding (qr)
+import           ZkFold.Base.Data.Vector                    (Vector (..), fromVector)
 import           ZkFold.Base.Protocol.ARK.Plonk.Internal
-import           ZkFold.Base.Protocol.ARK.Plonk.Relation             (PlonkRelation (..), toPlonkRelation)
-import           ZkFold.Base.Protocol.Commitment.KZG                 (com)
+import           ZkFold.Base.Protocol.ARK.Plonk.Relation    (PlonkRelation (..), toPlonkRelation)
+import           ZkFold.Base.Protocol.Commitment.KZG        (com)
 import           ZkFold.Base.Protocol.NonInteractiveProof
-import           ZkFold.Prelude                                      (length, (!))
-import           ZkFold.Symbolic.Compiler                            (Arithmetic, ArithmeticCircuit, inputVariables)
+import           ZkFold.Prelude                             (length, (!))
+import           ZkFold.Symbolic.Compiler                   (Arithmetic, ArithmeticCircuit, inputVariables)
 
 {-
     NOTE: we need to parametrize the type of transcripts because we use BuiltinByteString on-chain and ByteString off-chain.

--- a/src/ZkFold/Base/Protocol/ARK/Plonk.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Plonk.hs
@@ -151,7 +151,7 @@ instance forall n l c1 c2 t plonk f g1.
             g0''    = gen
             h0''    = gen
             h1''    = x `mul` gen
-            pow''   = floor @Double . logBase 2.0 . fromIntegral $ value @n
+            pow''   = log2 $ value @n
 
             pr   = fromJust $ toPlonkRelation @n @l @f iPub ac
             perm = plonkPermutation plonk pr

--- a/src/ZkFold/Base/Protocol/ARK/Plonk/Internal.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Plonk/Internal.hs
@@ -19,11 +19,13 @@ import           ZkFold.Base.Algebra.EllipticCurve.Class    (EllipticCurve (..),
 import           ZkFold.Base.Algebra.Polynomials.Univariate hiding (qr)
 import           ZkFold.Prelude                             (take)
 
+log2 :: (Integral a, Integral b) => a -> b
+log2 = ceiling @Double . logBase 2 . fromIntegral
+
 getParams :: forall a . (Eq a, FiniteField a) => Natural -> (a, a, a)
 getParams n = findK' $ mkStdGen 0
     where
-        q = ceiling @Double @Natural $ logBase 2 $ fromIntegral n
-        omega = case rootOfUnity @a q of
+        omega = case rootOfUnity @a (log2 n) of
                   Just o -> o
                   _      -> error "impossible"
         hGroup = map (omega^) [0 .. n-!1]

--- a/src/ZkFold/Base/Protocol/ARK/Plonk/Internal.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Plonk/Internal.hs
@@ -1,12 +1,25 @@
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module ZkFold.Base.Protocol.ARK.Plonk.Internal where
 
-import           Data.Bifunctor                  (first)
-import           Data.Bool                       (bool)
-import           Numeric.Natural                 (Natural)
-import           Prelude                         hiding (Num (..), drop, length, sum, take, (!!), (/), (^))
-import           System.Random                   (RandomGen, mkStdGen, uniformR)
+import           Data.Bifunctor                             (first)
+import           Data.Bool                                  (bool)
+import qualified Data.Map                                   as Map
+import qualified Data.Vector                                as V
+import           GHC.IsList                                 (IsList (..))
+import           Numeric.Natural                            (Natural)
+import           Prelude                                    hiding (Num (..), drop, length, sum, take, (!!), (/), (^))
+import           System.Random                              (RandomGen, mkStdGen, uniformR)
+import           Test.QuickCheck                            (Arbitrary (..), Gen, shuffle)
 
 import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Base.Algebra.Basic.Number
+
+
+import           ZkFold.Base.Algebra.EllipticCurve.Class    (EllipticCurve (..), Point)
+import           ZkFold.Base.Algebra.Polynomials.Univariate hiding (qr)
+import           ZkFold.Prelude                             (take)
 
 getParams :: forall a . (Eq a, FiniteField a) => Natural -> (a, a, a)
 getParams l = findK' $ mkStdGen 0
@@ -24,3 +37,192 @@ getParams l = findK' $ mkStdGen 0
             in bool (findK' g'') (omega, k1, k2) $
                 all (`notElem` hGroup) (hGroup' k1)
                 && all (`notElem` hGroup' k1) (hGroup' k2)
+
+genSubset :: Natural -> Natural -> Gen [Natural]
+genSubset maxLength maxValue = take maxLength <$> shuffle [1..maxValue]
+
+type PlonkPermutationSize d = 3 * d
+
+-- TODO (Issue #25): check that the extended polynomials are of the right size
+type PlonkMaxPolyDegree d = 4 * d + 7
+
+type PlonkPolyExtended d c = PolyVec (ScalarField c) (PlonkMaxPolyDegree d)
+
+data PlonkSetupParamsProve c1 c2 = PlonkSetupParamsProve {
+        omega'  :: ScalarField c1,
+        k1'     :: ScalarField c1,
+        k2'     :: ScalarField c1,
+        gs'     :: V.Vector (Point c1),
+        h0'     :: Point c2,
+        h1'     :: Point c2,
+        iPub'   :: V.Vector Natural
+    }
+instance (Show (ScalarField c1), Show (BaseField c1), Show (BaseField c2),
+        EllipticCurve c1, EllipticCurve c2) => Show (PlonkSetupParamsProve c1 c2) where
+    show (PlonkSetupParamsProve omega' k1' k2' gs' h0' h1' iPub') =
+        "Setup Parameters (Prove): "
+        ++ show omega' ++ " "
+        ++ show k1' ++ " "
+        ++ show k2' ++ " "
+        ++ show gs' ++ " "
+        ++ show h0' ++ " "
+        ++ show h1' ++ " "
+        ++ show iPub'
+
+data PlonkSetupParamsVerify c1 c2 = PlonkSetupParamsVerify {
+        omega'' :: ScalarField c1,
+        k1''    :: ScalarField c1,
+        k2''    :: ScalarField c1,
+        g0''    :: Point c1,
+        h0''    :: Point c2,
+        h1''    :: Point c2,
+        pow''   :: Integer
+    }
+instance (Show (ScalarField c1), Show (BaseField c1), Show (BaseField c2),
+        EllipticCurve c1, EllipticCurve c2) => Show (PlonkSetupParamsVerify c1 c2) where
+    show (PlonkSetupParamsVerify omega'' k1'' k2'' g0'' h0'' h1'' pow'') =
+        "Setup Parameters (Verify): "
+        ++ show omega'' ++ " "
+        ++ show k1'' ++ " "
+        ++ show k2'' ++ " "
+        ++ show g0'' ++ " "
+        ++ show h0'' ++ " "
+        ++ show h1'' ++ " "
+        ++ show pow''
+
+data PlonkPermutation d c = PlonkPermutation {
+        s1 :: PolyVec (ScalarField c) d,
+        s2 :: PolyVec (ScalarField c) d,
+        s3 :: PolyVec (ScalarField c) d
+    }
+instance Show (ScalarField c) => Show (PlonkPermutation d c) where
+    show (PlonkPermutation s1 s2 s3) = "Permutation: " ++ show s1 ++ " " ++ show s2 ++ " " ++ show s3
+
+data PlonkCircuitPolynomials d c = PlonkCircuitPolynomials {
+        ql     :: PlonkPolyExtended d c,
+        qr     :: PlonkPolyExtended d c,
+        qo     :: PlonkPolyExtended d c,
+        qm     :: PlonkPolyExtended d c,
+        qc     :: PlonkPolyExtended d c,
+        sigma1 :: PlonkPolyExtended d c,
+        sigma2 :: PlonkPolyExtended d c,
+        sigma3 :: PlonkPolyExtended d c
+    }
+instance Show (ScalarField c) => Show (PlonkCircuitPolynomials d c) where
+    show (PlonkCircuitPolynomials ql qr qo qm qc sigma1 sigma2 sigma3) =
+        "Circuit Polynomials: "
+        ++ show ql ++ " "
+        ++ show qr ++ " "
+        ++ show qo ++ " "
+        ++ show qm ++ " "
+        ++ show qc ++ " "
+        ++ show sigma1 ++ " "
+        ++ show sigma2 ++ " "
+        ++ show sigma3
+
+data PlonkCircuitCommitments c = PlonkCircuitCommitments {
+        cmQl :: Point c,
+        cmQr :: Point c,
+        cmQo :: Point c,
+        cmQm :: Point c,
+        cmQc :: Point c,
+        cmS1 :: Point c,
+        cmS2 :: Point c,
+        cmS3 :: Point c
+    }
+instance (Show (BaseField c), EllipticCurve c) => Show (PlonkCircuitCommitments c) where
+    show (PlonkCircuitCommitments cmQl cmQr cmQo cmQm cmQc cmS1 cmS2 cmS3) =
+        "Circuit Commitments: "
+        ++ show cmQl ++ " "
+        ++ show cmQr ++ " "
+        ++ show cmQo ++ " "
+        ++ show cmQm ++ " "
+        ++ show cmQc ++ " "
+        ++ show cmS1 ++ " "
+        ++ show cmS2 ++ " "
+        ++ show cmS3
+
+newtype PlonkWitnessMap d c = PlonkWitnessMap
+    (Map.Map Natural (ScalarField c) -> (PolyVec (ScalarField c) d, PolyVec (ScalarField c) d, PolyVec (ScalarField c) d))
+
+newtype PlonkWitnessInput c = PlonkWitnessInput (Map.Map Natural (ScalarField c))
+instance Show (ScalarField c) => Show (PlonkWitnessInput c) where
+    show (PlonkWitnessInput m) = "Witness Input: " ++ show m
+
+data PlonkProverSecret c = PlonkProverSecret {
+        b1  :: ScalarField c,
+        b2  :: ScalarField c,
+        b3  :: ScalarField c,
+        b4  :: ScalarField c,
+        b5  :: ScalarField c,
+        b6  :: ScalarField c,
+        b7  :: ScalarField c,
+        b8  :: ScalarField c,
+        b9  :: ScalarField c,
+        b10 :: ScalarField c,
+        b11 :: ScalarField c
+    }
+instance Show (ScalarField c) => Show (PlonkProverSecret c) where
+    show (PlonkProverSecret b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11) =
+        "Prover Secret: "
+        ++ show b1 ++ " "
+        ++ show b2 ++ " "
+        ++ show b3 ++ " "
+        ++ show b4 ++ " "
+        ++ show b5 ++ " "
+        ++ show b6 ++ " "
+        ++ show b7 ++ " "
+        ++ show b8 ++ " "
+        ++ show b9 ++ " "
+        ++ show b10 ++ " "
+        ++ show b11
+
+instance Arbitrary (ScalarField c) => Arbitrary (PlonkProverSecret c) where
+    arbitrary = PlonkProverSecret <$>
+        arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+        <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
+newtype PlonkInput c = PlonkInput (V.Vector (ScalarField c))
+instance Show (ScalarField c) => Show (PlonkInput c) where
+    show (PlonkInput v) = "Input: " ++ show v
+
+instance Arbitrary (ScalarField c) => Arbitrary (PlonkInput c) where
+    arbitrary = do
+        PlonkInput . fromList <$> arbitrary
+
+data PlonkProof c = PlonkProof {
+        cmA    :: Point c,
+        cmB    :: Point c,
+        cmC    :: Point c,
+        cmZ    :: Point c,
+        cmT1   :: Point c,
+        cmT2   :: Point c,
+        cmT3   :: Point c,
+        proof1 :: Point c,
+        proof2 :: Point c,
+        a_xi   :: ScalarField c,
+        b_xi   :: ScalarField c,
+        c_xi   :: ScalarField c,
+        s1_xi  :: ScalarField c,
+        s2_xi  :: ScalarField c,
+        z_xi   :: ScalarField c
+    }
+instance (Show (ScalarField c), Show (BaseField c), EllipticCurve c) => Show (PlonkProof c) where
+    show (PlonkProof cmA cmB cmC cmZ cmT1 cmT2 cmT3 proof1 proof2 a_xi b_xi c_xi s1_xi s2_xi z_xi) =
+        "Proof: "
+        ++ show cmA ++ " "
+        ++ show cmB ++ " "
+        ++ show cmC ++ " "
+        ++ show cmZ ++ " "
+        ++ show cmT1 ++ " "
+        ++ show cmT2 ++ " "
+        ++ show cmT3 ++ " "
+        ++ show proof1 ++ " "
+        ++ show proof2 ++ " "
+        ++ show a_xi ++ " "
+        ++ show b_xi ++ " "
+        ++ show c_xi ++ " "
+        ++ show s1_xi ++ " "
+        ++ show s2_xi ++ " "
+        ++ show z_xi
+

--- a/src/ZkFold/Base/Protocol/ARK/Plonk/Internal.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Plonk/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module ZkFold.Base.Protocol.ARK.Plonk.Internal where
@@ -15,8 +15,6 @@ import           Test.QuickCheck                            (Arbitrary (..), Gen
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Number
-
-
 import           ZkFold.Base.Algebra.EllipticCurve.Class    (EllipticCurve (..), Point)
 import           ZkFold.Base.Algebra.Polynomials.Univariate hiding (qr)
 import           ZkFold.Prelude                             (take)
@@ -50,13 +48,13 @@ type PlonkPolyExtendedLength n = 4 * n + 6
 type PlonkPolyExtended n c = PolyVec (ScalarField c) (PlonkPolyExtendedLength n)
 
 data PlonkSetupParamsProve c1 c2 = PlonkSetupParamsProve {
-        omega'  :: ScalarField c1,
-        k1'     :: ScalarField c1,
-        k2'     :: ScalarField c1,
-        gs'     :: V.Vector (Point c1),
-        h0'     :: Point c2,
-        h1'     :: Point c2,
-        iPub'   :: V.Vector Natural
+        omega' :: ScalarField c1,
+        k1'    :: ScalarField c1,
+        k2'    :: ScalarField c1,
+        gs'    :: V.Vector (Point c1),
+        h0'    :: Point c2,
+        h1'    :: Point c2,
+        iPub'  :: V.Vector Natural
     }
 instance (Show (ScalarField c1), Show (BaseField c1), Show (BaseField c2),
         EllipticCurve c1, EllipticCurve c2) => Show (PlonkSetupParamsProve c1 c2) where

--- a/tests/Tests/Arithmetization/Test4.hs
+++ b/tests/Tests/Arithmetization/Test4.hs
@@ -11,7 +11,7 @@ import           Tests.NonInteractiveProof.Plonk             (PlonkBS)
 
 import           ZkFold.Base.Algebra.Basic.Class             (FromConstant (..), one)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_G1)
-import           ZkFold.Base.Algebra.EllipticCurve.Class     (EllipticCurve(..))
+import           ZkFold.Base.Algebra.EllipticCurve.Class     (EllipticCurve (..))
 import qualified ZkFold.Base.Data.Vector                     as V
 import           ZkFold.Base.Protocol.ARK.Plonk              (Plonk (..), PlonkProverSecret, PlonkWitnessInput (..),
                                                               plonkVerifierInput)

--- a/tests/Tests/Arithmetization/Test4.hs
+++ b/tests/Tests/Arithmetization/Test4.hs
@@ -45,7 +45,7 @@ testZKP :: F -> PlonkProverSecret C -> F -> Haskell.Bool
 testZKP x ps targetValue =
     let Bool ac = compile @F (lockedByTxId @ArithmeticCircuit @F targetValue) :: Bool (ArithmeticCircuit 1 F)
 
-        (omega, k1, k2) = getParams 5
+        (omega, k1, k2) = getParams 32
         inputs  = fromList [(1, targetValue), (V.item $ acOutput ac, 1)]
         plonk   = Plonk @32 omega k1 k2 (acOutput ac) ac x
         setupP  = setupProve @(PlonkBS N) plonk

--- a/tests/Tests/NonInteractiveProof.hs
+++ b/tests/Tests/NonInteractiveProof.hs
@@ -10,7 +10,6 @@ import           Test.QuickCheck                             (Arbitrary, Testabl
 import           Tests.NonInteractiveProof.Internal          (NonInteractiveProofTestData (..))
 import           Tests.NonInteractiveProof.Plonk             (PlonkBS, specPlonk)
 
-import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381
 import           ZkFold.Base.Protocol.Commitment.KZG         (KZG)
 import           ZkFold.Base.Protocol.NonInteractiveProof    (NonInteractiveProof (..))
@@ -35,7 +34,7 @@ specNonInteractiveProof' = hspec $ do
 
 specNonInteractiveProof :: IO ()
 specNonInteractiveProof = do
-    specNonInteractiveProof' @(KZG BLS12_381_G1 BLS12_381_G2 BLS12_381_GT (Zp BLS12_381_Scalar) 32)
+    specNonInteractiveProof' @(KZG BLS12_381_G1 BLS12_381_G2 32)
 
     specPlonk
     specNonInteractiveProof' @(PlonkBS 2)

--- a/tests/Tests/NonInteractiveProof/Internal.hs
+++ b/tests/Tests/NonInteractiveProof/Internal.hs
@@ -11,9 +11,10 @@ import           Test.QuickCheck                                (Arbitrary (arbi
 
 import           ZkFold.Base.Algebra.Basic.Number               (value)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381    (BLS12_381_G1, BLS12_381_G2)
-import           ZkFold.Base.Algebra.EllipticCurve.Class        (EllipticCurve(..))
+import           ZkFold.Base.Algebra.EllipticCurve.Class        (EllipticCurve (..))
 import           ZkFold.Base.Data.Vector                        (Vector (..))
-import           ZkFold.Base.Protocol.ARK.Plonk                 (Plonk (Plonk), PlonkWitnessInput (..), genSubset, getParams)
+import           ZkFold.Base.Protocol.ARK.Plonk                 (Plonk (Plonk), PlonkWitnessInput (..), genSubset,
+                                                                 getParams)
 import           ZkFold.Base.Protocol.Commitment.KZG            (KZG)
 import           ZkFold.Base.Protocol.NonInteractiveProof       (NonInteractiveProof (..))
 import           ZkFold.Prelude                                 (length)

--- a/tests/Tests/NonInteractiveProof/Internal.hs
+++ b/tests/Tests/NonInteractiveProof/Internal.hs
@@ -5,7 +5,6 @@
 module Tests.NonInteractiveProof.Internal (NonInteractiveProofTestData(..)) where
 
 import           Data.ByteString                                (ByteString)
-import           GHC.Natural                                    (Natural)
 import           GHC.TypeNats                                   (KnownNat)
 import           Prelude                                        hiding (Fractional (..), Num (..), length)
 import           Test.QuickCheck                                (Arbitrary (arbitrary), Gen)
@@ -38,7 +37,7 @@ instance forall n . (KnownNat n) => Arbitrary (NonInteractiveProofTestData (Plon
         ArithmeticCircuitTest ac wi <- arbitrary :: Gen (ArithmeticCircuitTest 1 (ScalarField BLS12_381_G1))
         let inputLen = length . inputVariables $ ac
         vecPubInp <- genSubset (value @n) inputLen
-        let (omega, k1, k2) = getParams $ ceiling @Double @Natural $ logBase 2 $ fromIntegral $ value @PlonkSizeBS
+        let (omega, k1, k2) = getParams $ value @PlonkSizeBS
         pl <- Plonk omega k1 k2 (Vector vecPubInp) ac <$> arbitrary
         secret <- arbitrary
         return $ TestData pl (PlonkWitnessInput $ witnessGenerator ac wi, secret)

--- a/tests/Tests/NonInteractiveProof/Plonk.hs
+++ b/tests/Tests/NonInteractiveProof/Plonk.hs
@@ -20,7 +20,7 @@ import           ZkFold.Base.Algebra.Basic.Class             (AdditiveGroup (..)
                                                               MultiplicativeSemigroup (..), negate, zero, (-!))
 import           ZkFold.Base.Algebra.Basic.Number            (KnownNat, value)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_G1, BLS12_381_G2)
-import           ZkFold.Base.Algebra.EllipticCurve.Class     (EllipticCurve(..))
+import           ZkFold.Base.Algebra.EllipticCurve.Class     (EllipticCurve (..))
 import           ZkFold.Base.Algebra.Polynomials.Univariate  (evalPolyVec, fromPolyVec, polyVecInLagrangeBasis,
                                                               polyVecLinear, polyVecZero, toPolyVec)
 import           ZkFold.Base.Data.Vector                     (fromVector)

--- a/tests/Tests/NonInteractiveProof/Plonk.hs
+++ b/tests/Tests/NonInteractiveProof/Plonk.hs
@@ -3,32 +3,34 @@
 
 module Tests.NonInteractiveProof.Plonk (PlonkBS, PlonkMaxPolyDegreeBS, PlonkSizeBS, specPlonk) where
 
-import           Data.ByteString                            (ByteString)
-import           Data.List                                  (transpose)
-import           Data.Map                                   ((!))
-import           Data.Maybe                                 (fromJust)
-import qualified Data.Vector                                as V
-import           GHC.IsList                                 (IsList (..))
-import           GHC.Natural                                (Natural)
-import           Prelude                                    hiding (Fractional (..), Num (..), drop, length, replicate,
-                                                             take)
+import           Data.ByteString                             (ByteString)
+import           Data.List                                   (transpose)
+import           Data.Map                                    ((!))
+import           Data.Maybe                                  (fromJust)
+import qualified Data.Vector                                 as V
+import           GHC.IsList                                  (IsList (..))
+import           GHC.Natural                                 (Natural)
+import           Prelude                                     hiding (Fractional (..), Num (..), drop, length, replicate,
+                                                              take)
 import           Test.Hspec
 import           Test.QuickCheck
-import           Tests.NonInteractiveProof.Internal         (NonInteractiveProofTestData (..))
+import           Tests.NonInteractiveProof.Internal          (NonInteractiveProofTestData (..))
 
-import           ZkFold.Base.Algebra.Basic.Class            (AdditiveGroup (..), AdditiveSemigroup (..), FiniteField,
-                                                             MultiplicativeSemigroup (..), negate, zero, (-!))
-import           ZkFold.Base.Algebra.Basic.Number           (KnownNat, value)
-import           ZkFold.Base.Algebra.Polynomials.Univariate (evalPolyVec, fromPolyVec, polyVecInLagrangeBasis,
-                                                             polyVecLinear, polyVecZero, toPolyVec)
-import           ZkFold.Base.Data.Vector                    (fromVector)
+import           ZkFold.Base.Algebra.Basic.Class             (AdditiveGroup (..), AdditiveSemigroup (..), FiniteField,
+                                                              MultiplicativeSemigroup (..), negate, zero, (-!))
+import           ZkFold.Base.Algebra.Basic.Number            (KnownNat, value)
+import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_G1, BLS12_381_G2)
+import           ZkFold.Base.Algebra.EllipticCurve.Class     (EllipticCurve(..))
+import           ZkFold.Base.Algebra.Polynomials.Univariate  (evalPolyVec, fromPolyVec, polyVecInLagrangeBasis,
+                                                              polyVecLinear, polyVecZero, toPolyVec)
+import           ZkFold.Base.Data.Vector                     (fromVector)
 import           ZkFold.Base.Protocol.ARK.Plonk
 import           ZkFold.Base.Protocol.ARK.Plonk.Constraint
-import           ZkFold.Base.Protocol.ARK.Plonk.Relation    (PlonkRelation (..), toPlonkRelation)
-import           ZkFold.Base.Protocol.NonInteractiveProof   (NonInteractiveProof (..))
+import           ZkFold.Base.Protocol.ARK.Plonk.Relation     (PlonkRelation (..), toPlonkRelation)
+import           ZkFold.Base.Protocol.NonInteractiveProof    (NonInteractiveProof (..))
 
 type PlonkSizeBS = 32
-type PlonkBS n = Plonk PlonkSizeBS n ByteString
+type PlonkBS n = Plonk PlonkSizeBS n BLS12_381_G1 BLS12_381_G2 ByteString
 type PlonkMaxPolyDegreeBS = PlonkMaxPolyDegree PlonkSizeBS
 
 propPlonkConstraintConversion :: (Eq a, FiniteField a) => PlonkConstraint a -> Bool
@@ -57,7 +59,7 @@ propPlonkConstraintSatisfaction (TestData (Plonk _ _ _ iPub ac _) w) =
 
 propPlonkPolyIdentity :: forall n . KnownNat n => NonInteractiveProofTestData (PlonkBS n) -> Bool
 propPlonkPolyIdentity (TestData plonk w) =
-    let zH = polyVecZero @F @PlonkSizeBS @PlonkMaxPolyDegreeBS
+    let zH = polyVecZero @(ScalarField BLS12_381_G1) @PlonkSizeBS @PlonkMaxPolyDegreeBS
 
         s = setupProve @(PlonkBS n) plonk
         (PlonkSetupParamsProve {..}, _, PlonkCircuitPolynomials {..}, PlonkWitnessMap wmap) = s
@@ -66,7 +68,8 @@ propPlonkPolyIdentity (TestData plonk w) =
         (w1, w2, w3) = wmap wInput
 
         wPub = fmap (negate . (wInput !)) iPub'
-        pubPoly = polyVecInLagrangeBasis @F @PlonkSizeBS @PlonkMaxPolyDegreeBS omega' $ toPolyVec @F @PlonkSizeBS wPub
+        pubPoly = polyVecInLagrangeBasis @(ScalarField BLS12_381_G1) @PlonkSizeBS @PlonkMaxPolyDegreeBS omega' $
+            toPolyVec @(ScalarField BLS12_381_G1) @PlonkSizeBS wPub
 
         a = polyVecLinear b2 b1 * zH + polyVecInLagrangeBasis omega' w1
         b = polyVecLinear b4 b3 * zH + polyVecInLagrangeBasis omega' w2
@@ -90,7 +93,7 @@ specPlonk :: IO ()
 specPlonk = hspec $ do
     describe "Plonk specification" $ do
         describe "Conversion to Plonk constraints and back" $ do
-            it "produces equivalent polynomials" $ property $ propPlonkConstraintConversion @F
+            it "produces equivalent polynomials" $ property $ propPlonkConstraintConversion @(ScalarField BLS12_381_G1)
         describe "Plonk constraint satisfaction" $ do
             it "should hold" $ property $ propPlonkConstraintSatisfaction @2
         describe "Plonk polynomial identity" $ do

--- a/tests/Tests/Pairing.hs
+++ b/tests/Tests/Pairing.hs
@@ -20,8 +20,8 @@ import           ZkFold.Base.Algebra.Polynomials.Univariate  (PolyVec, deg, eval
 import           ZkFold.Base.Protocol.Commitment.KZG         (com)
 
 propVerificationKZG
-    :: forall c1 c2 t f
-    .  Pairing c1 c2 t
+    :: forall c1 c2 f
+    .  Pairing c1 c2
     => f ~ ScalarField c1
     => f ~ ScalarField c2
     => Field f
@@ -49,11 +49,11 @@ propVerificationKZG x p z =
     in pairing v0 h0 == pairing w h1
 
 specPairing'
-    :: forall (c1 :: Type) (c2 :: Type) t f
+    :: forall (c1 :: Type) (c2 :: Type) f
     .  Typeable c1
     => Typeable c2
-    => Typeable t
-    => Pairing c1 c2 t
+    => Typeable (TargetGroup c1 c2)
+    => Pairing c1 c2
     => f ~ ScalarField c1
     => Field f
     => Eq f

--- a/tests/Tests/Univariate/PolyVec.hs
+++ b/tests/Tests/Univariate/PolyVec.hs
@@ -7,24 +7,23 @@
 
 module Tests.Univariate.PolyVec (specUnivariatePolyVec) where
 
-import           Data.Bool                                  (bool)
-import           Data.Data                                  (Typeable, typeOf)
-import           Data.List                                  ((\\))
-import qualified Data.Vector                                as V
-import qualified Data.Vector.Algorithms.Intro               as VA
-import           Numeric.Natural                            (Natural)
-import           Prelude                                    hiding (Fractional (..), Num (..), drop, length, take, (!!),
-                                                             (^))
-import           Prelude                                    (abs)
+import           Data.Bool                                   (bool)
+import           Data.Data                                   (Typeable, typeOf)
+import           Data.List                                   ((\\))
+import qualified Data.Vector                                 as V
+import qualified Data.Vector.Algorithms.Intro                as VA
+import           Numeric.Natural                             (Natural)
+import           Prelude                                     hiding (Fractional (..), Num (..), drop, length, take, (!!),
+                                                              (^))
+import           Prelude                                     (abs)
 import           Test.Hspec
 import           Test.QuickCheck
-import           Tests.NonInteractiveProof.Plonk            (PlonkMaxPolyDegreeBS, PlonkSizeBS)
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Number
+import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (Fr)
 import           ZkFold.Base.Algebra.Polynomials.Univariate
-import           ZkFold.Base.Protocol.ARK.Plonk             (F)
-import           ZkFold.Prelude                             (length, take)
+import           ZkFold.Prelude                              (length, take)
 
 propToPolyVec :: forall c s .
     (Ring c, KnownNat s) =>
@@ -132,4 +131,4 @@ specUnivariatePolyVec' = hspec $ do
 
 specUnivariatePolyVec :: IO ()
 specUnivariatePolyVec = do
-    specUnivariatePolyVec' @F @PlonkSizeBS @PlonkMaxPolyDegreeBS
+    specUnivariatePolyVec' @Fr @32 @135

--- a/tests/Tests/Univariate/PolyVec.hs
+++ b/tests/Tests/Univariate/PolyVec.hs
@@ -13,8 +13,8 @@ import           Data.List                                   ((\\))
 import qualified Data.Vector                                 as V
 import qualified Data.Vector.Algorithms.Intro                as VA
 import           Numeric.Natural                             (Natural)
-import           Prelude                                     hiding (Fractional (..), Num (..), drop, length, take, (!!),
-                                                              (^))
+import           Prelude                                     hiding (Fractional (..), Num (..), drop, length, take,
+                                                              (!!), (^))
 import           Prelude                                     (abs)
 import           Test.Hspec
 import           Test.QuickCheck


### PR DESCRIPTION
- [x] Plonk is now polymorphic in elliptic curve pairing.
- [x] Plonk type parameters `d` and `n` are renamed into `n` and `l`, respectively. Now, it is in line with the paper, where `n` is the number of constraints and `l` is the number of public inputs.
- [x] Function `getParams` now expects the number of constraints `n`.
- [x] Minor renamings in tests for clarity.