### PR TITLE
- overlapping for Conditional and Eq

### DIFF
--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
@@ -23,6 +23,7 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (
 
 import           Control.Monad                                             (foldM, replicateM)
 import           Data.Containers.ListUtils                                 (nubOrd)
+import           Data.Eq                                                   ((==))
 import           Data.Foldable                                             (foldlM)
 import           Data.List                                                 (sort)
 import           Data.Map                                                  (elems)
@@ -42,9 +43,6 @@ import           ZkFold.Prelude                                            (leng
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       (Arithmetic, ArithmeticCircuit (..),
                                                                             Circuit (acSystem), acInput, joinCircuits)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint
-import           ZkFold.Symbolic.Data.Bool                                 (Bool)
-import           ZkFold.Symbolic.Data.Conditional                          (Conditional (..))
-import           ZkFold.Symbolic.Data.Eq                                   (Eq (..))
 
 boolCheckC :: Arithmetic a => ArithmeticCircuit n a -> ArithmeticCircuit n a
 -- ^ @boolCheckC r@ computes @r (r - 1)@ in one PLONK constraint.
@@ -138,12 +136,9 @@ invertC r = circuitN $ snd <$> runInvert r
 runInvert :: MonadBlueprint i a m => ArithmeticCircuit n a -> m (Vector n i, Vector n i)
 runInvert r = do
     is <- runCircuit r
-    js <- for is $ \i -> newConstrained (\x j -> x i * x j) (isZero . ($ i))
+    js <- for is $ \i -> newConstrained (\x j -> x i * x j) (\x -> let xi = x i in one - xi // xi)
     ks <- for (Z.zip is js) $ \(i, j) -> newConstrained (\x k -> x i * x k + x j - one) (finv . ($ i))
     return (js, ks)
-    where
-      isZero :: forall a . (Ring a, Eq (Bool a) a, Conditional (Bool a) a) => a -> a
-      isZero x = bool @(Bool a) zero one (x == zero)
 
 embedVarIndex :: Arithmetic a => Natural -> ArithmeticCircuit 1 a
 embedVarIndex n = ArithmeticCircuit { acCircuit = mempty { acInput = [ n ]}, acOutput = pure n}

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -50,7 +50,7 @@ instance Arithmetic a => SymbolicData a (ArithmeticCircuit n a) where
 -- TODO: I had to add these constraints and I don't like them
 instance
     ( KnownNat (n * Order a)
-    , KnownNat (Log2 ((n * Order a) - 1) + 1)
+    , KnownNat (Log2 (n * Order a - 1) + 1)
     ) => Finite (ArithmeticCircuit n a) where
     type Order (ArithmeticCircuit n a) = n * Order a
 
@@ -151,7 +151,7 @@ instance (Arithmetic a, KnownNat n, 1 <= n) => Eq (Bool (ArithmeticCircuit 1 a))
     x == y = isZero (x - y)
     x /= y = not $ isZero (x - y)
 
-instance {-# OVERLAPPING #-} (SymbolicData a x, n ~ TypeSize a x, KnownNat n) => Conditional (Bool (ArithmeticCircuit 1 a)) x where
+instance (SymbolicData a x, n ~ TypeSize a x, KnownNat n) => Conditional (Bool (ArithmeticCircuit 1 a)) x where
     bool brFalse brTrue (Bool b) = restore c o
         where
             f' = pieces brFalse
@@ -211,7 +211,7 @@ instance (FromJSON a, KnownNat n) => FromJSON (ArithmeticCircuit n a) where
             acInput    <- v .: "input"
             acVarOrder <- v .: "order"
             outs       <- v .: "output"
-            guard (length v == (value @n))
+            guard (length v Haskell.== value @n)
             let acWitness = empty
                 acRNG     = mkStdGen 0
                 acOutput  = Vector outs

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
@@ -39,8 +39,7 @@ import           ZkFold.Symbolic.Data.Bool                           (Bool (..))
 import           ZkFold.Symbolic.Data.Conditional                    (Conditional (..))
 import           ZkFold.Symbolic.Data.Eq                             (Eq (..))
 
-type WitnessField a x = (Algebra a x, FiniteField x, BinaryExpansion x, Bits x ~ [x],
-    Eq (Bool x) x, Conditional (Bool x) x, Conditional (Bool x) (Bool x))
+type WitnessField a x = (Algebra a x, FiniteField x, BinaryExpansion x, Bits x ~ [x])
 -- ^ DSL for constructing witnesses in an arithmetic circuit. @a@ is a base
 -- field; @x@ is a "field of witnesses over @a@" which you can safely assume to
 -- be identical to @a@ with internalized equality.

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
@@ -35,9 +35,6 @@ import           ZkFold.Base.Algebra.Polynomials.Multivariate        (var)
 import           ZkFold.Base.Data.Vector
 import qualified ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal as I
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal hiding (constraint)
-import           ZkFold.Symbolic.Data.Bool                           (Bool (..))
-import           ZkFold.Symbolic.Data.Conditional                    (Conditional (..))
-import           ZkFold.Symbolic.Data.Eq                             (Eq (..))
 
 type WitnessField a x = (Algebra a x, FiniteField x, BinaryExpansion x, Bits x ~ [x])
 -- ^ DSL for constructing witnesses in an arithmetic circuit. @a@ is a base
@@ -166,13 +163,3 @@ circuits b = let (os, r) = runState (fmap pure <$> b) (mempty :: Circuit a) in (
 
 sources :: forall a i . (FiniteField a, Ord i) => Witness i a -> Set i
 sources = runSources . ($ Sources @a . Set.singleton)
-
-instance Ord i => Eq (Bool (Sources a i)) (Sources a i) where
-  x == y = Bool (x <> y)
-  x /= y = Bool (x <> y)
-
-instance (Finite a, Ord i) => Conditional (Bool (Sources a i)) (Sources a i) where
-  bool x y (Bool b) = x <> y <> b
-
-instance (Finite a, Ord i) => Conditional (Bool (Sources a i)) (Bool (Sources a i)) where
-  bool (Bool x) (Bool y) (Bool b) = Bool (x <> y <> b)

--- a/src/ZkFold/Symbolic/Compiler/Arithmetizable.hs
+++ b/src/ZkFold/Symbolic/Compiler/Arithmetizable.hs
@@ -130,7 +130,7 @@ instance (Arithmetizable a f, KnownNat n, KnownNat (InputSize a f)) => Arithmeti
     type OutputSize a (Vector n f) = n * OutputSize a f
     arithmetize v (ArithmeticCircuit c o) = concatCircuits results
         where
-            inputs  = (ArithmeticCircuit c) <$> V.chunks @n @(InputSize a f) o
+            inputs  = ArithmeticCircuit c <$> V.chunks @n @(InputSize a f) o
             results = arithmetize <$> v <*> inputs
 
 instance

--- a/src/ZkFold/Symbolic/Data/Conditional.hs
+++ b/src/ZkFold/Symbolic/Data/Conditional.hs
@@ -1,8 +1,16 @@
 module ZkFold.Symbolic.Data.Conditional where
 
-import           Prelude                   hiding (Bool, Num (..), (/))
+import qualified Data.Bool                         as Haskell
+import           Data.Eq                           ((==))
+import           Data.Function                     (($))
+import           Data.Zip                          (zipWith)
 
-import           ZkFold.Symbolic.Data.Bool (BoolType (..))
+import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Base.Algebra.Basic.Field   (Zp)
+import           ZkFold.Base.Algebra.Basic.Number  (KnownNat)
+import           ZkFold.Base.Data.Vector           (Vector, item)
+import           ZkFold.Symbolic.Data.Bool         (Bool (Bool), BoolType (..))
+import           ZkFold.Symbolic.Data.FieldElement
 
 class BoolType b => Conditional b a where
     bool :: a -> a -> b -> a
@@ -13,5 +21,13 @@ class BoolType b => Conditional b a where
     (?) :: b -> a -> a -> a
     (?) = gif
 
-instance {-# OVERLAPPABLE #-} (BoolType b, Eq b) => Conditional b x where
-    bool f t b = if b == true then t else f
+instance KnownNat p => Conditional (Bool (Zp p)) (Zp p) where
+    bool x y b = Haskell.bool x y (b == true)
+
+instance FieldElementData a Vector x => Conditional (Bool (Vector 1 a)) x where
+    bool x y (Bool b) =
+      let b' = item b
+       in fromFieldElements @a
+          $ zipWith (\x' y' -> (one - b') * x' + b' * y')
+              (toFieldElements @a @Vector x)
+              (toFieldElements @a y)

--- a/src/ZkFold/Symbolic/Data/Eq.hs
+++ b/src/ZkFold/Symbolic/Data/Eq.hs
@@ -3,11 +3,13 @@ module ZkFold.Symbolic.Data.Eq (
     elem
 ) where
 
-import           Data.Bool                 (bool)
-import           Data.Foldable             (Foldable)
-import qualified Prelude                   as Haskell
+import           Data.Bool                        (bool)
+import qualified Data.Eq                          as Haskell
+import           Data.Foldable                    (Foldable)
 
-import           ZkFold.Symbolic.Data.Bool (BoolType (..), any)
+import           ZkFold.Base.Algebra.Basic.Field  (Zp)
+import           ZkFold.Base.Algebra.Basic.Number (KnownNat)
+import           ZkFold.Symbolic.Data.Bool        (Bool, BoolType (..), any)
 
 class BoolType b => Eq b a where
     infix 4 ==
@@ -16,9 +18,9 @@ class BoolType b => Eq b a where
     infix 4 /=
     (/=) :: a -> a -> b
 
-instance {-# OVERLAPPABLE #-} (BoolType b, Haskell.Eq x) => Eq b x where
-    x == y = bool false true (x Haskell.== y)
-    x /= y = bool false true (x Haskell./= y)
-
 elem :: (Eq b a, Foldable t) => a -> t a -> b
 elem x = any (== x)
+
+instance KnownNat p => Eq (Bool (Zp p)) (Zp p) where
+    x == y = bool false true (x Haskell.== y)
+    x /= y = bool false true (x Haskell./= y)

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -109,7 +109,7 @@ cast n =
         r = numberOfRegisters @a @n -! 1
      in case greedySplitAt r registers of
         (lo, hi:rest) -> (lo, hi, rest)
-        (lo, [])      -> ((lo ++ replicate (r -! length lo) zero), zero, [])
+        (lo, [])      -> (lo ++ replicate (r -! length lo) zero, zero, [])
     where
         greedySplitAt 0 xs = ([], xs)
         greedySplitAt _ [] = ([], [])
@@ -144,7 +144,7 @@ eea a b = eea' 1 a b one zero zero one
 
         eea' :: Natural -> UInt n b a -> UInt n b a -> UInt n b a -> UInt n b a -> UInt n b a -> UInt n b a -> (UInt n b a, UInt n b a, UInt n b a)
         eea' iteration oldR r oldS s oldT t
-          | iteration == iterations = (oldS, oldT, oldR)
+          | iteration Haskell.== iterations = (oldS, oldT, oldR)
           | otherwise = bool @(Bool (b 1 a)) rec (if Haskell.even iteration then b - oldS else oldS, if Haskell.odd iteration then a - oldT else oldT, oldR) (r == zero)
             where
                 quotient = oldR `div` r
@@ -206,11 +206,10 @@ instance (Finite (Zp p), KnownNat n) => Arbitrary (UInt n Vector (Zp p)) where
         where toss b = fromConstant <$> chooseInteger (0, 2 ^ b - 1)
 
 instance (Finite (Zp p), KnownNat n) => Iso (ByteString n Vector (Zp p)) (UInt n Vector (Zp p)) where
-    from bs = fromConstant @Natural . toConstant $ bs
+    from = fromConstant @Natural . toConstant
 
 instance (Finite (Zp p), KnownNat n) => Iso (UInt n Vector (Zp p)) (ByteString n Vector (Zp p)) where
-    from ui = fromConstant @Natural . toConstant $ ui
-
+    from = fromConstant @Natural . toConstant
 
 --------------------------------------------------------------------------------
 
@@ -285,7 +284,7 @@ instance
             numeratorBits = from numerator
 
             addBit :: UInt n b a -> Natural -> UInt n b a
-            addBit ui bs = ui + (bool @(Bool (b 1 a)) zero one (isSet numeratorBits bs))
+            addBit ui bs = ui + bool @(Bool (b 1 a)) zero one (isSet numeratorBits bs)
 
             longDivisionStep
                 :: (UInt n b a, UInt n b a)
@@ -383,7 +382,7 @@ instance
                 ys = replicate (numberOfRegisters @a @n -! 2) (2 ^ registerSize @a @n -! 1)
                 y' = 2 ^ highRegisterSize @a @n -! 1
                 ns
-                  | numberOfRegisters @a @n == 1 = V.unsafeToVector [y' + 1]
+                  | numberOfRegisters @a @n Haskell.== 1 = V.unsafeToVector [y' + 1]
                   | otherwise = V.unsafeToVector $ (y : ys) <> [y']
              in UInt (negateN ns x)
 

--- a/tests/Tests/Arithmetization/Test1.hs
+++ b/tests/Tests/Arithmetization/Test1.hs
@@ -27,7 +27,7 @@ testFunc x y =
     in (g3 == y :: Bool a) ? g1 $ g2
 
 testResult :: forall a . (Symbolic a, Haskell.Eq a) => ArithmeticCircuit 1 a -> a -> a -> Haskell.Bool
-testResult r x y = V.item (acValue (applyArgs r [x, y])) == testFunc @a x y
+testResult r x y = V.item (acValue (applyArgs r [x, y])) Haskell.== testFunc @a x y
 
 specArithmetization1 :: forall a . (Symbolic a, Arithmetic a, Arbitrary a, Show a) => Spec
 specArithmetization1 = do

--- a/tests/Tests/Arithmetization/Test2.hs
+++ b/tests/Tests/Arithmetization/Test2.hs
@@ -26,7 +26,7 @@ testTautology :: forall a . (Symbolic a, BinaryExpansion a, Haskell.Eq a, Bits a
 testTautology x y =
     let Bool ac = compile @a (tautology @ArithmeticCircuit @a)
         b       = Bool $ acValue (applyArgs ac [x, y])
-    in b == true
+    in b Haskell.== true
 
 specArithmetization2 :: Spec
 specArithmetization2 = do

--- a/tests/Tests/Arithmetization/Test4.hs
+++ b/tests/Tests/Arithmetization/Test4.hs
@@ -33,13 +33,13 @@ testSameValue :: F -> Haskell.Bool
 testSameValue targetValue =
     let Bool ac = compile @F (lockedByTxId @ArithmeticCircuit @F targetValue) :: Bool (ArithmeticCircuit 1 F)
         b       = Bool $ acValue (applyArgs ac [targetValue])
-    in b == true
+    in b Haskell.== true
 
 testDifferentValue :: F -> F -> Haskell.Bool
 testDifferentValue targetValue otherValue =
     let Bool ac = compile @F (lockedByTxId @ArithmeticCircuit @F targetValue) :: Bool (ArithmeticCircuit 1 F)
         b       = Bool $ acValue (applyArgs ac [otherValue])
-    in b == false
+    in b Haskell.== false
 
 testZKP :: F -> PlonkProverSecret C -> F -> Haskell.Bool
 testZKP x ps targetValue =
@@ -63,6 +63,6 @@ specArithmetization4 = do
     describe "LockedByTxId arithmetization test 1" $ do
         it "should pass" $ property testSameValue
     describe "LockedByTxId arithmetization test 2" $ do
-        it "should pass" $ property $ \x y -> x /= y ==> testDifferentValue x y
+        it "should pass" $ property $ \x y -> x Haskell./= y ==> testDifferentValue x y
     describe "LockedByTxId ZKP test" $ do
         it "should pass" $ withMaxSuccess 10 $ property testZKP

--- a/tests/Tests/UInt.hs
+++ b/tests/Tests/UInt.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeOperators       #-}
+
 {-# OPTIONS_GHC -freduction-depth=0 #-} -- Avoid reduction overflow error caused by NumberOfRegisters
 
 module Tests.UInt (specUInt) where
@@ -58,7 +59,7 @@ specUInt'
     .  PrimeField (Zp p)
     => KnownNat n
     => KnownNat (2 * n)
-    => n <= (2 * n)
+    => n <= 2 * n
     => r ~ NumberOfRegisters (Zp p) n
     => r2n ~ NumberOfRegisters (Zp p) (2 * n)
     => 1 <= r
@@ -111,8 +112,8 @@ specUInt' = hspec $ do
         it "calculates Bezout coefficients correctly" $ withMaxSuccess 10 $ do
             x' <- toss m
             y' <- toss m
-            let x = x' `P.div` (P.gcd x' y')
-                y = y' `P.div` (P.gcd x' y')
+            let x = x' `P.div` P.gcd x' y'
+                y = y' `P.div` P.gcd x' y'
 
                 -- We will test Bezout coefficients by multiplying two UInts less than 2^n, hence we need 2^(2n) bits to store the result
                 zpX = fromConstant x :: UInt (2 * n) Vector (Zp p)
@@ -146,17 +147,17 @@ specUInt' = hspec $ do
         it "checks equality" $ do
             x <- toss m
             let acUint = fromConstant x :: UInt n ArithmeticCircuit (Zp p)
-            return $ evalBool @(Zp p) (acUint == acUint) === (Bool one)
+            return $ evalBool @(Zp p) (acUint == acUint) === Bool one
 
         it "checks inequality" $ do
             x <- toss m
             y' <- toss m
-            let y = if y' == x then x + 1 else y'
+            let y = if y' P.== x then x + 1 else y'
 
             let acUint1 = fromConstant x :: UInt n ArithmeticCircuit (Zp p)
                 acUint2 = fromConstant y :: UInt n ArithmeticCircuit (Zp p)
 
-            return $ evalBool @(Zp p) (acUint1 == acUint2) === (Bool zero)
+            return $ evalBool @(Zp p) (acUint1 == acUint2) === Bool zero
 
         it "checks greater than" $ do
             x <- toss m


### PR DESCRIPTION
Remove overlapping instances of `Conditional` and `Symbolic.Eq` classes. Also some minor linting cleanups on the way