### PR TITLE
context is now `(Type -> Type) -> Type`

### DIFF
--- a/examples/Examples/Conditional.hs
+++ b/examples/Examples/Conditional.hs
@@ -2,6 +2,7 @@
 
 module Examples.Conditional (exampleConditional) where
 
+import           GHC.Generics                                (Par1)
 import           Prelude                                     (IO, putStrLn)
 
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
@@ -20,4 +21,4 @@ exampleConditional = do
 
     putStrLn "\nExample: conditional\n"
 
-    compileIO @F file (bool @B @(A 1))
+    compileIO @F file (bool @B @(A Par1))

--- a/examples/Examples/MiMCHash.hs
+++ b/examples/Examples/MiMCHash.hs
@@ -2,6 +2,7 @@
 
 module Examples.MiMCHash (exampleMiMC) where
 
+import           GHC.Generics                                   (Par1)
 import           Prelude                                        hiding (Eq (..), Num (..), any, not, (!!), (/), (^),
                                                                  (||))
 
@@ -20,4 +21,4 @@ exampleMiMC = do
 
     putStrLn "\nExample: MiMC hash function\n"
 
-    compileIO @F file (mimcHash2 @F @(ArithmeticCircuit F 1) mimcConstants zero)
+    compileIO @F file (mimcHash2 @F @(ArithmeticCircuit F Par1) mimcConstants zero)

--- a/examples/Examples/ReverseList.hs
+++ b/examples/Examples/ReverseList.hs
@@ -3,6 +3,7 @@
 
 module Examples.ReverseList (exampleReverseList) where
 
+import           GHC.Generics                                (Par1)
 import           Prelude
 
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
@@ -21,4 +22,4 @@ exampleReverseList = do
 
     putStrLn "\nExample: Reverse List function\n"
 
-    compileIO @(Zp BLS12_381_Scalar) file (reverseList @(ArithmeticCircuit (Zp BLS12_381_Scalar) 1) @32)
+    compileIO @(Zp BLS12_381_Scalar) file (reverseList @(ArithmeticCircuit (Zp BLS12_381_Scalar) Par1) @32)

--- a/src/ZkFold/Base/Data/Par1.hs
+++ b/src/ZkFold/Base/Data/Par1.hs
@@ -1,0 +1,14 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module ZkFold.Base.Data.Par1 where
+
+import           Data.Semialign (Semialign (..))
+import           Data.These     (These (These))
+import           Data.Zip       (Zip (..))
+import           GHC.Generics   (Par1 (..))
+
+instance Semialign Par1 where
+  align (Par1 x) (Par1 y) = Par1 (These x y)
+
+instance Zip Par1 where
+  zip (Par1 x) (Par1 y) = Par1 (x, y)

--- a/src/ZkFold/Base/Data/Vector.hs
+++ b/src/ZkFold/Base/Data/Vector.hs
@@ -7,6 +7,7 @@ module ZkFold.Base.Data.Vector where
 import           Control.DeepSeq                  (NFData)
 import qualified Control.Monad                    as M
 import           Control.Parallel.Strategies      (parMap, rpar)
+import           Data.Aeson                       (ToJSON (..))
 import           Data.Bifunctor                   (first)
 import qualified Data.List                        as List
 import           Data.List.Split                  (chunksOf)
@@ -169,3 +170,6 @@ instance (Random a, KnownNat size) => Random (Vector size a) where
                 let (a, g'') = randomR (P.head xs', P.head ys') g'
                 in ((as' ++ [a], g''), (P.tail xs', P.tail ys'))) (([], g), (xs, ys)) [1..value @size]
         in first Vector as
+
+instance ToJSON a => ToJSON (Vector n a) where
+    toJSON (Vector xs) = toJSON xs

--- a/src/ZkFold/Base/Protocol/ARK/Plonk.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Plonk.hs
@@ -13,6 +13,7 @@ module ZkFold.Base.Protocol.ARK.Plonk (
 
 import           Data.Maybe                                 (fromJust)
 import qualified Data.Vector                                as V
+import           GHC.Generics                               (Par1)
 import           GHC.IsList                                 (IsList (..))
 import           Numeric.Natural                            (Natural)
 import           Prelude                                    hiding (Num (..), div, drop, length, replicate, sum, take,
@@ -43,7 +44,7 @@ data Plonk (n :: Natural) (l :: Natural) curve1 curve2 transcript = Plonk {
         k1    :: ScalarField curve1,
         k2    :: ScalarField curve1,
         iPub  :: Vector l Natural,
-        ac    :: ArithmeticCircuit (ScalarField curve1) 1,
+        ac    :: ArithmeticCircuit (ScalarField curve1) Par1,
         x     :: ScalarField curve1
     }
 instance (Show (ScalarField c1), Arithmetic (ScalarField c1)) => Show (Plonk n l c1 c2 t) where

--- a/src/ZkFold/Base/Protocol/ARK/Plonk/Relation.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Plonk/Relation.hs
@@ -4,6 +4,7 @@
 module ZkFold.Base.Protocol.ARK.Plonk.Relation where
 
 import           Data.Map                                     (Map, elems, (!))
+import           GHC.Generics                                 (Par1)
 import           GHC.IsList                                   (IsList (..))
 import           Numeric.Natural                              (Natural)
 import           Prelude                                      hiding (Num (..), drop, length, replicate, sum, take,
@@ -38,7 +39,7 @@ toPlonkRelation :: forall n l a .
     => Scale a a
     => FromConstant a a
     => Vector l Natural
-    -> ArithmeticCircuit a 1
+    -> ArithmeticCircuit a Par1
     -> Maybe (PlonkRelation n l a)
 toPlonkRelation xPub ac0 =
     let ac = desugarRanges ac0

--- a/src/ZkFold/Symbolic/Algorithms/Hash/MiMC.hs
+++ b/src/ZkFold/Symbolic/Algorithms/Hash/MiMC.hs
@@ -3,12 +3,13 @@
 module ZkFold.Symbolic.Algorithms.Hash.MiMC where
 
 import           Data.List.NonEmpty                                     (NonEmpty ((:|)), nonEmpty)
+import           GHC.Generics                                           (Par1 (Par1))
 import           Numeric.Natural                                        (Natural)
 import           Prelude                                                hiding (Eq (..), Num (..), any, length, not,
                                                                          (!!), (/), (^), (||))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Data.Vector                                (fromVector, singleton)
+import           ZkFold.Base.Data.Vector                                (fromVector)
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators
 import           ZkFold.Symbolic.Data.FieldElement                      (FieldElement (..), FieldElementData (..))
@@ -40,7 +41,7 @@ class MiMCHash a c x where
     mimcHash :: [a] -> a -> x -> FieldElement c
 
 instance (Ring a, FieldElementData (Interpreter a) x) => MiMCHash a (Interpreter a) x where
-    mimcHash xs k = FieldElement . Interpreter . singleton . mimcHashN xs k . fromVector . runInterpreter . toFieldElements
+    mimcHash xs k = FieldElement . Interpreter . Par1 . mimcHashN xs k . fromVector . runInterpreter . toFieldElements
 
 instance (Arithmetic a, FieldElementData (ArithmeticCircuit a) x) => MiMCHash a (ArithmeticCircuit a) x where
     mimcHash xs k = FieldElement  . mimcHashN xs k . fromVector . splitCircuit . toFieldElements

--- a/src/ZkFold/Symbolic/Algorithms/Hash/SHA2.hs
+++ b/src/ZkFold/Symbolic/Algorithms/Hash/SHA2.hs
@@ -35,7 +35,7 @@ import           ZkFold.Symbolic.Data.UInt                      (UInt)
 -- | SHA2 is a family of hashing functions with almost identical implementations but different constants and parameters.
 -- This class links these varying parts with the appropriate algorithm.
 --
-class AlgorithmSetup (algorithm :: Symbol) (backend :: Natural -> Type) where
+class AlgorithmSetup (algorithm :: Symbol) (backend :: (Type -> Type) -> Type) where
     type WordSize algorithm :: Natural
     -- ^ The length of words the algorithm operates internally, in bits.
 
@@ -247,7 +247,7 @@ type SHA2N algorithm backend =
 -- Only used for testing.
 --
 sha2Natural
-    :: forall (algorithm :: Symbol) (backend :: Natural -> Type)
+    :: forall (algorithm :: Symbol) (backend :: (Type -> Type) -> Type)
     .  SHA2N algorithm backend
     => Natural -> Natural -> ByteString (ResultSize algorithm) backend
 sha2Natural numBits messageBits = sha2Blocks @algorithm @backend chunks
@@ -281,7 +281,7 @@ sha2Natural numBits messageBits = sha2Blocks @algorithm @backend chunks
 -- Even 16 GB of RAM is not enough.
 --
 sha2Blocks
-    :: forall algorithm (backend :: Natural -> Type)
+    :: forall algorithm (backend :: (Type -> Type) -> Type)
     .  AlgorithmSetup algorithm backend
     => NFData (ByteString (WordSize algorithm) backend)
     => Iso (ByteString (WordSize algorithm) backend) (UInt (WordSize algorithm) backend)

--- a/src/ZkFold/Symbolic/Cardano/Contracts/BatchTransfer.hs
+++ b/src/ZkFold/Symbolic/Cardano/Contracts/BatchTransfer.hs
@@ -4,6 +4,7 @@ module ZkFold.Symbolic.Cardano.Contracts.BatchTransfer where
 
 import           Data.Maybe                                     (fromJust)
 import           Data.Zip                                       (zip)
+import           GHC.Generics                                   (Par1)
 import           Numeric.Natural                                (Natural)
 import           Prelude                                        hiding (Bool, Eq (..), all, length, splitAt, zip, (&&),
                                                                  (*), (+))
@@ -28,10 +29,10 @@ hash :: forall context x . MiMCHash F context x => x -> FieldElement context
 hash = mimcHash @F mimcConstants zero
 
 type Sig context =
-    ( StrictConv (context 1) (UInt 256 context)
+    ( StrictConv (context Par1) (UInt 256 context)
     , FromConstant Natural (UInt 256 context)
     , MultiplicativeSemigroup (UInt 256 context)
-    , AdditiveMonoid (context 1)
+    , AdditiveMonoid (context Par1)
     , MiMCHash F context (TxOut context, TxOut context)
     , BoolType (Bool context)
     , Eq (Bool context) (UInt 256 context)

--- a/src/ZkFold/Symbolic/Cardano/Types/Basic.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/Basic.hs
@@ -14,6 +14,7 @@ import           Prelude                                     hiding (Bool, Eq, l
 
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
+import           ZkFold.Base.Data.Vector                     (Vector)
 import           ZkFold.Symbolic.Compiler                    (ArithmeticCircuit)
 import qualified ZkFold.Symbolic.Data.Bool                   as Symbolic
 import qualified ZkFold.Symbolic.Data.ByteString             as Symbolic
@@ -25,7 +26,7 @@ import           ZkFold.Symbolic.Interpreter                 (Interpreter)
 type F = Zp BLS12_381_Scalar
 
 type FieldElement context     = Symbolic.FieldElement context
-type FieldElementBits context = context 256
+type FieldElementBits context = context (Vector 256)
 
 type Bool context = Symbolic.Bool context
 

--- a/src/ZkFold/Symbolic/Cardano/UPLC/Builtins.hs
+++ b/src/ZkFold/Symbolic/Cardano/UPLC/Builtins.hs
@@ -4,6 +4,7 @@
 module ZkFold.Symbolic.Cardano.UPLC.Builtins where
 
 import           Data.Typeable                     (Proxy (..), Typeable)
+import           GHC.Generics                      (Par1)
 import           Prelude                           (($))
 
 import           ZkFold.Base.Algebra.Basic.Class
@@ -24,13 +25,13 @@ data BuiltinFunctions =
 -- TODO: use shortcuts to make these definitions more readable
 instance forall a . (Arithmetic a, Typeable a) => PlutusBuiltinFunction a BuiltinFunctions where
     builtinFunctionType AddField =
-          SomeFunction (SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a 1))
-        $ SomeFunction (SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a 1))
-        $ SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a 1)
+          SomeFunction (SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a Par1))
+        $ SomeFunction (SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a Par1))
+        $ SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a Par1)
     builtinFunctionType MulField =
-        SomeFunction (SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a 1))
-        $ SomeFunction (SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a 1))
-        $ SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a 1)
+        SomeFunction (SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a Par1))
+        $ SomeFunction (SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a Par1))
+        $ SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a Par1)
 
