### PR TITLE
+ Symbolic c => BoolType (Bool c) instance

### DIFF
--- a/src/ZkFold/Symbolic/Cardano/Contracts/BatchTransfer.hs
+++ b/src/ZkFold/Symbolic/Cardano/Contracts/BatchTransfer.hs
@@ -14,6 +14,7 @@ import           ZkFold.Base.Data.Vector                        (Vector, fromVec
 import           ZkFold.Symbolic.Algorithms.Hash.MiMC
 import           ZkFold.Symbolic.Algorithms.Hash.MiMC.Constants (mimcConstants)
 import           ZkFold.Symbolic.Cardano.Types
+import           ZkFold.Symbolic.Class                          (Symbolic)
 import           ZkFold.Symbolic.Data.Bool                      (BoolType (..), all)
 import           ZkFold.Symbolic.Data.Combinators
 import           ZkFold.Symbolic.Data.Eq
@@ -29,12 +30,12 @@ hash :: forall context x . MiMCHash F context x => x -> FieldElement context
 hash = mimcHash @F mimcConstants zero
 
 type Sig context =
-    ( StrictConv (context Par1) (UInt 256 Auto context)
+    ( Symbolic context
+    , StrictConv (context Par1) (UInt 256 Auto context)
     , FromConstant Natural (UInt 256 Auto context)
     , MultiplicativeSemigroup (UInt 256 Auto context)
     , AdditiveMonoid (context Par1)
     , MiMCHash F context (TxOut context, TxOut context)
-    , BoolType (Bool context)
     , Eq (Bool context) (UInt 256 Auto context)
     , Eq (Bool context) (TxOut context)
     , Iso (UInt 256 Auto context) (ByteString 256 context)

--- a/src/ZkFold/Symbolic/Cardano/Contracts/RandomOracle.hs
+++ b/src/ZkFold/Symbolic/Cardano/Contracts/RandomOracle.hs
@@ -11,6 +11,7 @@ import           ZkFold.Base.Data.Vector                        ((!!))
 import           ZkFold.Symbolic.Algorithms.Hash.MiMC           (MiMCHash, mimcHash)
 import           ZkFold.Symbolic.Algorithms.Hash.MiMC.Constants (mimcConstants)
 import           ZkFold.Symbolic.Cardano.Types
+import           ZkFold.Symbolic.Class                          (Symbolic)
 import           ZkFold.Symbolic.Data.Bool                      (BoolType (..))
 import qualified ZkFold.Symbolic.Data.ByteString                as Symbolic
 import           ZkFold.Symbolic.Data.Combinators
@@ -25,9 +26,9 @@ hash :: forall context x . MiMCHash F context x => x -> FieldElement context
 hash = mimcHash @F mimcConstants zero
 
 type Sig context =
-    ( FromConstant F (FieldElement context)
+    ( Symbolic context
+    , FromConstant F (FieldElement context)
     , MultiplicativeMonoid (UInt 64 Auto context)
-    , BoolType (Bool context)
     , Eq (Bool context) (FieldElement context)
     , Eq (Bool context) (UInt 64 Auto context)
     , Eq (Bool context) (ByteString 224 context)

--- a/src/ZkFold/Symbolic/Cardano/Wrapper.hs
+++ b/src/ZkFold/Symbolic/Cardano/Wrapper.hs
@@ -3,6 +3,7 @@ module ZkFold.Symbolic.Cardano.Wrapper where
 import           Prelude                          hiding (Bool, Eq (..), length, splitAt, (&&), (*), (+))
 
 import           ZkFold.Symbolic.Cardano.Types
+import           ZkFold.Symbolic.Class            (Symbolic)
 import           ZkFold.Symbolic.Data.Bool        (BoolType (..))
 import           ZkFold.Symbolic.Data.Combinators (RegisterSize (..))
 import           ZkFold.Symbolic.Data.Eq          (Eq ((==)))
@@ -17,7 +18,7 @@ type Contract tx redeemer context = tx context -> redeemer context -> Bool conte
 
 -- | Wrap the contract, exposing the transaction hash as the single public input.
 symbolicContractWrapper :: forall inputs rinputs outputs tokens mint datum redeemer context .
-    (BoolType (Bool context), Eq (Bool context) (TxHash context))
+    (Symbolic context, Eq (Bool context) (TxHash context))
     => Contract (Transaction inputs rinputs outputs tokens mint datum) redeemer context
     -> TxHash context
     -> Transaction inputs rinputs outputs tokens mint datum context

--- a/src/ZkFold/Symbolic/Data/Ed25519.hs
+++ b/src/ZkFold/Symbolic/Data/Ed25519.hs
@@ -18,6 +18,7 @@ import           ZkFold.Base.Algebra.EllipticCurve.Class
 import           ZkFold.Base.Algebra.EllipticCurve.Ed25519
 import           ZkFold.Base.Control.HApplicative          (hliftA2)
 import qualified ZkFold.Base.Data.Vector                   as V
+import           ZkFold.Symbolic.Class                     (Symbolic)
 import           ZkFold.Symbolic.Compiler                  hiding (forceZero)
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.ByteString
@@ -78,7 +79,7 @@ instance
             partialRestore = restore c
             (x, y) = (partialRestore piecesX, partialRestore piecesY)
 
-instance (BoolType (Bool (c a)), Eq (Bool (c a)) (BaseField (Ed25519 c a))) => Eq (Bool (c a)) (Point (Ed25519 c a)) where
+instance (Symbolic (c a), Eq (Bool (c a)) (BaseField (Ed25519 c a))) => Eq (Bool (c a)) (Point (Ed25519 c a)) where
     Inf == Inf                     = true
     Inf == _                       = false
     _ == Inf                       = false

--- a/src/ZkFold/Symbolic/Ledger/Types.hs
+++ b/src/ZkFold/Symbolic/Ledger/Types.hs
@@ -18,7 +18,7 @@ import           Data.Functor                             (Functor)
 import           Data.Zip                                 (Zip)
 
 import           ZkFold.Base.Algebra.Basic.Class          (AdditiveMonoid)
-import           ZkFold.Symbolic.Data.Bool                (BoolType)
+import           ZkFold.Symbolic.Class                    (Symbolic)
 import           ZkFold.Symbolic.Data.Eq                  (Eq)
 import           ZkFold.Symbolic.Ledger.Types.Address
 import           ZkFold.Symbolic.Ledger.Types.Basic
@@ -42,8 +42,8 @@ import           ZkFold.Symbolic.Ledger.Types.Value
 -}
 
 type Signature context =
-    ( AdditiveMonoid (Value context)
-    , BoolType (Bool context)
+    ( Symbolic context
+    , AdditiveMonoid (Value context)
     , Eq (Bool context) (Hash context)
     , Eq (Bool context) (Input context)
     , Eq (Bool context) (Address context, Datum context)

--- a/tests/Tests/Arithmetization/Test2.hs
+++ b/tests/Tests/Arithmetization/Test2.hs
@@ -12,13 +12,14 @@ import           Test.QuickCheck                             (property)
 
 import           ZkFold.Base.Algebra.Basic.Class             (one)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (Fr)
+import           ZkFold.Symbolic.Class                       (Symbolic)
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Data.Bool                   (Bool (..), BoolType (..))
 import           ZkFold.Symbolic.Data.Eq                     (Eq (..))
 import           ZkFold.Symbolic.Data.FieldElement           (FieldElement)
 
 -- A true statement.
-tautology :: (BoolType (Bool c), Eq (Bool c) (FieldElement c)) => FieldElement c -> FieldElement c -> Bool c
+tautology :: (Symbolic c, Eq (Bool c) (FieldElement c)) => FieldElement c -> FieldElement c -> Bool c
 tautology x y = (x /= y) || (x == y)
 
 testTautology :: forall a . Arithmetic a => a -> a -> Haskell.Bool


### PR DESCRIPTION
As said in the title, migrates `BoolType (Bool c)` instance to the new Symbolic DSL.