### PR TITLE
- input in MonadBlueprint

### DIFF
--- a/src/ZkFold/Symbolic/Compiler.hs
+++ b/src/ZkFold/Symbolic/Compiler.hs
@@ -9,16 +9,15 @@ module ZkFold.Symbolic.Compiler (
     compileIO
 ) where
 
-import           Data.Aeson                                                (ToJSON)
-import           Prelude                                                   (FilePath, IO, Show (..), putStrLn, type (~),
-                                                                            ($), (++), (<$>))
+import           Data.Aeson                                          (ToJSON)
+import           Prelude                                             (FilePath, IO, Monoid (mempty), Show (..),
+                                                                      putStrLn, type (~), ($), (++))
 
 import           ZkFold.Base.Algebra.Basic.Number
-import           ZkFold.Base.Data.Vector                                   (Vector (..))
-import           ZkFold.Prelude                                            (replicateA, writeFileJSON)
+import           ZkFold.Base.Data.Vector                             (unsafeToVector)
+import           ZkFold.Prelude                                      (writeFileJSON)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       (ArithmeticCircuit (..))
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (ArithmeticCircuit (..), Circuit (acInput))
 import           ZkFold.Symbolic.Compiler.Arithmetizable
 
 {-
@@ -37,8 +36,8 @@ import           ZkFold.Symbolic.Compiler.Arithmetizable
 solder :: forall a f . (Arithmetizable a f, KnownNat (InputSize a f)) => f -> ArithmeticCircuit a (OutputSize a f)
 solder f = arithmetize f inputC
     where
-        inputC :: ArithmeticCircuit a (InputSize a f)
-        inputC = circuitN $ Vector <$> replicateA (value @(InputSize a f)) input
+        inputList = [1..(value @(InputSize a f))]
+        inputC = withOutputs (mempty { acInput = inputList }) (unsafeToVector inputList)
 
 -- | Compiles function `f` into an arithmetic circuit.
 compile

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
@@ -20,7 +20,6 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (
         assignment,
         addVariable,
         newVariableWithSource,
-        input,
         eval,
         eval1,
         exec,
@@ -193,16 +192,6 @@ forceZero = mapM_ (constraint . var)
 -- TODO: forbid reassignment of variables
 assignment :: Natural -> (Map Natural a -> a) -> State (Circuit a) ()
 assignment i f = zoom #acWitness . modify $ insert i f
-
--- | Adds a new input variable to the arithmetic circuit.
-input :: State (Circuit a) Natural
-input = do
-  inputs <- zoom #acInput get
-  let s = if null inputs then 1 else maximum inputs + 1
-  zoom #acInput $ modify (++ [s])
-  zoom #acVarOrder . modify
-      $ \vo -> insert (length vo, s) s vo
-  return s
 
 -- | Evaluates the arithmetic circuit with one output using the supplied input map.
 eval1 :: ArithmeticCircuit a 1 -> Map Natural a -> a

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
@@ -89,9 +89,6 @@ class Monad m => MonadBlueprint i a m | m -> i, m -> a where
     -- * That introduced polynomial constraints are supported by the zk-SNARK
     --   utilized for later proving.
 
-    -- | Creates new input variable.
-    input :: m i
-
     -- | Adds the supplied circuit to the blueprint and returns its output variable.
     runCircuit :: ArithmeticCircuit a n -> m (Vector n i)
 
@@ -111,8 +108,6 @@ class Monad m => MonadBlueprint i a m | m -> i, m -> a where
     newAssigned p = newConstrained (\x i -> p x - x i) p
 
 instance Arithmetic a => MonadBlueprint Natural a (State (Circuit a)) where
-    input = I.input
-
     runCircuit r = modify (<> acCircuit r) $> acOutput r
 
     newRanged upperBound witness = do


### PR DESCRIPTION
This PR removes `input` method from `MonadBlueprint` class because
* it prevents the simple pure interface (e.g. `Arithmetic a => MonadBlueprint a a Identity`)
* it is not used outside of `solder` function and it is not expected to be used anywhere else
* it SHOULD not be used by the users of a `MonadBlueprint` class

This is a preparation for migration to the new `Symbolic` typeclass.