-    builtinFunctionRep AddField = SomeArithmetizable $ \(x :: ArithmeticCircuit a 1) (y :: ArithmeticCircuit a 1) -> x + y
-    builtinFunctionRep MulField = SomeArithmetizable $ \(x :: ArithmeticCircuit a 1) (y :: ArithmeticCircuit a 1) -> x * y
+    builtinFunctionRep AddField = SomeArithmetizable $ \(x :: ArithmeticCircuit a Par1) (y :: ArithmeticCircuit a Par1) -> x + y
+    builtinFunctionRep MulField = SomeArithmetizable $ \(x :: ArithmeticCircuit a Par1) (y :: ArithmeticCircuit a Par1) -> x * y

--- a/src/ZkFold/Symbolic/Class.hs
+++ b/src/ZkFold/Symbolic/Class.hs
@@ -1,7 +1,6 @@
 module ZkFold.Symbolic.Class where
 
 import           Data.Kind       (Type)
-import           Numeric.Natural (Natural)
 
-class Symbolic (c :: Natural -> Type) where
+class Symbolic (c :: (Type -> Type) -> Type) where
     type BaseField c :: Type

--- a/src/ZkFold/Symbolic/Class.hs
+++ b/src/ZkFold/Symbolic/Class.hs
@@ -1,6 +1,6 @@
 module ZkFold.Symbolic.Class where
 
-import           Data.Kind       (Type)
+import           Data.Kind (Type)
 
 class Symbolic (c :: (Type -> Type) -> Type) where
     type BaseField c :: Type

--- a/src/ZkFold/Symbolic/Compiler.hs
+++ b/src/ZkFold/Symbolic/Compiler.hs
@@ -14,7 +14,7 @@ import           Prelude                                             (FilePath, 
                                                                       putStrLn, type (~), ($), (++))
 
 import           ZkFold.Base.Algebra.Basic.Number
-import           ZkFold.Base.Data.Vector                             (unsafeToVector)
+import           ZkFold.Base.Data.Vector                             (unsafeToVector, Vector)
 import           ZkFold.Prelude                                      (writeFileJSON)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (ArithmeticCircuit (..), Circuit (acInput))
@@ -33,7 +33,7 @@ import           ZkFold.Symbolic.Compiler.Arithmetizable
 -}
 
 -- | Arithmetizes an argument by feeding an appropriate amount of inputs.
-solder :: forall a f . (Arithmetizable a f, KnownNat (InputSize a f)) => f -> ArithmeticCircuit a (OutputSize a f)
+solder :: forall a f . (Arithmetizable a f, KnownNat (InputSize a f)) => f -> ArithmeticCircuit a (Vector (OutputSize a f))
 solder f = arithmetize f inputC
     where
         inputList = [1..(value @(InputSize a f))]
@@ -54,7 +54,7 @@ compile f = restore @a c o
 -- | Compiles a function `f` into an arithmetic circuit. Writes the result to a file.
 compileIO :: forall a f . (ToJSON a, Arithmetizable a f, KnownNat (InputSize a f)) => FilePath -> f -> IO ()
 compileIO scriptFile f = do
-    let ac = optimize (solder @a f) :: ArithmeticCircuit a (OutputSize a f)
+    let ac = optimize (solder @a f) :: ArithmeticCircuit a (Vector (OutputSize a f))
 
     putStrLn "\nCompiling the script...\n"
 

--- a/src/ZkFold/Symbolic/Compiler.hs
+++ b/src/ZkFold/Symbolic/Compiler.hs
@@ -14,7 +14,7 @@ import           Prelude                                             (FilePath, 
                                                                       putStrLn, type (~), ($), (++))
 
 import           ZkFold.Base.Algebra.Basic.Number
-import           ZkFold.Base.Data.Vector                             (unsafeToVector, Vector)
+import           ZkFold.Base.Data.Vector                             (Vector, unsafeToVector)
 import           ZkFold.Prelude                                      (writeFileJSON)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (ArithmeticCircuit (..), Circuit (acInput))

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit.hs
@@ -48,7 +48,6 @@ import           Text.Pretty.Simple                                     (pPrint)
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Polynomials.Multivariate           (evalMonomial, evalPolynomial)
-import           ZkFold.Base.Data.Vector                                (Vector)
 import           ZkFold.Prelude                                         (length)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (desugarRange)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Instance    ()
@@ -62,17 +61,17 @@ import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Map
 --------------------------------- High-level functions --------------------------------
 
 -- TODO: make this work for different input types.
-applyArgs :: ArithmeticCircuit a n -> [a] -> ArithmeticCircuit a n
+applyArgs :: ArithmeticCircuit a f -> [a] -> ArithmeticCircuit a f
 applyArgs r args = r { acCircuit = execState (apply args) (acCircuit r) }
 
 -- | Optimizes the constraint system.
 --
 -- TODO: Implement nontrivial optimizations.
-optimize :: ArithmeticCircuit a n -> ArithmeticCircuit a n
+optimize :: ArithmeticCircuit a f -> ArithmeticCircuit a f
 optimize = id
 
 -- | Desugars range constraints into polynomial constraints
