### PR TITLE
newRanged and friends

### DIFF
--- a/src/ZkFold/Base/Protocol/ARK/Plonk/Relation.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Plonk/Relation.hs
@@ -33,15 +33,15 @@ toPlonkRelation :: forall n l a .
        KnownNat n
     => KnownNat (3 * n)
     => KnownNat l
-    => Eq a
-    => FiniteField a
+    => Arithmetic a
     => Scale a a
     => FromConstant a a
     => Vector l Natural
     -> ArithmeticCircuit 1 a
     -> Maybe (PlonkRelation n l a)
-toPlonkRelation xPub ac =
-    let evalX0 = evalPolynomial evalMonomial (\x -> if x == 0 then one else var x)
+toPlonkRelation xPub ac0 =
+    let ac = desugarRanges ac0
+        evalX0 = evalPolynomial evalMonomial (\x -> if x == 0 then one else var x)
 
         pubInputConstraints = map var (fromVector xPub)
         acConstraints       = map evalX0 $ elems (constraintSystem ac)

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
@@ -21,7 +21,7 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (
     getAllVars
 ) where
 
-import           Control.Monad                                             (replicateM, foldM)
+import           Control.Monad                                             (foldM, replicateM)
 import           Data.Containers.ListUtils                                 (nubOrd)
 import           Data.Foldable                                             (foldlM)
 import           Data.List                                                 (sort)

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
@@ -16,6 +16,7 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (
         varOrder,
         -- low-level functions
         constraint,
+        rangeConstraint,
         assignment,
         addVariable,
         newVariableWithSource,
@@ -180,6 +181,9 @@ type Constraint c = Poly c Natural Natural
 -- | Adds a constraint to the arithmetic circuit.
 constraint :: Arithmetic a => Constraint a -> State (Circuit a) ()
 constraint c = zoom #acSystem . modify $ insert (toVar [] c) c
+
+rangeConstraint :: Natural -> a -> State (Circuit a) ()
+rangeConstraint i b = zoom #acRange . modify $ insert i b
 
 -- | Forces the provided variables to be zero.
 forceZero :: forall n a . Arithmetic a => Vector n Natural -> State (Circuit a) ()

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
@@ -15,14 +15,19 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (
     circuits
 ) where
 
+import           Control.Applicative                                 (pure)
+import           Control.Monad                                       (Monad, return, (=<<))
 import           Control.Monad.State                                 (State, modify, runState)
-import           Data.Functor                                        (($>))
+import           Data.Foldable                                       (maximum)
+import           Data.Function                                       (($), (.))
+import           Data.Functor                                        (Functor, fmap, ($>), (<$>))
 import           Data.Map                                            ((!))
+import           Data.Monoid                                         (mempty, (<>))
+import           Data.Ord                                            (Ord)
 import           Data.Set                                            (Set)
 import qualified Data.Set                                            as Set
+import           Data.Type.Equality                                  (type (~))
 import           Numeric.Natural                                     (Natural)
-import           Prelude                                             hiding (Bool (..), Eq (..), replicate, (*), (+),
-                                                                      (-))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Sources
@@ -94,6 +99,9 @@ class Monad m => MonadBlueprint i a m | m -> i, m -> a where
     -- | Adds the supplied circuit to the blueprint and returns its output variable.
     runCircuit :: ArithmeticCircuit n a -> m (Vector n i)
 
+    -- | Creates new variable given an upper bound on a value and a witness.
+    newRanged :: a -> Witness i a -> m i
+
     -- | Creates new variable given a constraint polynomial and a witness.
     newConstrained :: NewConstraint i a -> Witness i a -> m i
 
@@ -108,6 +116,17 @@ instance Arithmetic a => MonadBlueprint Natural a (State (Circuit a)) where
     input = I.input
 
     runCircuit r = modify (<> acCircuit r) $> acOutput r
+
+    newRanged upperBound witness = do
+        let s   = sources @a witness
+            -- | A wild (and obviously incorrect) approximation of
+            -- x (x - 1) ... (x - (upperBound - 1))
+            -- It's ok because we only use it for variable generation anyway.
+            p i = var i * (var i - one) * (var i - fromConstant upperBound + one)
+        i <- addVariable =<< newVariableWithSource (Set.toList s) p
+        I.rangeConstraint i upperBound
+        assignment i (\m -> witness (m !))
+        return i
 
     newConstrained
         :: NewConstraint Natural a


### PR DESCRIPTION
This PR adds a `newRanged` function to `MonadBlueprint` class to generate range-constrained variables.
In addition, a function `desugarRanges :: AC n a -> AC n a` is added to desugar range constraints into bit-by-bit comparisons with constants, which is used in `toPlonkRelation` function.