### PR TITLE
Complete Symbolic definition

### DIFF
--- a/src/ZkFold/Base/Data/Product.hs
+++ b/src/ZkFold/Base/Data/Product.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE TypeOperators #-}
+
+module ZkFold.Base.Data.Product where
+
+import           Data.Function (const, id)
+import           GHC.Generics  ((:*:) (..))
+
+uncurryP :: (f a -> g a -> b) -> (f :*: g) a -> b
+uncurryP f (x :*: y) = f x y
+
+fstP :: (f :*: g) a -> f a
+fstP = uncurryP const
+
+sndP :: (f :*: g) a -> g a
+sndP = uncurryP (const id)

--- a/src/ZkFold/Symbolic/Class.hs
+++ b/src/ZkFold/Symbolic/Class.hs
@@ -1,9 +1,49 @@
+{-# LANGUAGE TypeOperators #-}
+
 module ZkFold.Symbolic.Class where
 
+import           Data.Foldable                    (Foldable)
+import           Data.Function                    (const, ($), (.))
+import           Data.Functor                     (Functor (fmap), (<$>))
 import           Data.Kind                        (Type)
+import           Data.Type.Equality               (type (~))
+import           GHC.Generics                     (Par1 (Par1), type (:.:) (unComp1))
 
-import           ZkFold.Base.Control.HApplicative (HApplicative)
-import           ZkFold.Base.Data.Package         (Package)
+import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Base.Control.HApplicative (HApplicative (hpair, hunit))
+import           ZkFold.Base.Data.Package         (Package (pack), packed)
+import           ZkFold.Base.Data.Product         (uncurryP)
+import           ZkFold.Symbolic.MonadCircuit
 
-class (HApplicative c, Package c) => Symbolic c where
+type CircuitFun f g a = forall i m. MonadCircuit i a m => f i -> m (g i)
+
+class (HApplicative c, Package c, SymbolicField (BaseField c)) => Symbolic c where
     type BaseField c :: Type
+
+    symbolicF :: BaseField c ~ a => c f -> (f a -> g a) -> CircuitFun f g a -> c g
+
+    fromCircuitF :: c f -> CircuitFun f g (BaseField c) -> c g
+    fromCircuitF x f = symbolicF x (runWitnesses @(BaseField c) . f) f
+
+embed :: (Symbolic c, Foldable f, Functor f) => f (BaseField c) -> c f
+embed = packed . fmap (\x ->
+    fromCircuitF hunit $ const $ Par1 <$> newAssigned (const $ fromConstant x))
+
+symbolic2F ::
+    (Symbolic c, BaseField c ~ a) => c f -> c g -> (f a -> g a -> h a) ->
+    (forall i m. MonadCircuit i a m => f i -> g i -> m (h i)) -> c h
+symbolic2F x y f m = symbolicF (hpair x y) (uncurryP f) (uncurryP m)
+
+fromCircuit2F :: Symbolic c => c f -> c g -> (forall i m. MonadCircuit i (BaseField c) m => f i -> g i -> m (h i)) -> c h
+fromCircuit2F x y m = fromCircuitF (hpair x y) (uncurryP m)
+
+symbolicVF ::
+    (Symbolic c, BaseField c ~ a, Foldable f, Functor f) =>
+    f (c g) -> (f (g a) -> h a) ->
+    (forall i m. MonadCircuit i a m => f (g i) -> m (h i)) -> c h
+symbolicVF xs f m = symbolicF (pack xs) (f . unComp1) (m . unComp1)
+
+fromCircuitVF ::
+    (Symbolic c, Foldable f, Functor f) => f (c g) ->
+    (forall i m. MonadCircuit i (BaseField c) m => f (g i) -> m (h i)) -> c h
+fromCircuitVF xs m = fromCircuitF (pack xs) (m . unComp1)

--- a/src/ZkFold/Symbolic/Class.hs
+++ b/src/ZkFold/Symbolic/Class.hs
@@ -15,16 +15,43 @@ import           ZkFold.Base.Data.Package         (Package (pack), packed)
 import           ZkFold.Base.Data.Product         (uncurryP)
 import           ZkFold.Symbolic.MonadCircuit
 
+-- | A type of mappings between functors inside a circuit.
+-- @f@ is an input functor, @g@ is an output functor, @a@ is a base field.
+--
+-- A function is a mapping between functors inside a circuit if,
+-- given an arbitrary builder of circuits @m@ over @a@ with arbitrary @i@ as
+-- variables, it maps @f@ many inputs to @g@ many outputs using @m@.
+--
+-- NOTE: the property above is correct by construction for each function of a
+-- suitable type, you don't have to check it yourself.
 type CircuitFun f g a = forall i m. MonadCircuit i a m => f i -> m (g i)
 
-class (HApplicative c, Package c, SymbolicField (BaseField c)) => Symbolic c where
+-- | A Symbolic DSL for performant pure computations with arithmetic circuits.
+-- @c@ is a generic context in which computations are performed.
+class (HApplicative c, Package c, WitnessField (BaseField c)) => Symbolic c where
+    -- | Base algebraic field over which computations are performed.
     type BaseField c :: Type
 
+    -- | To perform computations in a generic context @c@ -- that is,
+    -- to form a mapping between @c f@ and @c g@ for given @f@ and @g@ --
+    -- you need to provide two things:
+    --
+    -- 1. An algorithm for turning @f@ into @g@ in a pure context;
+    -- 2. An algorithm for turning @f@ into @g@ inside a circuit.
+    --
+    -- It is not however checked (yet) that the provided algorithms
+    -- compute the same things.
+    --
+    -- If the pure-context computation is tautological to the circuit
+    -- computation, use @'fromCircuitF'@.
     symbolicF :: BaseField c ~ a => c f -> (f a -> g a) -> CircuitFun f g a -> c g
 
+    -- | A wrapper around @'symbolicF'@ which extracts the pure computation
+    -- from the circuit computation using the @'Witnesses'@ newtype.
     fromCircuitF :: c f -> CircuitFun f g (BaseField c) -> c g
     fromCircuitF x f = symbolicF x (runWitnesses @(BaseField c) . f) f
 
+-- | Embeds the pure value(s) into generic context @c@.
 embed :: (Symbolic c, Foldable f, Functor f) => f (BaseField c) -> c f
 embed = packed . fmap (\x ->
     fromCircuitF hunit $ const $ Par1 <$> newAssigned (const $ fromConstant x))
@@ -32,18 +59,24 @@ embed = packed . fmap (\x ->
 symbolic2F ::
     (Symbolic c, BaseField c ~ a) => c f -> c g -> (f a -> g a -> h a) ->
     (forall i m. MonadCircuit i a m => f i -> g i -> m (h i)) -> c h
+-- | Runs the binary function from @f@ and @g@ into @h@ in a generic context @c@.
 symbolic2F x y f m = symbolicF (hpair x y) (uncurryP f) (uncurryP m)
 
-fromCircuit2F :: Symbolic c => c f -> c g -> (forall i m. MonadCircuit i (BaseField c) m => f i -> g i -> m (h i)) -> c h
+fromCircuit2F ::
+    Symbolic c => c f -> c g ->
+    (forall i m. MonadCircuit i (BaseField c) m => f i -> g i -> m (h i)) -> c h
+-- | Runs the binary @'CircuitFun'@ in a generic context.
 fromCircuit2F x y m = fromCircuitF (hpair x y) (uncurryP m)
 
 symbolicVF ::
     (Symbolic c, BaseField c ~ a, Foldable f, Functor f) =>
     f (c g) -> (f (g a) -> h a) ->
     (forall i m. MonadCircuit i a m => f (g i) -> m (h i)) -> c h
+-- | Given a generic context @c@, runs the function from @f@ many @c g@'s into @c h@.
 symbolicVF xs f m = symbolicF (pack xs) (f . unComp1) (m . unComp1)
 
 fromCircuitVF ::
     (Symbolic c, Foldable f, Functor f) => f (c g) ->
     (forall i m. MonadCircuit i (BaseField c) m => f (g i) -> m (h i)) -> c h
+-- | Given a generic context @c@, runs the @'CircuitFun'@ from @f@ many @c g@'s into @c h@.
 fromCircuitVF xs m = fromCircuitF (pack xs) (m . unComp1)

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
@@ -41,6 +41,7 @@ import           ZkFold.Prelude                                            (leng
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       (Arithmetic, ArithmeticCircuit (..),
                                                                             Circuit (acSystem), acInput)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint
+import           ZkFold.Symbolic.MonadCircuit
 
 boolCheckC :: (Arithmetic a, Traversable f) => ArithmeticCircuit a f -> ArithmeticCircuit a f
 -- ^ @boolCheckC r@ computes @r (r - 1)@ in one PLONK constraint.

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -40,6 +40,7 @@ import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.Conditional
 import           ZkFold.Symbolic.Data.DiscreteField
 import           ZkFold.Symbolic.Data.Eq
+import           ZkFold.Symbolic.MonadCircuit                              (newAssigned)
 
 ------------------------------------- Instances -------------------------------------
 

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
@@ -118,10 +118,11 @@ instance Arithmetic a => Symbolic (ArithmeticCircuit a) where
 instance Arithmetic a => MonadCircuit Natural a (State (Circuit a)) where
     newRanged upperBound witness = do
         let s   = sources @a witness
+            b   = fromConstant upperBound
             -- | A wild (and obviously incorrect) approximation of
             -- x (x - 1) ... (x - upperBound)
             -- It's ok because we only use it for variable generation anyway.
-            p i = var i * (var i - fromConstant upperBound)
+            p i = b * var i * (var i - b)
         i <- addVariable =<< newVariableWithSource (S.toList s) p
         rangeConstraint i upperBound
         assignment i (\m -> witness (m !))

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
@@ -107,7 +107,7 @@ instance (Eq a, MultiplicativeMonoid a) => Package (ArithmeticCircuit a) where
     unpackWith f (ArithmeticCircuit c o) = ArithmeticCircuit c <$> f o
     packWith f = ArithmeticCircuit <$> foldMap acCircuit <*> f . fmap acOutput
 
-type Arithmetic a = (SymbolicField a, Eq a)
+type Arithmetic a = (WitnessField a, Eq a)
 
 instance Arithmetic a => Symbolic (ArithmeticCircuit a) where
     type BaseField (ArithmeticCircuit a) = a

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
@@ -19,10 +19,9 @@ import           Numeric.Natural                                     (Natural)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal hiding (constraint)
 import           ZkFold.Symbolic.MonadCircuit
 
+-- | A @'MonadCircuit'@ with an added capability
+-- of embedding another arithmetic circuit inside.
 class MonadCircuit i a m => MonadBlueprint i a m where
-    -- ^ A @'MonadCircuit'@ with an added capability
-    -- of embedding another arithmetic circuit inside.
-
     -- | Adds the supplied circuit to the blueprint and returns its output variable.
     runCircuit :: ArithmeticCircuit a f -> m (f i)
 

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MonadBlueprint.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TypeApplications   #-}
-{-# LANGUAGE TypeOperators      #-}
-
-{-# OPTIONS_GHC -Wno-orphans    #-}
-
 module ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (
     ClosedPoly,
     MonadBlueprint (..),
@@ -16,127 +10,24 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (
 ) where
 
 import           Control.Applicative                                 (pure)
-import           Control.Monad                                       (Monad, return, (=<<))
 import           Control.Monad.State                                 (State, modify, runState)
-import           Data.Foldable                                       (maximum)
-import           Data.Function                                       (($), (.))
 import           Data.Functor                                        (Functor, fmap, ($>), (<$>))
-import           Data.Map                                            ((!))
 import           Data.Monoid                                         (mempty, (<>))
-import           Data.Ord                                            (Ord)
-import           Data.Set                                            (Set)
-import qualified Data.Set                                            as Set
-import           Data.Type.Equality                                  (type (~))
 import           GHC.Generics                                        (Par1)
 import           Numeric.Natural                                     (Natural)
 
-import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.Basic.Sources
-import           ZkFold.Base.Algebra.Polynomials.Multivariate        (var)
-import qualified ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal as I
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal hiding (constraint)
+import           ZkFold.Symbolic.MonadCircuit
 
-type WitnessField a x = (Algebra a x, FiniteField x, BinaryExpansion x, Bits x ~ [x])
--- ^ DSL for constructing witnesses in an arithmetic circuit. @a@ is a base
--- field; @x@ is a "field of witnesses over @a@" which you can safely assume to
--- be identical to @a@ with internalized equality.
-
-type Witness i a = forall x . WitnessField a x => (i -> x) -> x
--- ^ A type of witness builders. @i@ is a type of variables, @a@ is a base field.
---
--- A function is a witness builer if, given an arbitrary field of witnesses @x@
--- over @a@ and a function mapping known variables to their witnesses, it computes
--- the new witness in @x@.
---
--- NOTE: the property above is correct by construction for each function of a
--- suitable type, you don't have to check it yourself.
-
-type NewConstraint i a = forall x . Algebra a x => (i -> x) -> i -> x
--- ^ A type of constraints for new variables. @i@ is a type of variables, @a@ is a base field.
---
--- A function is a constraint for a new variable if, given an arbitrary algebra
--- @x@ over @a@, a function mapping known variables to their witnesses in that
--- algebra and a new variable, it computes the value of a constraint polynomial
--- in that algebra.
---
--- NOTE: the property above is correct by construction for each function of a
--- suitable type, you don't have to check it yourself.
-
-type ClosedPoly i a = forall x . Algebra a x => (i -> x) -> x
--- ^ A type of polynomial expressions. @i@ is a type of variables, @a@ is a base field.
---
--- A function is a polynomial expression if, given an arbitrary algebra @x@ over
--- @a@ and a function mapping known variables to their witnesses, it computes a
--- new value in that algebra.
---
--- NOTE: the property above is correct by construction for each function of a
--- suitable type, you don't have to check it yourself.
-
-class Monad m => MonadBlueprint i a m | m -> i, m -> a where
-    -- ^ DSL for constructing arithmetic circuits. @i@ is a type of variables,
-    -- @a@ is a base field and @m@ is a monad for constructing the circuit.
-    --
-    -- DSL provides the following guarantees:
-    -- * There are no unconstrained variables;
-    -- * Variables with equal constraints and witnesses are reused as much as possible;
-    -- * Variables with either different constraints or different witnesses are different;
-    -- * There is an order in which witnesses can be generated;
-    -- * Constraints never reference undefined variables.
-    --
-    -- However, DSL does NOT provide the following guarantees (yet):
-    -- * That provided witnesses satisfy the provided constraints. To check this,
-    --   you can use 'ZkFold.Symbolic.Compiler.ArithmeticCircuit.checkCircuit'.
-    -- * That introduced polynomial constraints are supported by the zk-SNARK
-    --   utilized for later proving.
+class MonadCircuit i a m => MonadBlueprint i a m where
+    -- ^ A @'MonadCircuit'@ with an added capability
+    -- of embedding another arithmetic circuit inside.
 
     -- | Adds the supplied circuit to the blueprint and returns its output variable.
     runCircuit :: ArithmeticCircuit a f -> m (f i)
 
-    -- | Creates new variable given an inclusive upper bound on a value and a witness.
-    -- e.g., @newRanged b (\\x -> x i - one)@ creates new variable whose value
-    -- is equal to @x i - one@ and which is expected to be in range @[0..b]@.
-    newRanged :: a -> Witness i a -> m i
-
-    -- | Creates new variable given a constraint polynomial and a witness.
-    newConstrained :: NewConstraint i a -> Witness i a -> m i
-
-    -- | Adds new constraint to the system.
-    constraint :: ClosedPoly i a -> m ()
-
-    -- | Creates new variable given a polynomial witness.
-    newAssigned :: ClosedPoly i a -> m i
-    newAssigned p = newConstrained (\x i -> p x - x i) p
-
 instance Arithmetic a => MonadBlueprint Natural a (State (Circuit a)) where
     runCircuit r = modify (<> acCircuit r) $> acOutput r
-
-    newRanged upperBound witness = do
-        let s   = sources @a witness
-            -- | A wild (and obviously incorrect) approximation of
-            -- x (x - 1) ... (x - upperBound)
-            -- It's ok because we only use it for variable generation anyway.
-            p i = var i * (var i - fromConstant upperBound)
-        i <- addVariable =<< newVariableWithSource (Set.toList s) p
-        I.rangeConstraint i upperBound
-        assignment i (\m -> witness (m !))
-        return i
-
-    newConstrained
-        :: NewConstraint Natural a
-        -> Witness Natural a
-        -> State (Circuit a) Natural
-    newConstrained new witness = do
-        let ws = sources @a witness
-            -- | We need a throwaway variable to feed into `new` which definitely would not be present in a witness
-            x = maximum (Set.mapMonotonic (+1) ws <> Set.singleton 0)
-            -- | `s` is meant to be a set of variables used in a witness not present in a constraint.
-            s = ws `Set.difference` sources @a (`new` x)
-        i <- addVariable =<< newVariableWithSource (Set.toList s) (new var)
-        constraint (`new` i)
-        assignment i (\m -> witness (m !))
-        return i
-
-    constraint p = I.constraint (p var)
 
 circuit :: Arithmetic a => (forall i m . MonadBlueprint i a m => m i) -> ArithmeticCircuit a Par1
 -- ^ Builds a circuit from blueprint. A blueprint is a function which, given an
@@ -155,6 +46,3 @@ circuits :: forall a f . (Arithmetic a, Functor f) => (forall i m . MonadBluepri
 -- which, given an arbitrary type of variables @i@ and a monad @m@ supporting the
 -- 'MonadBlueprint' API, computes the collection of output variables of future circuits.
 circuits b = let (os, r) = runState (fmap pure <$> b) (mempty :: Circuit a) in (\o -> ArithmeticCircuit { acCircuit = r, acOutput = o }) <$> os
-
-sources :: forall a i . (FiniteField a, Ord i) => Witness i a -> Set i
-sources = runSources . ($ Sources @a . Set.singleton)

--- a/src/ZkFold/Symbolic/Data/Bool.hs
+++ b/src/ZkFold/Symbolic/Data/Bool.hs
@@ -18,9 +18,9 @@ import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field                           (Zp)
 import           ZkFold.Base.Algebra.Basic.Number                          (KnownNat)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       (Arithmetic, ArithmeticCircuit)
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint (newAssigned, runCircuit),
-                                                                            circuit)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (circuit, runCircuit)
 import           ZkFold.Symbolic.Interpreter                               (Interpreter (..))
+import           ZkFold.Symbolic.MonadCircuit                              (newAssigned)
 
 class BoolType b where
     true  :: b

--- a/src/ZkFold/Symbolic/Data/ByteString.hs
+++ b/src/ZkFold/Symbolic/Data/ByteString.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
+
 {-# OPTIONS_GHC -freduction-depth=0 #-} -- Avoid reduction overflow error caused by NumberOfRegisters
 
 module ZkFold.Symbolic.Data.ByteString
@@ -51,6 +52,7 @@ import           ZkFold.Symbolic.Data.Bool                                 (Bool
 import           ZkFold.Symbolic.Data.Combinators
 import           ZkFold.Symbolic.Data.FieldElement                         (FieldElementData (..))
 import           ZkFold.Symbolic.Interpreter                               (Interpreter (..))
+import           ZkFold.Symbolic.MonadCircuit                              (newAssigned)
 
 
 -- | A ByteString which stores @n@ bits and uses elements of @a@ as registers, one element per register.

--- a/src/ZkFold/Symbolic/Data/FFA.hs
+++ b/src/ZkFold/Symbolic/Data/FFA.hs
@@ -24,11 +24,11 @@ import           ZkFold.Base.Data.Vector
 import           ZkFold.Prelude                                            (iterateM, length)
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (expansion, splitExpansion)
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint, circuitF, newAssigned,
-                                                                            runCircuit)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint, circuitF, runCircuit)
 import           ZkFold.Symbolic.Data.Combinators                          (log2, maxBitsPerFieldElement)
 import           ZkFold.Symbolic.Data.Ord                                  (blueprintGE)
 import           ZkFold.Symbolic.Interpreter
+import           ZkFold.Symbolic.MonadCircuit                              (newAssigned)
 
 type Size = 7
 

--- a/src/ZkFold/Symbolic/Data/Ord.hs
+++ b/src/ZkFold/Symbolic/Data/Ord.hs
@@ -23,6 +23,7 @@ import           ZkFold.Symbolic.Data.Bool                                 (Bool
 import           ZkFold.Symbolic.Data.Conditional                          (Conditional (..))
 import           ZkFold.Symbolic.Data.FieldElement                         (FieldElement (..))
 import           ZkFold.Symbolic.Interpreter                               (Interpreter (..))
+import           ZkFold.Symbolic.MonadCircuit                              (newAssigned)
 
 -- TODO (Issue #23): add `compare`
 class Ord b a where

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -52,6 +52,7 @@ import           ZkFold.Symbolic.Data.Eq.Structural
 import           ZkFold.Symbolic.Data.FieldElement                         (FieldElementData (..))
 import           ZkFold.Symbolic.Data.Ord
 import           ZkFold.Symbolic.Interpreter                               (Interpreter (..))
+import           ZkFold.Symbolic.MonadCircuit                              (constraint, newAssigned)
 
 -- TODO (Issue #18): hide this constructor
 newtype UInt (n :: Natural) (r :: RegisterSize) (backend :: (Type -> Type) -> Type) = UInt (backend (Vector (NumberOfRegisters (BaseField backend) n r)))

--- a/src/ZkFold/Symbolic/Interpreter.hs
+++ b/src/ZkFold/Symbolic/Interpreter.hs
@@ -12,7 +12,7 @@ import           ZkFold.Base.Control.HApplicative
 import           ZkFold.Base.Data.HFunctor
 import           ZkFold.Base.Data.Package
 import           ZkFold.Symbolic.Class
-import           ZkFold.Symbolic.MonadCircuit     (SymbolicField)
+import           ZkFold.Symbolic.MonadCircuit     (WitnessField)
 
 newtype Interpreter a f = Interpreter { runInterpreter :: f a }
     deriving (Eq, Show, Generic, NFData)
@@ -28,7 +28,7 @@ instance Package (Interpreter a) where
   unpackWith f (Interpreter x) = Interpreter <$> f x
   packWith f g = Interpreter $ f (runInterpreter <$> g)
 
-instance SymbolicField a => Symbolic (Interpreter a) where
+instance WitnessField a => Symbolic (Interpreter a) where
   type BaseField (Interpreter a) = a
   symbolicF (Interpreter x) f _ = Interpreter (f x)
 

--- a/src/ZkFold/Symbolic/Interpreter.hs
+++ b/src/ZkFold/Symbolic/Interpreter.hs
@@ -4,7 +4,6 @@ import           Control.DeepSeq                  (NFData)
 import           Data.Eq                          (Eq)
 import           Data.Function                    (($), (.))
 import           Data.Functor                     ((<$>))
-import           Data.Kind                        (Type)
 import           GHC.Generics                     (Generic, Par1 (Par1))
 import           Text.Show                        (Show)
 
@@ -13,6 +12,7 @@ import           ZkFold.Base.Control.HApplicative
 import           ZkFold.Base.Data.HFunctor
 import           ZkFold.Base.Data.Package
 import           ZkFold.Symbolic.Class
+import           ZkFold.Symbolic.MonadCircuit     (SymbolicField)
 
 newtype Interpreter a f = Interpreter { runInterpreter :: f a }
     deriving (Eq, Show, Generic, NFData)
@@ -28,8 +28,9 @@ instance Package (Interpreter a) where
   unpackWith f (Interpreter x) = Interpreter <$> f x
   packWith f g = Interpreter $ f (runInterpreter <$> g)
 
-instance Symbolic (Interpreter (a :: Type)) where
+instance SymbolicField a => Symbolic (Interpreter a) where
   type BaseField (Interpreter a) = a
+  symbolicF (Interpreter x) f _ = Interpreter (f x)
 
 value :: Interpreter a Par1 -> a
 value (Interpreter (Par1 x)) = x

--- a/src/ZkFold/Symbolic/MonadCircuit.hs
+++ b/src/ZkFold/Symbolic/MonadCircuit.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE DerivingVia   #-}
+{-# LANGUAGE TypeOperators #-}
+
+module ZkFold.Symbolic.MonadCircuit where
+
+import           Control.Applicative             (Applicative)
+import           Control.Monad                   (Monad (return))
+import           Data.Function                   (id)
+import           Data.Functor                    (Functor)
+import           Data.Functor.Identity           (Identity (..))
+import           Data.Type.Equality              (type (~))
+
+import           ZkFold.Base.Algebra.Basic.Class
+
+type SymbolicField a = (FiniteField a, BinaryExpansion a, Bits a ~ [a])
+
+-- | DSL for constructing witnesses in an arithmetic circuit. @a@ is a base
+-- field; @x@ is a "field of witnesses over @a@" which you can safely assume to
+-- be identical to @a@.
+type WitnessField a x = (Algebra a x, SymbolicField x)
+
+-- | A type of witness builders. @i@ is a type of variables, @a@ is a base field.
+--
+-- A function is a witness builer if, given an arbitrary field of witnesses @x@
+-- over @a@ and a function mapping known variables to their witnesses, it computes
+-- the new witness in @x@.
+--
+-- NOTE: the property above is correct by construction for each function of a
+-- suitable type, you don't have to check it yourself.
+type Witness i a = forall x . WitnessField a x => (i -> x) -> x
+
+-- | A type of constraints for new variables. @i@ is a type of variables, @a@ is a base field.
+--
+-- A function is a constraint for a new variable if, given an arbitrary algebra
+-- @x@ over @a@, a function mapping known variables to their witnesses in that
+-- algebra and a new variable, it computes the value of a constraint polynomial
+-- in that algebra.
+--
+-- NOTE: the property above is correct by construction for each function of a
+-- suitable type, you don't have to check it yourself.
+type NewConstraint i a = forall x . Algebra a x => (i -> x) -> i -> x
+
+-- | A type of polynomial expressions. @i@ is a type of variables, @a@ is a base field.
+--
+-- A function is a polynomial expression if, given an arbitrary algebra @x@ over
+-- @a@ and a function mapping known variables to their witnesses, it computes a
+-- new value in that algebra.
+--
+-- NOTE: the property above is correct by construction for each function of a
+-- suitable type, you don't have to check it yourself.
+type ClosedPoly i a = forall x . Algebra a x => (i -> x) -> x
+
+-- | DSL for constructing arithmetic circuits. @i@ is a type of variables,
+-- @a@ is a base field and @m@ is a monad for constructing the circuit.
+--
+-- DSL provides the following guarantees:
+-- * There are no unconstrained variables;
+-- * Variables with equal constraints and witnesses are reused as much as possible;
+-- * Variables with either different constraints or different witnesses are different;
+-- * There is an order in which witnesses can be generated;
+-- * Constraints never reference undefined variables.
+--
+-- However, DSL does NOT provide the following guarantees (yet):
+-- * That provided witnesses satisfy the provided constraints. To check this,
+--   you can use 'ZkFold.Symbolic.Compiler.ArithmeticCircuit.checkCircuit'.
+-- * That introduced polynomial constraints are supported by the zk-SNARK
+--   utilized for later proving.
+class Monad m => MonadCircuit i a m | m -> i, m -> a where
+    -- | Creates new variable given an inclusive upper bound on a value and a witness.
+    -- e.g., @newRanged b (\\x -> x i - one)@ creates new variable whose value
+    -- is equal to @x i - one@ and which is expected to be in range @[0..b]@.
+    newRanged :: a -> Witness i a -> m i
+
+    -- | Creates new variable given a constraint polynomial and a witness.
+    newConstrained :: NewConstraint i a -> Witness i a -> m i
+
+    -- | Adds new constraint to the system.
+    constraint :: ClosedPoly i a -> m ()
+
+    -- | Creates new variable given a polynomial witness.
+    newAssigned :: ClosedPoly i a -> m i
+    newAssigned p = newConstrained (\x i -> p x - x i) p
+
+newtype Witnesses a x = Witnesses { runWitnesses :: x }
+  deriving (Functor, Applicative, Monad) via Identity
+
+instance SymbolicField a => MonadCircuit a a (Witnesses a) where
+    newRanged _ w = return (w id)
+    newConstrained _ w = return (w id)
+    constraint _ = return ()
+    newAssigned w = return (w id)

--- a/zkfold-base.cabal
+++ b/zkfold-base.cabal
@@ -103,6 +103,7 @@ library
       ZkFold.Base.Data.Matrix
       ZkFold.Base.Data.Package
       ZkFold.Base.Data.Par1
+      ZkFold.Base.Data.Product
       ZkFold.Base.Data.Sparse.Matrix
       ZkFold.Base.Data.Sparse.Vector
       ZkFold.Base.Data.Type
@@ -191,6 +192,7 @@ library
       ZkFold.Symbolic.Ledger.Validation.PrivateInput
       ZkFold.Symbolic.Ledger.Validation.PublicInput
       ZkFold.Symbolic.Ledger.Validation.Transaction
+      ZkFold.Symbolic.MonadCircuit
     build-depends:
       base                          >= 4.9 && < 5,
       adjunctions                           < 4.5,


### PR DESCRIPTION
1. Added `MonadCircuit` as a superclass to the (soon to be deprecated) `MonadBlueprint`. The latter now only contains the `runCircuit`, every other member has been moved to `MonadCircuit`.
2. Completed `Symbolic` class definition with a `symbolicF` function.
3. Various utilities and QoL improvements to simplify working with new `Symbolic` class.
4. Docs