-desugarRanges :: Arithmetic a => ArithmeticCircuit a n -> ArithmeticCircuit a n
+desugarRanges :: Arithmetic a => ArithmeticCircuit a f -> ArithmeticCircuit a f
 desugarRanges c@(ArithmeticCircuit r _) =
   let r' = flip execState r . traverse (uncurry desugarRange) $ toList (acRange r)
    in c { acCircuit = r' { acRange = mempty } }
@@ -80,22 +79,22 @@ desugarRanges c@(ArithmeticCircuit r _) =
 ----------------------------------- Information -----------------------------------
 
 -- | Calculates the number of constraints in the system.
-acSizeN :: ArithmeticCircuit a n -> Natural
+acSizeN :: ArithmeticCircuit a f -> Natural
 acSizeN = length . acSystem . acCircuit
 
 -- | Calculates the number of variables in the system.
 -- The constant `1` is not counted.
-acSizeM :: ArithmeticCircuit a n -> Natural
+acSizeM :: ArithmeticCircuit a f -> Natural
 acSizeM = length . acVarOrder . acCircuit
 
-acValue :: ArithmeticCircuit a n -> Vector n a
+acValue :: Functor f => ArithmeticCircuit a f -> f a
 acValue r = eval r mempty
 
 -- | Prints the constraint system, the witness, and the output.
 --
 -- TODO: Move this elsewhere (?)
 -- TODO: Check that all arguments have been applied.
-acPrint :: Show a => ArithmeticCircuit a n -> IO ()
+acPrint :: (Show a, Show (f Natural), Show (f a), Functor f) => ArithmeticCircuit a f -> IO ()
 acPrint ac@(ArithmeticCircuit r o) = do
     let m = elems (acSystem r)
         i = acInput r

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
@@ -29,6 +29,7 @@ import           Data.List                                                 (sort
 import           Data.Map                                                  (elems)
 import           Data.Traversable                                          (for)
 import qualified Data.Zip                                                  as Z
+import           GHC.Generics                                              (Par1 (Par1))
 import           GHC.IsList                                                (IsList (..))
 import           Numeric.Natural                                           (Natural)
 import           Prelude                                                   hiding (Bool, Eq (..), length, negate,
@@ -44,18 +45,18 @@ import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       (Arit
                                                                             Circuit (acSystem), acInput, joinCircuits)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint
 
-boolCheckC :: Arithmetic a => ArithmeticCircuit a n -> ArithmeticCircuit a n
+boolCheckC :: (Arithmetic a, Traversable f) => ArithmeticCircuit a f -> ArithmeticCircuit a f
 -- ^ @boolCheckC r@ computes @r (r - 1)@ in one PLONK constraint.
-boolCheckC r = circuitN $ do
+boolCheckC r = circuitF $ do
     is <- runCircuit r
     for is $ \i -> newAssigned (\x -> let xi = x i in xi * (xi - one))
 
 -- | TODO: This is ONLY needed in ZkFold.Symbolic.Cardano.Contracts.BatchTransfer
 -- Using this function is against the new approach to ArithmeticCircuits
-splitCircuit :: forall n a . ArithmeticCircuit a n -> Vector n (ArithmeticCircuit a 1)
-splitCircuit (ArithmeticCircuit c o) = ArithmeticCircuit c <$> V.chunks @n @1 o
+splitCircuit :: forall f a . Functor f => ArithmeticCircuit a f -> f (ArithmeticCircuit a Par1)
+splitCircuit (ArithmeticCircuit c o) = ArithmeticCircuit c . Par1 <$> o
 
-foldCircuit :: forall n a. Arithmetic a => (forall i m . MonadBlueprint i a m => i -> i -> m i) -> ArithmeticCircuit a n -> ArithmeticCircuit a 1
+foldCircuit :: forall n a. Arithmetic a => (forall i m . MonadBlueprint i a m => i -> i -> m i) -> ArithmeticCircuit a (Vector n) -> ArithmeticCircuit a Par1
 foldCircuit f c = circuit $ do
     outputs <- runCircuit c
     let (element, rest) = V.uncons outputs
@@ -63,17 +64,17 @@ foldCircuit f c = circuit $ do
 
 -- | TODO: Think about circuits with multiple outputs
 --
-embed :: Arithmetic a => a -> ArithmeticCircuit a 1
+embed :: Arithmetic a => a -> ArithmeticCircuit a Par1
 embed x = circuit $ newAssigned $ const (fromConstant x)
 
-embedV :: Arithmetic a => Vector n a -> ArithmeticCircuit a n
-embedV v = circuitN $ for v $ \x -> newAssigned $ const (fromConstant x)
+embedV :: (Arithmetic a, Traversable f) => f a -> ArithmeticCircuit a f
+embedV v = circuitF $ for v $ \x -> newAssigned $ const (fromConstant x)
 
 embedVar :: forall a . a -> (forall i m . MonadBlueprint i a m => m i)
 embedVar x = newAssigned $ const (fromConstant x)
 
-embedAll :: forall a n . (Arithmetic a, KnownNat n) => a -> ArithmeticCircuit a n
-embedAll x = circuitN $ Vector <$> replicateM (fromIntegral $ value @n) (newAssigned $ const (fromConstant x))
+embedAll :: forall a n . (Arithmetic a, KnownNat n) => a -> ArithmeticCircuit a (Vector n)
+embedAll x = circuitF $ Vector <$> replicateM (fromIntegral $ value @n) (newAssigned $ const (fromConstant x))
 
 expansion :: MonadBlueprint i a m => Natural -> i -> m [i]
 -- ^ @expansion n k@ computes a binary expansion of @k@ if it fits in @n@ bits.
@@ -127,23 +128,23 @@ desugarRange i b
           | c == zero = ($ j) * (one - ($ k))
           | otherwise = one + ($ k) * (($ j) - one)
 
-isZeroC :: Arithmetic a => ArithmeticCircuit a n -> ArithmeticCircuit a n
-isZeroC r = circuitN $ fst <$> runInvert r
+isZeroC :: (Arithmetic a, Z.Zip f, Traversable f) => ArithmeticCircuit a f -> ArithmeticCircuit a f
+isZeroC r = circuitF $ fst <$> runInvert r
 
-invertC :: Arithmetic a => ArithmeticCircuit a n -> ArithmeticCircuit a n
-invertC r = circuitN $ snd <$> runInvert r
+invertC :: (Arithmetic a, Z.Zip f, Traversable f) => ArithmeticCircuit a f -> ArithmeticCircuit a f
+invertC r = circuitF $ snd <$> runInvert r
 
-runInvert :: MonadBlueprint i a m => ArithmeticCircuit a n -> m (Vector n i, Vector n i)
+runInvert :: (MonadBlueprint i a m, Z.Zip f, Traversable f) => ArithmeticCircuit a f -> m (f i, f i)
 runInvert r = do
     is <- runCircuit r
     js <- for is $ \i -> newConstrained (\x j -> x i * x j) (\x -> let xi = x i in one - xi // xi)
     ks <- for (Z.zip is js) $ \(i, j) -> newConstrained (\x k -> x i * x k + x j - one) (finv . ($ i))
     return (js, ks)
 
-embedVarIndex :: Arithmetic a => Natural -> ArithmeticCircuit a 1
+embedVarIndex :: Arithmetic a => Natural -> ArithmeticCircuit a Par1
 embedVarIndex n = ArithmeticCircuit { acCircuit = mempty { acInput = [ n ]}, acOutput = pure n}
 
-embedVarIndexV :: (Arithmetic a, KnownNat n) => Natural -> ArithmeticCircuit a n
+embedVarIndexV :: (Arithmetic a, KnownNat n) => Natural -> ArithmeticCircuit a (Vector n)
 embedVarIndexV n = ArithmeticCircuit { acCircuit = mempty { acInput = [ n ]}, acOutput = pure n}
 
 getAllVars :: MultiplicativeMonoid a => Circuit a -> [Natural]

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -8,12 +8,13 @@
 
 module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Instance where
 
-import           Control.Monad                                             (foldM, guard, replicateM)
+import           Control.Monad                                             (foldM, replicateM)
 import           Data.Aeson                                                hiding (Bool)
 import           Data.Map                                                  hiding (drop, foldl, foldl', foldr, map,
                                                                             null, splitAt, take)
-import           Data.Traversable                                          (for)
+import           Data.Traversable                                          (Traversable, for)
 import qualified Data.Zip                                                  as Z
+import           GHC.Generics                                              (Par1 (..))
 import           GHC.Num                                                   (integerToNatural)
 import           Numeric.Natural                                           (Natural)
 import           Prelude                                                   (Integer, Show, const, id, mempty, pure,
@@ -26,14 +27,14 @@ import           Test.QuickCheck                                           (Arbi
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Number
+import           ZkFold.Base.Data.Par1                                     ()
 import qualified ZkFold.Base.Data.Vector                                   as V
 import           ZkFold.Base.Data.Vector                                   (Vector (..))
-import           ZkFold.Prelude                                            (length)
 import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embedAll, embedV, expansion, foldCircuit,
-                                                                            getAllVars, horner, invertC, isZeroC)
+                                                                            getAllVars, horner, invertC, isZeroC, embed)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       hiding (constraint)
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint (..), circuit, circuitN)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint (..), circuit, circuitF)
 import           ZkFold.Symbolic.Compiler.Arithmetizable                   (Arithmetizable, SymbolicData (..))
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.Conditional
@@ -45,12 +46,19 @@ import           ZkFold.Symbolic.Data.Eq
 instance Symbolic (ArithmeticCircuit a) where
     type BaseField (ArithmeticCircuit a) = a
 
-instance Arithmetic a => SymbolicData a (ArithmeticCircuit a n) where
-    type TypeSize a (ArithmeticCircuit a n) = n
+instance Arithmetic a => SymbolicData a (ArithmeticCircuit a (Vector n)) where
+    type TypeSize a (ArithmeticCircuit a (Vector n)) = n
 
     pieces = id
 
     restore = ArithmeticCircuit
+
+instance Arithmetic a => SymbolicData a (ArithmeticCircuit a Par1) where
+    type TypeSize a (ArithmeticCircuit a Par1) = 1
+
+    pieces = mapOutputs (V.singleton . unPar1)
+
+    restore r o = mapOutputs (Par1 . V.item) $ withOutputs r o
 
 deriving newtype instance Arithmetic a => SymbolicData a (Bool (ArithmeticCircuit a))
 deriving newtype instance Arithmetic a => Arithmetizable a (Bool (ArithmeticCircuit a))
@@ -59,59 +67,76 @@ deriving newtype instance Arithmetic a => Arithmetizable a (Bool (ArithmeticCirc
 instance
     ( KnownNat (n * Order a)
     , KnownNat (Log2 (n * Order a - 1) + 1)
-    ) => Finite (ArithmeticCircuit a n) where
-    type Order (ArithmeticCircuit a n) = n * Order a
+    ) => Finite (ArithmeticCircuit a (Vector n)) where
+    type Order (ArithmeticCircuit a (Vector n)) = n * Order a
 
-instance Arithmetic a => AdditiveSemigroup (ArithmeticCircuit a n) where
-    r1 + r2 = circuitN $ do
+instance (Arithmetic a, Z.Zip f, Traversable f) => AdditiveSemigroup (ArithmeticCircuit a f) where
+    r1 + r2 = circuitF $ do
         is <- runCircuit r1
         js <- runCircuit r2
         for (Z.zip is js) $ \(i, j) -> newAssigned (\x -> x i + x j)
 
-instance (Arithmetic a, Scale c a) => Scale c (ArithmeticCircuit a n) where
-    scale c r = circuitN $ do
+instance (Arithmetic a, Scale c a, Traversable f) => Scale c (ArithmeticCircuit a f) where
+    scale c r = circuitF $ do
         is <- runCircuit r
         for is $ \i -> newAssigned (\x -> (c `scale` one :: a) `scale` x i)
 
-instance (Arithmetic a, KnownNat n) => AdditiveMonoid (ArithmeticCircuit a n) where
-    zero = circuitN $ Vector <$> replicateM (Haskell.fromIntegral $ value @n) (newAssigned (const zero))
+instance (Arithmetic a, KnownNat n) => AdditiveMonoid (ArithmeticCircuit a (Vector n)) where
+    zero = circuitF $ Vector <$> replicateM (Haskell.fromIntegral $ value @n) (newAssigned (const zero))
 
-instance (Arithmetic a, KnownNat n) => AdditiveGroup (ArithmeticCircuit a n) where
-    negate r = circuitN $ do
+instance Arithmetic a => AdditiveMonoid (ArithmeticCircuit a Par1) where
+    zero = embed zero
+
+instance (Arithmetic a, Z.Zip f, Traversable f, AdditiveMonoid (ArithmeticCircuit a f)) => AdditiveGroup (ArithmeticCircuit a f) where
+    negate r = circuitF $ do
         is <- runCircuit r
         for is $ \i -> newAssigned (\x -> negate (x i))
 
-    r1 - r2 = circuitN $ do
+    r1 - r2 = circuitF $ do
         is <- runCircuit r1
         js <- runCircuit r2
         for (Z.zip is js) $ \(i, j) -> newAssigned (\x -> x i - x j)
 
-instance Arithmetic a => MultiplicativeSemigroup (ArithmeticCircuit a n) where
-    r1 * r2 = circuitN $ do
+instance (Arithmetic a, Z.Zip f, Traversable f) => MultiplicativeSemigroup (ArithmeticCircuit a f) where
+    r1 * r2 = circuitF $ do
         is <- runCircuit r1
         js <- runCircuit r2
         for (Z.zip is js) $ \(i, j) -> newAssigned (\x -> x i * x j)
 
-instance (Arithmetic a, KnownNat n) => Exponent (ArithmeticCircuit a n) Natural where
+instance MultiplicativeMonoid (ArithmeticCircuit a f) => Exponent (ArithmeticCircuit a f) Natural where
     (^) = natPow
 
-instance (Arithmetic a, KnownNat n) => MultiplicativeMonoid (ArithmeticCircuit a n) where
+instance (Arithmetic a, KnownNat n) => MultiplicativeMonoid (ArithmeticCircuit a (Vector n)) where
     one = embedV (pure one)
 
+instance Arithmetic a => MultiplicativeMonoid (ArithmeticCircuit a Par1) where
+    one = embed one
+
 -- TODO: The constant will be replicated in all outputs. Is this the desired behaviour?
-instance (Arithmetic a, FromConstant b a, KnownNat n) => FromConstant b (ArithmeticCircuit a n) where
+instance (Arithmetic a, FromConstant b a, KnownNat n) => FromConstant b (ArithmeticCircuit a (Vector n)) where
     fromConstant c = embedAll (fromConstant c)
 
-instance (Arithmetic a, KnownNat n) => Semiring (ArithmeticCircuit a n)
+instance (Arithmetic a, FromConstant b a) => FromConstant b (ArithmeticCircuit a Par1) where
+    fromConstant c = embed (fromConstant c)
 
-instance (Arithmetic a, KnownNat n) => Ring (ArithmeticCircuit a n)
+instance (Arithmetic a, KnownNat n) => Semiring (ArithmeticCircuit a (Vector n))
 
-instance (Arithmetic a, KnownNat n) => Exponent (ArithmeticCircuit a n) Integer where
+instance Arithmetic a => Semiring (ArithmeticCircuit a Par1)
+
+instance (Arithmetic a, KnownNat n) => Ring (ArithmeticCircuit a (Vector n))
+
+instance Arithmetic a => Ring (ArithmeticCircuit a Par1)
+
+instance (Arithmetic a, Field (ArithmeticCircuit a f)) => Exponent (ArithmeticCircuit a f) Integer where
     (^) = intPowF
 
-instance (Arithmetic a, KnownNat n) => Field (ArithmeticCircuit a n) where
+instance (Arithmetic a, KnownNat n) => Field (ArithmeticCircuit a (Vector n)) where
     finv = invertC
     rootOfUnity n = embedAll <$> rootOfUnity n
+
+instance Arithmetic a => Field (ArithmeticCircuit a Par1) where
+    finv = invertC
+    rootOfUnity n = embed <$> rootOfUnity n
 
 -- TODO: The only implementation that seems to make sense is when there is only one output.
 -- It is true?
@@ -121,18 +146,18 @@ instance (Arithmetic a, KnownNat n) => Field (ArithmeticCircuit a n) where
 --
 -- Ideally, we want to return another ArithmeticCircuit with a number of outputs corresponding to the number of bits.
 -- This does not align well with the type of @binaryExpansion@
-instance Arithmetic a => BinaryExpansion (ArithmeticCircuit a 1) where
-    type Bits (ArithmeticCircuit a 1) = ArithmeticCircuit a (NumberOfBits a)
-    binaryExpansion r = circuitN $ do
+instance Arithmetic a => BinaryExpansion (ArithmeticCircuit a Par1) where
+    type Bits (ArithmeticCircuit a Par1) = ArithmeticCircuit a (Vector (NumberOfBits a))
+    binaryExpansion r = circuitF $ do
         output <- runCircuit r
-        bits   <- expansion (numberOfBits @a) . V.item $ output
+        bits   <- expansion (numberOfBits @a) . unPar1 $ output
         pure $ V.unsafeToVector bits
     fromBinary bits = circuit $ runCircuit bits >>= horner . V.fromVector
 
-instance (Arithmetic a, KnownNat n) => DiscreteField' (ArithmeticCircuit a n) where
+instance (Arithmetic a, Z.Zip f, Traversable f, Field (ArithmeticCircuit a f)) => DiscreteField' (ArithmeticCircuit a f) where
     equal r1 r2 = isZeroC (r1 - r2)
 
-instance Arithmetic a => TrichotomyField (ArithmeticCircuit a 1) where
+instance Arithmetic a => TrichotomyField (ArithmeticCircuit a Par1) where
     trichotomy r1 r2 =
         let
             bits1 = binaryExpansion r1
@@ -145,12 +170,15 @@ instance Arithmetic a => TrichotomyField (ArithmeticCircuit a 1) where
         in
             foldCircuit reverseLexicographical comparedBits
 
-instance (Arithmetic a, KnownNat n, 1 <= n) => DiscreteField (Bool (ArithmeticCircuit a)) (ArithmeticCircuit a n) where
+instance (Arithmetic a, KnownNat n, 1 <= n) => DiscreteField (Bool (ArithmeticCircuit a)) (ArithmeticCircuit a (Vector n)) where
     isZero x = Bool $ circuit $ do
         bools <- runCircuit $ isZeroC x
         foldM (\i j -> newAssigned (\p -> p i * p j)) (V.head bools) (V.tail bools)
 
-instance (Arithmetic a, KnownNat n, 1 <= n) => Eq (Bool (ArithmeticCircuit a)) (ArithmeticCircuit a n) where
+instance Arithmetic a => DiscreteField (Bool (ArithmeticCircuit a)) (ArithmeticCircuit a Par1) where
+    isZero = Bool . isZeroC
+
+instance (Arithmetic a, DiscreteField (Bool (ArithmeticCircuit a)) (ArithmeticCircuit a f)) => Eq (Bool (ArithmeticCircuit a)) (ArithmeticCircuit a f) where
     x == y = isZero (x - y)
     x /= y = not $ isZero (x - y)
 
@@ -159,22 +187,22 @@ instance (SymbolicData a x, n ~ TypeSize a x, KnownNat n) => Conditional (Bool (
         where
             f' = pieces brFalse
             t' = pieces brTrue
-            ArithmeticCircuit c o = circuitN solve
+            ArithmeticCircuit c o = circuitF solve
 
             solve :: forall i m . MonadBlueprint i a m => m (Vector n i)
             solve = do
                 ts <- runCircuit t'
                 fs <- runCircuit f'
-                bs <- V.item <$> runCircuit b
+                bs <- unPar1 <$> runCircuit b
                 V.zipWithM (\x y -> newAssigned $ \p -> p bs * (p x - p y) + p y) ts fs
 
-instance (Arithmetic a, Arbitrary a) => Arbitrary (ArithmeticCircuit a 1) where
+instance (Arithmetic a, Arbitrary a) => Arbitrary (ArithmeticCircuit a Par1) where
     arbitrary = do
         k <- integerToNatural <$> chooseInteger (2, 10)
         let ac = ArithmeticCircuit { acCircuit = mempty {acInput = [1..k]}, acOutput = pure k }
         arbitrary' ac 10
 
-arbitrary' :: forall a . (Arithmetic a, Arbitrary a, FromConstant a a) => ArithmeticCircuit a 1 -> Natural -> Gen (ArithmeticCircuit a 1)
+arbitrary' :: forall a . (Arithmetic a, Arbitrary a, FromConstant a a) => ArithmeticCircuit a Par1 -> Natural -> Gen (ArithmeticCircuit a Par1)
 arbitrary' ac 0 = return ac
 arbitrary' ac iter = do
     let vars = getAllVars . acCircuit $ ac
@@ -190,33 +218,31 @@ arbitrary' ac iter = do
     arbitrary' ac' (iter -! 1)
 
 -- TODO: make it more readable
-instance (FiniteField a, Haskell.Eq a, Show a) => Show (ArithmeticCircuit a n) where
+instance (FiniteField a, Haskell.Eq a, Show a, Show (f Natural)) => Show (ArithmeticCircuit a f) where
     show (ArithmeticCircuit r o) = "ArithmeticCircuit { acInput = " ++ show (acInput r)
         ++ "\n, acSystem = " ++ show (acSystem r) ++ "\n, acOutput = " ++ show o ++ "\n, acVarOrder = " ++ show (acVarOrder r) ++ " }"
 
 -- TODO: add witness generation info to the JSON object
-instance ToJSON a => ToJSON (ArithmeticCircuit a n) where
+instance (ToJSON a, ToJSON (f Natural)) => ToJSON (ArithmeticCircuit a f) where
     toJSON (ArithmeticCircuit r o) = object
         [
             "system" .= acSystem r,
             "input"  .= acInput r,
-            "output" .= V.fromVector o,
+            "output" .= o,
             "order"  .= acVarOrder r
         ]
 
 -- TODO: properly restore the witness generation function
 -- TODO: Check that there are exactly N outputs
-instance (FromJSON a, KnownNat n) => FromJSON (ArithmeticCircuit a n) where
+instance (FromJSON a, FromJSON (f Natural)) => FromJSON (ArithmeticCircuit a f) where
     parseJSON =
         withObject "ArithmeticCircuit" $ \v -> do
             acSystem   <- v .: "system"
             acRange    <- v .: "range"
             acInput    <- v .: "input"
             acVarOrder <- v .: "order"
-            outs       <- v .: "output"
-            guard (length v Haskell.== value @n)
+            acOutput   <- v .: "output"
             let acWitness = empty
                 acRNG     = mkStdGen 0
-                acOutput  = Vector outs
                 acCircuit = Circuit{..}
             pure ArithmeticCircuit{..}

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -31,8 +31,9 @@ import           ZkFold.Base.Data.Par1                                     ()
 import qualified ZkFold.Base.Data.Vector                                   as V
 import           ZkFold.Base.Data.Vector                                   (Vector (..))
 import           ZkFold.Symbolic.Class
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embedAll, embedV, expansion, foldCircuit,
-                                                                            getAllVars, horner, invertC, isZeroC, embed)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embed, embedAll, embedV, expansion,
+                                                                            foldCircuit, getAllVars, horner, invertC,
+                                                                            isZeroC)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       hiding (constraint)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint (..), circuit, circuitF)
 import           ZkFold.Symbolic.Compiler.Arithmetizable                   (Arithmetizable, SymbolicData (..))

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Map.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Map.hs
@@ -9,6 +9,7 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Map (
 import           Data.Map                                               hiding (drop, foldl, foldr, fromList, map, null,
                                                                          splitAt, take, toList)
 import qualified Data.Map                                               as Map
+import           GHC.Generics                                           (Par1)
 import           GHC.IsList                                             (IsList (..))
 import           GHC.Natural                                            (naturalToInteger)
 import           GHC.Num                                                (integerToInt)
@@ -26,17 +27,17 @@ import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal    (Arithme
 
 -- This module contains functions for mapping variables in arithmetic circuits.
 
-data ArithmeticCircuitTest a n = ArithmeticCircuitTest
+data ArithmeticCircuitTest a f = ArithmeticCircuitTest
     {
-        arithmeticCircuit :: ArithmeticCircuit a n
+        arithmeticCircuit :: ArithmeticCircuit a f
         , witnessInput    :: Map.Map Natural a
     }
 
-instance (Show (ArithmeticCircuit a n), Show a) => Show (ArithmeticCircuitTest a n) where
+instance (Show (ArithmeticCircuit a f), Show a) => Show (ArithmeticCircuitTest a f) where
     show (ArithmeticCircuitTest ac wi) = show ac ++ ",\nwitnessInput: " ++ show wi
 
-instance (Arithmetic a, Arbitrary a, Arbitrary (ArithmeticCircuit a 1)) => Arbitrary (ArithmeticCircuitTest a 1) where
-    arbitrary :: Gen (ArithmeticCircuitTest a 1)
+instance (Arithmetic a, Arbitrary a, Arbitrary (ArithmeticCircuit a Par1)) => Arbitrary (ArithmeticCircuitTest a Par1) where
+    arbitrary :: Gen (ArithmeticCircuitTest a Par1)
     arbitrary = do
         ac <- arbitrary
         let keysAC = inputVariables ac
@@ -47,7 +48,7 @@ instance (Arithmetic a, Arbitrary a, Arbitrary (ArithmeticCircuit a 1)) => Arbit
             , witnessInput = wi
             }
 
-mapVarArithmeticCircuit :: MultiplicativeMonoid a => ArithmeticCircuitTest a n -> ArithmeticCircuitTest a n
+mapVarArithmeticCircuit :: (MultiplicativeMonoid a, Functor f) => ArithmeticCircuitTest a f -> ArithmeticCircuitTest a f
 mapVarArithmeticCircuit (ArithmeticCircuitTest ac wi) =
     let ct = acCircuit ac
         vars = getAllVars ct

--- a/src/ZkFold/Symbolic/Data/Conditional.hs
+++ b/src/ZkFold/Symbolic/Data/Conditional.hs
@@ -2,9 +2,9 @@ module ZkFold.Symbolic.Data.Conditional where
 
 import           Data.Function                     (($), (.))
 import           Data.Zip                          (zipWith)
+import           GHC.Generics                      (Par1 (..))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Data.Vector           (item)
 import           ZkFold.Symbolic.Data.Bool         (Bool (Bool))
 import           ZkFold.Symbolic.Data.FieldElement
 import           ZkFold.Symbolic.Interpreter       (Interpreter (..))
@@ -19,8 +19,7 @@ class Conditional b a where
     (?) = gif
 
 instance (Ring a, FieldElementData (Interpreter a) x) => Conditional (Bool (Interpreter a)) x where
-    bool x y (Bool (Interpreter b)) =
-      let b' = item b
-       in fromFieldElements . Interpreter $ zipWith (\x' y' -> (one - b') * x' + b' * y')
-              (runInterpreter $ toFieldElements x)
-              (runInterpreter $ toFieldElements y)
+    bool x y (Bool (Interpreter (Par1 b))) =
+       fromFieldElements . Interpreter $ zipWith (\x' y' -> (one - b) * x' + b * y')
+          (runInterpreter $ toFieldElements x)
+          (runInterpreter $ toFieldElements y)

--- a/src/ZkFold/Symbolic/Data/Ed25519.hs
+++ b/src/ZkFold/Symbolic/Data/Ed25519.hs
@@ -19,6 +19,7 @@ import           ZkFold.Base.Algebra.EllipticCurve.Ed25519
 import qualified ZkFold.Base.Data.Vector                                as V
 import           ZkFold.Symbolic.Compiler                               hiding (forceZero)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (joinCircuits)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal    (mapOutputs)
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.ByteString
 import           ZkFold.Symbolic.Data.Combinators
@@ -26,6 +27,7 @@ import           ZkFold.Symbolic.Data.Conditional
 import           ZkFold.Symbolic.Data.Eq
 import           ZkFold.Symbolic.Data.UInt
 import           ZkFold.Symbolic.Interpreter
+import GHC.Generics ((:*:)(..))
 
 zpToEd :: (Finite (Zp p)) => Point (Ed25519 UInt (Zp p)) -> Point (Ed25519 Void Void)
 zpToEd Inf         = Inf
@@ -69,8 +71,8 @@ instance
 
     -- (0, 0) is never on a Twisted Edwards curve for any curve parameters.
     -- We can encode the point at infinity as (0, 0), therefore.
-    pieces Inf         = pieces (zero :: UInt 256 (ArithmeticCircuit a)) `joinCircuits` pieces (zero :: UInt 256 (ArithmeticCircuit a))
-    pieces (Point x y) = pieces x `joinCircuits` pieces y
+    pieces Inf         = mapOutputs (\(q :*: r) -> q `V.append` r) $ pieces (zero :: UInt 256 (ArithmeticCircuit a)) `joinCircuits` pieces (zero :: UInt 256 (ArithmeticCircuit a))
+    pieces (Point x y) = mapOutputs (\(q :*: r) -> q `V.append` r) $ pieces x `joinCircuits` pieces y
 
     restore c o = bool @(Bool (ArithmeticCircuit a)) @(Point (Ed25519 ArithmeticCircuit a)) (Point x y) Inf ((x == zero) && (y == zero))
         where

--- a/src/ZkFold/Symbolic/Data/Ed25519.hs
+++ b/src/ZkFold/Symbolic/Data/Ed25519.hs
@@ -7,6 +7,7 @@
 module ZkFold.Symbolic.Data.Ed25519  where
 
 import           Data.Void                                              (Void)
+import           GHC.Generics                                           ((:*:) (..))
 import           GHC.TypeNats                                           (Natural)
 import           Prelude                                                (type (~), ($), (.))
 import qualified Prelude                                                as P
@@ -27,7 +28,6 @@ import           ZkFold.Symbolic.Data.Conditional
 import           ZkFold.Symbolic.Data.Eq
 import           ZkFold.Symbolic.Data.UInt
 import           ZkFold.Symbolic.Interpreter
-import GHC.Generics ((:*:)(..))
 
 zpToEd :: (Finite (Zp p)) => Point (Ed25519 UInt (Zp p)) -> Point (Ed25519 Void Void)
 zpToEd Inf         = Inf

--- a/src/ZkFold/Symbolic/Data/Eq.hs
+++ b/src/ZkFold/Symbolic/Data/Eq.hs
@@ -6,6 +6,7 @@ module ZkFold.Symbolic.Data.Eq (
 import           Data.Bool                               (bool)
 import qualified Data.Eq                                 as Haskell
 import           Data.Foldable                           (Foldable)
+import           GHC.Generics                            (Par1)
 
 import           ZkFold.Symbolic.Compiler.Arithmetizable (Arithmetic)
 import           ZkFold.Symbolic.Data.Bool               (Bool, BoolType (..), any)
@@ -21,6 +22,6 @@ class Eq b a where
 elem :: (BoolType b, Eq b a, Foldable t) => a -> t a -> b
 elem x = any (== x)
 
-instance Arithmetic a => Eq (Bool (Interpreter a)) (Interpreter a 1) where
+instance Arithmetic a => Eq (Bool (Interpreter a)) (Interpreter a Par1) where
     x == y = bool false true (x Haskell.== y)
     x /= y = bool false true (x Haskell./= y)

--- a/src/ZkFold/Symbolic/Data/Eq/Structural.hs
+++ b/src/ZkFold/Symbolic/Data/Eq/Structural.hs
@@ -5,6 +5,7 @@ module ZkFold.Symbolic.Data.Eq.Structural where
 
 import           Prelude                   (type (~))
 
+import           ZkFold.Base.Data.Vector   (Vector)
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.Eq
@@ -15,7 +16,7 @@ newtype Structural a = Structural a
 instance
     ( SymbolicData a x
     , n ~ TypeSize a x
-    , Eq (Bool (ArithmeticCircuit a)) (ArithmeticCircuit a n)
+    , Eq (Bool (ArithmeticCircuit a)) (ArithmeticCircuit a (Vector n))
     ) => Eq (Bool (ArithmeticCircuit a)) (Structural x) where
 
     Structural x == Structural y =

--- a/src/ZkFold/Symbolic/Data/FFA.hs
+++ b/src/ZkFold/Symbolic/Data/FFA.hs
@@ -24,7 +24,7 @@ import           ZkFold.Base.Data.Vector
 import           ZkFold.Prelude                                            (iterateM, length)
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (expansion, splitExpansion)
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint, circuitN, newAssigned,
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint, circuitF, newAssigned,
                                                                             runCircuit)
 import           ZkFold.Symbolic.Data.Combinators                          (log2, maxBitsPerFieldElement)
 import           ZkFold.Symbolic.Data.Ord                                  (blueprintGE)
@@ -33,7 +33,7 @@ import           ZkFold.Symbolic.Interpreter
 type Size = 7
 
 -- | Foreign-field arithmetic based on https://cr.yp.to/papers/mmecrt.pdf
-newtype FFA (p :: Natural) b = FFA (b Size)
+newtype FFA (p :: Natural) b = FFA (b (Vector Size))
 
 deriving newtype instance Arithmetic a => SymbolicData a (FFA p (ArithmeticCircuit a))
 deriving newtype instance Arithmetic a => Arithmetizable a (FFA p (ArithmeticCircuit a))
@@ -87,8 +87,8 @@ instance (FromConstant c (Zp p), Finite (Zp q)) => FromConstant c (FFA p (Interp
 instance (FromConstant c (Zp p), Arithmetic a) => FromConstant c (FFA p (ArithmeticCircuit a)) where
   fromConstant = FFA . impl . toConstant . (fromConstant :: c -> Zp p)
     where
-      impl :: Natural -> ArithmeticCircuit a Size
-      impl x = circuitN $ for (coprimes @a) $ \m -> newAssigned (fromConstant (x `mod` m))
+      impl :: Natural -> ArithmeticCircuit a (Vector Size)
+      impl x = circuitF $ for (coprimes @a) $ \m -> newAssigned (fromConstant (x `mod` m))
 
 condSubOF :: forall i a m . MonadBlueprint i a m => Natural -> i -> m (i, i)
 condSubOF m i = do
@@ -142,7 +142,7 @@ instance (Finite (Zp p), Finite (Zp q)) => MultiplicativeSemigroup (FFA p (Inter
   x * y = fromConstant (toConstant x * toConstant y :: Zp p)
 
 instance (KnownNat p, Arithmetic a) => MultiplicativeSemigroup (FFA p (ArithmeticCircuit a)) where
-  FFA q * FFA r = FFA $ circuitN $ do
+  FFA q * FFA r = FFA $ circuitF $ do
     xs <- runCircuit q
     ys <- runCircuit r
     zs <- zipWithM (\i j -> newAssigned (($ i) * ($ j))) xs ys
@@ -164,7 +164,7 @@ instance (Finite (Zp p), Finite (Zp q)) => AdditiveSemigroup (FFA p (Interpreter
   x + y = fromConstant (toConstant x + toConstant y :: Zp p)
 
 instance (KnownNat p, Arithmetic a) => AdditiveSemigroup (FFA p (ArithmeticCircuit a)) where
-  FFA q + FFA r = FFA $ circuitN $ do
+  FFA q + FFA r = FFA $ circuitF $ do
     xs <- runCircuit q
     ys <- runCircuit r
     zs <- zipWithM (\i j -> newAssigned (($ i) + ($ j))) xs ys
@@ -183,7 +183,7 @@ instance (Finite (Zp p), Finite (Zp q)) => AdditiveGroup (FFA p (Interpreter (Zp
   negate = fromConstant . negate @(Zp p) . toConstant
 
 instance (Finite (Zp p), Arithmetic a) => AdditiveGroup (FFA p (ArithmeticCircuit a)) where
-  negate (FFA r) = FFA $ circuitN $ do
+  negate (FFA r) = FFA $ circuitF $ do
     xs <- runCircuit r
     ys <- zipWithM (\i m -> newAssigned $ fromConstant m - ($ i)) xs $ coprimes @a
     cast @p ys

--- a/src/ZkFold/Symbolic/Data/List.hs
+++ b/src/ZkFold/Symbolic/Data/List.hs
@@ -2,13 +2,14 @@ module ZkFold.Symbolic.Data.List where
 
 import           Data.Foldable                     (Foldable (..))
 import           Data.Kind                         (Type)
-import           GHC.TypeNats                      (Natural)
+import           GHC.Generics                      (Par1)
 import           Prelude                           (flip, undefined, (.))
 
+import           ZkFold.Base.Data.Vector           (Vector)
 import           ZkFold.Symbolic.Data.Bool         (Bool)
 import           ZkFold.Symbolic.Data.FieldElement (FieldElementData (..))
 
-data List (context :: Natural -> Type) x = List (context (TypeSize context x)) (context 1)
+data List (context :: (Type -> Type) -> Type) x = List (context (Vector (TypeSize context x))) (context Par1)
 
 emptyList :: List context x
 emptyList = undefined

--- a/src/ZkFold/Symbolic/Interpreter.hs
+++ b/src/ZkFold/Symbolic/Interpreter.hs
@@ -1,58 +1,60 @@
-module ZkFold.Symbolic.Interpreter (Interpreter (..)) where
+module ZkFold.Symbolic.Interpreter (Interpreter (..), mapInterpreter) where
 
 import           Control.DeepSeq                 (NFData)
 import           Data.Eq                         (Eq)
 import           Data.Function                   ((.))
 import           Data.Functor                    ((<$>))
-import           GHC.Generics                    (Generic)
+import           GHC.Generics                    (Generic, Par1 (Par1))
 import           Text.Show                       (Show)
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Data.Vector         (Vector, item, singleton)
 import           ZkFold.Symbolic.Class
 
-newtype Interpreter a n = Interpreter { runInterpreter :: Vector n a }
+newtype Interpreter a f = Interpreter { runInterpreter :: f a }
     deriving (Eq, Show, Generic, NFData)
 
 instance Symbolic (Interpreter a) where
     type BaseField (Interpreter a) = a
 
-value :: Interpreter a 1 -> a
-value (Interpreter (item -> x)) = x
+mapInterpreter :: (forall i . f i -> g i) -> Interpreter a f -> Interpreter a g
+mapInterpreter f (Interpreter x) = Interpreter (f x)
 
-const :: a -> Interpreter a 1
-const = Interpreter . singleton
+value :: Interpreter a Par1 -> a
+value (Interpreter (Par1 x)) = x
 
-instance MultiplicativeSemigroup a => MultiplicativeSemigroup (Interpreter a 1) where
+const :: a -> Interpreter a Par1
+const = Interpreter . Par1
+
+instance MultiplicativeSemigroup a => MultiplicativeSemigroup (Interpreter a Par1) where
   (value -> x) * (value -> y) = const (x * y)
 
-instance Exponent a p => Exponent (Interpreter a 1) p where
+instance Exponent a p => Exponent (Interpreter a Par1) p where
   (value -> x) ^ p = const (x ^ p)
 
-instance MultiplicativeMonoid a => MultiplicativeMonoid (Interpreter a 1) where
+instance MultiplicativeMonoid a => MultiplicativeMonoid (Interpreter a Par1) where
   one = const one
 
-instance Scale c a => Scale c (Interpreter a 1) where
+instance Scale c a => Scale c (Interpreter a Par1) where
   scale k (value -> x) = const (scale k x)
 
-instance AdditiveSemigroup a => AdditiveSemigroup (Interpreter a 1) where
+instance AdditiveSemigroup a => AdditiveSemigroup (Interpreter a Par1) where
   (value -> x) + (value -> y) = const (x + y)
 
-instance AdditiveMonoid a => AdditiveMonoid (Interpreter a 1) where
+instance AdditiveMonoid a => AdditiveMonoid (Interpreter a Par1) where
   zero = const zero
 
-instance AdditiveGroup a => AdditiveGroup (Interpreter a 1) where
+instance AdditiveGroup a => AdditiveGroup (Interpreter a Par1) where
   negate (value -> x) = const (negate x)
   (value -> x) - (value -> y) = const (x - y)
 
-instance FromConstant c a => FromConstant c (Interpreter a 1) where
+instance FromConstant c a => FromConstant c (Interpreter a Par1) where
   fromConstant = const . fromConstant
 
-instance Semiring a => Semiring (Interpreter a 1)
+instance Semiring a => Semiring (Interpreter a Par1)
 
-instance Ring a => Ring (Interpreter a 1)
+instance Ring a => Ring (Interpreter a Par1)
 
-instance Field a => Field (Interpreter a 1) where
+instance Field a => Field (Interpreter a Par1) where
   finv (value -> x) = const (finv x)
   (value -> x) // (value -> y) = const (x // y)
   rootOfUnity n = const <$> rootOfUnity n

--- a/tests/Tests/ArithmeticCircuit.hs
+++ b/tests/Tests/ArithmeticCircuit.hs
@@ -5,6 +5,7 @@
 module Tests.ArithmeticCircuit (exec1, it, specArithmeticCircuit) where
 
 import           Data.Bool                                              (bool)
+import           GHC.Generics                                           (Par1)
 import           Prelude                                                (IO, Show, String, id, ($))
 import qualified Prelude                                                as Haskell
 import qualified Test.Hspec
@@ -20,7 +21,6 @@ import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (embed)
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.DiscreteField
 import           ZkFold.Symbolic.Data.Eq
-import GHC.Generics (Par1)
 
 correctHom0 :: forall a . (Arithmetic a, FromConstant a a, Scale a a, Show a) => (forall b . Field b => b) -> Property
 correctHom0 f = let r = f in withMaxSuccess 1 $ checkClosedCircuit r .&&. exec1 r === f @a

--- a/tests/Tests/ArithmeticCircuit.hs
+++ b/tests/Tests/ArithmeticCircuit.hs
@@ -20,6 +20,7 @@ import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (embed)
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.DiscreteField
 import           ZkFold.Symbolic.Data.Eq
+import GHC.Generics (Par1)
 
 correctHom0 :: forall a . (Arithmetic a, FromConstant a a, Scale a a, Show a) => (forall b . Field b => b) -> Property
 correctHom0 f = let r = f in withMaxSuccess 1 $ checkClosedCircuit r .&&. exec1 r === f @a
@@ -45,19 +46,19 @@ specArithmeticCircuit' = hspec $ do
         it "inverts nonzero correctly" $ correctHom1 @a finv
         it "inverts zero correctly" $ correctHom0 @a (finv zero)
         it "checks isZero(nonzero)" $ \(x :: a) ->
-          let Bool (r :: ArithmeticCircuit a 1) = isZero (embed x)
+          let Bool (r :: ArithmeticCircuit a Par1) = isZero (embed x)
            in checkClosedCircuit r .&&. exec1 r === bool zero one (x Haskell.== zero)
         it "checks isZero(0)" $
-          let Bool (r :: ArithmeticCircuit a 1) = isZero (zero :: ArithmeticCircuit a 1)
+          let Bool (r :: ArithmeticCircuit a Par1) = isZero (zero :: ArithmeticCircuit a Par1)
            in withMaxSuccess 1 $ checkClosedCircuit r .&&. exec1 r === one
         it "computes binary expansion" $ \(x :: a) ->
           let rs = binaryExpansion (embed x)
            in checkClosedCircuit rs .&&. V.fromVector (exec rs) === padBits (numberOfBits @a) (binaryExpansion x)
         it "internalizes equality" $ \(x :: a) (y :: a) ->
-          let Bool (r :: ArithmeticCircuit a 1) = embed x == embed y
+          let Bool (r :: ArithmeticCircuit a Par1) = embed x == embed y
            in checkClosedCircuit r .&&. exec1 r === bool zero one (x Haskell.== y)
         it "internal equality is reflexive" $ \(x :: a) ->
-          let Bool (r :: ArithmeticCircuit a 1) = embed x == embed x
+          let Bool (r :: ArithmeticCircuit a Par1) = embed x == embed x
            in checkClosedCircuit r .&&. exec1 r === one
 
 specArithmeticCircuit :: IO ()

--- a/tests/Tests/Arithmetization.hs
+++ b/tests/Tests/Arithmetization.hs
@@ -3,6 +3,7 @@
 
 module Tests.Arithmetization (specArithmetization) where
 
+import           GHC.Generics                                   (Par1)
 import           Prelude
 import           Test.Hspec
 import           Test.QuickCheck
@@ -17,14 +18,14 @@ import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Map (ArithmeticCircuitTest (..))
 
-propCircuitInvariance :: (MultiplicativeMonoid a, Eq a) => ArithmeticCircuitTest a 1 -> Bool
+propCircuitInvariance :: (MultiplicativeMonoid a, Eq a) => ArithmeticCircuitTest a Par1 -> Bool
 propCircuitInvariance act@(ArithmeticCircuitTest ac wi) =
     let ArithmeticCircuitTest ac' wi' = mapVarArithmeticCircuit act
         v   = ac `eval` wi
         v'  = ac' `eval` wi'
     in v == v'
 
-specArithmetization' :: forall a . (FromConstant a a, Arithmetic a, Arbitrary a, Show a, Show (ArithmeticCircuitTest a 1)) => IO ()
+specArithmetization' :: forall a . (FromConstant a a, Arithmetic a, Arbitrary a, Show a, Show (ArithmeticCircuitTest a Par1)) => IO ()
 specArithmetization' = hspec $ do
     describe "Arithmetization specification" $ do
         describe "Variable mapping" $ do

--- a/tests/Tests/Arithmetization/Test1.hs
+++ b/tests/Tests/Arithmetization/Test1.hs
@@ -3,6 +3,7 @@
 
 module Tests.Arithmetization.Test1 (specArithmetization1) where
 
+import           GHC.Generics                      (Par1 (unPar1))
 import           Numeric.Natural                   (Natural)
 import           Prelude                           hiding (Bool, Eq (..), Num (..), not, replicate, (/), (>), (^), (||))
 import qualified Prelude                           as Haskell
@@ -10,7 +11,6 @@ import           Test.Hspec
 import           Test.QuickCheck
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Data.Vector           (item)
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Data.Bool         (Bool (..))
 import           ZkFold.Symbolic.Data.Conditional  (Conditional (..))
@@ -27,13 +27,13 @@ testFunc x y =
         g3 = c 2 // x
     in (g3 == y :: Bool c) ? g1 $ g2
 
-testResult :: forall a . (FromConstant a a, Arithmetic a) => ArithmeticCircuit a 1 -> a -> a -> Haskell.Bool
-testResult r x y = fromConstant (item $ acValue $ applyArgs r [x, y]) Haskell.==
+testResult :: forall a . (FromConstant a a, Arithmetic a) => ArithmeticCircuit a Par1 -> a -> a -> Haskell.Bool
+testResult r x y = fromConstant (unPar1 $ acValue $ applyArgs r [x, y]) Haskell.==
     testFunc @(Interpreter a) (fromConstant x) (fromConstant y)
 
 specArithmetization1 :: forall a . (FromConstant a a, Arithmetic a, Arbitrary a, Show a) => Spec
 specArithmetization1 = do
     describe "Arithmetization test 1" $ do
         it "should pass" $ do
-            let ac = compile @a (testFunc @(ArithmeticCircuit a)) :: ArithmeticCircuit a 1
+            let ac = compile @a (testFunc @(ArithmeticCircuit a)) :: ArithmeticCircuit a Par1
             property $ \x y -> testResult ac x y

--- a/tests/Tests/Arithmetization/Test2.hs
+++ b/tests/Tests/Arithmetization/Test2.hs
@@ -3,6 +3,7 @@
 
 module Tests.Arithmetization.Test2 (specArithmetization2) where
 
+import           GHC.Generics                                (Par1 (unPar1))
 import           Prelude                                     hiding (Bool, Eq (..), Num (..), not, replicate, (/), (^),
                                                               (||))
 import qualified Prelude                                     as Haskell
@@ -11,7 +12,6 @@ import           Test.QuickCheck                             (property)
 
 import           ZkFold.Base.Algebra.Basic.Class             (one)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (Fr)
-import           ZkFold.Base.Data.Vector                     (item)
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Data.Bool                   (Bool (..), BoolType (..))
 import           ZkFold.Symbolic.Data.Eq                     (Eq (..))
@@ -24,7 +24,7 @@ tautology x y = (x /= y) || (x == y)
 testTautology :: forall a . Arithmetic a => a -> a -> Haskell.Bool
 testTautology x y =
     let Bool ac = compile @a (tautology @(ArithmeticCircuit a))
-        b       = item $ acValue (applyArgs ac [x, y])
+        b       = unPar1 $ acValue (applyArgs ac [x, y])
     in b Haskell.== one
 
 specArithmetization2 :: Spec

--- a/tests/Tests/Arithmetization/Test4.hs
+++ b/tests/Tests/Arithmetization/Test4.hs
@@ -3,6 +3,7 @@
 module Tests.Arithmetization.Test4 (specArithmetization4) where
 
 import           Data.Map                                    (fromList)
+import           GHC.Generics                                (Par1 (unPar1))
 import           Prelude                                     hiding (Bool, Eq (..), Num (..), Ord (..), (&&))
 import qualified Prelude                                     as Haskell
 import           Test.Hspec                                  (Spec, describe, it)
@@ -21,7 +22,6 @@ import           ZkFold.Symbolic.Compiler                    (ArithmeticCircuit 
 import           ZkFold.Symbolic.Data.Bool                   (Bool (..))
 import           ZkFold.Symbolic.Data.Eq                     (Eq (..))
 import           ZkFold.Symbolic.Data.FieldElement           (FieldElement)
-import GHC.Generics (Par1(unPar1))
 
 type N = 1
 

--- a/tests/Tests/Blake2b.hs
+++ b/tests/Tests/Blake2b.hs
@@ -11,6 +11,7 @@ import           Test.Hspec
 import           ZkFold.Base.Algebra.Basic.Class             (FromConstant (..))
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
+import           ZkFold.Base.Data.Vector                     (Vector)
 import           ZkFold.Symbolic.Algorithms.Hash.Blake2b
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Data.ByteString             (ByteString, Concat, ReverseEndianness, ShiftBits,
@@ -30,7 +31,7 @@ blake2bSimple :: forall b .
     , Concat (ByteString 8 b) (ByteString 512 b)
     , FromConstant Natural (ByteString 0 b)
     , FromConstant Natural (ByteString 8 b)
-    , Eq (b 512)
+    , Eq (b (Vector 512))
     ) => Spec
 blake2bSimple =
     let a = blake2b_512 $ fromConstant @Natural @(ByteString 0 b) 0

--- a/tests/Tests/NonInteractiveProof/Internal.hs
+++ b/tests/Tests/NonInteractiveProof/Internal.hs
@@ -5,6 +5,7 @@
 module Tests.NonInteractiveProof.Internal (NonInteractiveProofTestData(..)) where
 
 import           Data.ByteString                                (ByteString)
+import           GHC.Generics                                   (Par1)
 import           GHC.TypeNats                                   (KnownNat)
 import           Prelude                                        hiding (Fractional (..), Num (..), length)
 import           Test.QuickCheck                                (Arbitrary (arbitrary), Gen)
@@ -35,7 +36,7 @@ instance (KZG c1 c2 d ~ kzg, NonInteractiveProof kzg, Arbitrary kzg, Arbitrary (
 
 instance forall n . (KnownNat n) => Arbitrary (NonInteractiveProofTestData (PlonkBS n)) where
     arbitrary = do
-        ArithmeticCircuitTest ac wi <- arbitrary :: Gen (ArithmeticCircuitTest (ScalarField BLS12_381_G1) 1)
+        ArithmeticCircuitTest ac wi <- arbitrary :: Gen (ArithmeticCircuitTest (ScalarField BLS12_381_G1) Par1)
         let inputLen = length . inputVariables $ ac
         vecPubInp <- genSubset (value @n) inputLen
         let (omega, k1, k2) = getParams $ value @PlonkSizeBS

--- a/tests/Tests/UInt.hs
+++ b/tests/Tests/UInt.hs
@@ -11,6 +11,7 @@ import           Control.Monad                               (return)
 import           Data.Function                               (($))
 import           Data.Functor                                ((<$>))
 import           Data.List                                   ((++))
+import           GHC.Generics                                (Par1 (Par1))
 import           Numeric.Natural                             (Natural)
 import           Prelude                                     (show, type (~))
 import qualified Prelude                                     as P
@@ -23,7 +24,7 @@ import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381
-import           ZkFold.Base.Data.Vector                     (Vector, item)
+import           ZkFold.Base.Data.Vector                     (Vector)
 import           ZkFold.Prelude                              (chooseNatural)
 import           ZkFold.Symbolic.Compiler                    (ArithmeticCircuit, exec)
 import           ZkFold.Symbolic.Data.Bool
@@ -40,7 +41,7 @@ evalBool :: forall a . Bool (ArithmeticCircuit a) -> a
 evalBool (Bool ac) = exec1 ac
 
 evalBoolVec :: forall a . Bool (Interpreter a) -> a
-evalBoolVec (Bool (Interpreter v)) = item v
+evalBoolVec (Bool (Interpreter (Par1 v))) = v
 
 execAcUint :: forall a n . UInt n (ArithmeticCircuit a) -> Vector (NumberOfRegisters a n) a
 execAcUint (UInt v) = exec v
@@ -71,6 +72,7 @@ specUInt'
     => KnownNat (r2n + r2n)
     => KnownNat (r - 1)
     => KnownNat (r2n - 1)
+    => (r - 1) + 1 ~ r
     => 1 + (r - 1) ~ r
     => 1 + (r2n - 1) ~ r2n
     => IO ()

--- a/zkfold-base.cabal
+++ b/zkfold-base.cabal
@@ -99,6 +99,7 @@ library
       ZkFold.Base.Algebra.Polynomials.Univariate
       ZkFold.Base.Data.ByteString
       ZkFold.Base.Data.Matrix
+      ZkFold.Base.Data.Par1
       ZkFold.Base.Data.Sparse.Matrix
       ZkFold.Base.Data.Sparse.Vector
       ZkFold.Base.Data.Type


### PR DESCRIPTION
This PR performs the migration from Natural-indexed contexts to functor-indexed ones.
Note that the only change is the type of contexts: `SymbolicData` and friends stay the same; `Symbolic` class is unchanged; symbolic datatypes just use `Vector`s internally.
Other changes will be performed in the future PRs.