### PR TITLE
Merged Arithmetizable & SymbolicData in one instance

### DIFF
--- a/src/ZkFold/Symbolic/Cardano/Types/Input.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/Input.hs
@@ -28,8 +28,9 @@ deriving instance
     => FE.FieldElementData CtxEvaluation (Input tokens datum CtxEvaluation)
 
 deriving instance
-    KnownNat (TypeSize F (Value tokens CtxCompilation))
-    => SymbolicData F (Input tokens datum CtxCompilation)
+    ( KnownNat tokens
+    , KnownNat (TypeSize F (Value tokens CtxCompilation))
+    ) => SymbolicData F (Input tokens datum CtxCompilation)
 
 txiOutputRef :: Input tokens datum context -> OutputRef context
 txiOutputRef (Input (ref, _)) = ref

--- a/src/ZkFold/Symbolic/Cardano/Types/Output.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/Output.hs
@@ -37,14 +37,16 @@ deriving instance
     => FE.FieldElementData CtxEvaluation (Output tokens datum CtxEvaluation)
 
 deriving instance
-    KnownNat (TypeSize F (Value tokens CtxCompilation))
-    => SymbolicData F (Output tokens datum CtxCompilation)
+    ( KnownNat (TypeSize F (Value tokens CtxCompilation))
+    , KnownNat tokens
+    ) => SymbolicData F (Output tokens datum CtxCompilation)
 
 deriving via (Structural (Output tokens datum CtxCompilation))
          instance
             ( ts ~ TypeSize F (Output tokens datum CtxCompilation)
             , 1 <= ts
             , KnownNat ts
+            , KnownNat tokens
             , KnownNat (TypeSize F (Value tokens CtxCompilation))
             ) => Eq (Bool CtxCompilation) (Output tokens datum CtxCompilation)
 

--- a/src/ZkFold/Symbolic/Cardano/Types/Transaction.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/Transaction.hs
@@ -43,7 +43,12 @@ deriving instance
 
 -- TODO: Think how to prettify this abomination
 deriving instance
-    ( KnownNat (TypeSize F (Value tokens CtxCompilation))
+    ( KnownNat tokens
+    , KnownNat rinputs
+    , KnownNat inputs
+    , KnownNat outputs
+    , KnownNat mint
+    , KnownNat (TypeSize F (Value tokens CtxCompilation))
     , KnownNat (TypeSize F (Output tokens datum CtxCompilation))
     , KnownNat (TypeSize F (Vector outputs (Output tokens datum CtxCompilation)))
     , KnownNat (TypeSize F (Input tokens datum CtxCompilation))

--- a/src/ZkFold/Symbolic/Cardano/Types/Value.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/Value.hs
@@ -8,6 +8,7 @@ import           Prelude                             hiding (Bool, Eq, length, r
 import qualified Prelude                             as Haskell
 
 import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Base.Algebra.Basic.Number    (KnownNat)
 import           ZkFold.Base.Data.Vector
 import           ZkFold.Symbolic.Cardano.Types.Basic
 import           ZkFold.Symbolic.Compiler
@@ -25,7 +26,7 @@ deriving instance (Haskell.Eq (ByteString 224 context), Haskell.Eq (ByteString 2
 
 deriving instance FE.FieldElementData CtxEvaluation (Value n CtxEvaluation)
 
-deriving instance SymbolicData F (Value n CtxCompilation)
+deriving instance KnownNat n => SymbolicData F (Value n CtxCompilation)
 
 instance (FromConstant Natural (UInt 64 Auto context), MultiplicativeSemigroup (UInt 64 Auto context))
         => Scale Natural (Value n context) where

--- a/src/ZkFold/Symbolic/Cardano/UPLC/Builtins.hs
+++ b/src/ZkFold/Symbolic/Cardano/UPLC/Builtins.hs
@@ -9,29 +9,29 @@ import           Prelude                           (($))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Symbolic.Cardano.UPLC.Type
-import           ZkFold.Symbolic.Compiler          (Arithmetic, ArithmeticCircuit, SomeArithmetizable (..))
+import qualified ZkFold.Symbolic.Compiler          as AC
 
 -- TODO: Add the actual builtins available on-chain in Plutus V3
 
 -- | A class for built-in functions in Plutus.
 class PlutusBuiltinFunction a fun where
     builtinFunctionType :: fun -> SomeType a
-    builtinFunctionRep  :: fun -> SomeArithmetizable a
+    builtinFunctionRep  :: fun -> AC.SomeData a
 
 data BuiltinFunctions =
       AddField
     | MulField
 
 -- TODO: use shortcuts to make these definitions more readable
-instance forall a . (Arithmetic a, Typeable a) => PlutusBuiltinFunction a BuiltinFunctions where
+instance forall a . (AC.Arithmetic a, Typeable a) => PlutusBuiltinFunction a BuiltinFunctions where
     builtinFunctionType AddField =
-          SomeFunction (SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a Par1))
-        $ SomeFunction (SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a Par1))
-        $ SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a Par1)
+          SomeFunction (SomeSym $ SomeData $ Proxy @(AC.ArithmeticCircuit a Par1))
+        $ SomeFunction (SomeSym $ SomeData $ Proxy @(AC.ArithmeticCircuit a Par1))
+        $ SomeSym $ SomeData $ Proxy @(AC.ArithmeticCircuit a Par1)
     builtinFunctionType MulField =
-        SomeFunction (SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a Par1))
-        $ SomeFunction (SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a Par1))
-        $ SomeSym $ SomeData $ Proxy @(ArithmeticCircuit a Par1)
+        SomeFunction (SomeSym $ SomeData $ Proxy @(AC.ArithmeticCircuit a Par1))
+        $ SomeFunction (SomeSym $ SomeData $ Proxy @(AC.ArithmeticCircuit a Par1))
+        $ SomeSym $ SomeData $ Proxy @(AC.ArithmeticCircuit a Par1)
 
-    builtinFunctionRep AddField = SomeArithmetizable $ \(x :: ArithmeticCircuit a Par1) (y :: ArithmeticCircuit a Par1) -> x + y
-    builtinFunctionRep MulField = SomeArithmetizable $ \(x :: ArithmeticCircuit a Par1) (y :: ArithmeticCircuit a Par1) -> x * y
+    builtinFunctionRep AddField = AC.SomeData $ \(x :: AC.ArithmeticCircuit a Par1) (y :: AC.ArithmeticCircuit a Par1) -> x + y
+    builtinFunctionRep MulField = AC.SomeData $ \(x :: AC.ArithmeticCircuit a Par1) (y :: AC.ArithmeticCircuit a Par1) -> x * y

--- a/src/ZkFold/Symbolic/Cardano/UPLC/Term.hs
+++ b/src/ZkFold/Symbolic/Cardano/UPLC/Term.hs
@@ -7,7 +7,7 @@ import           Data.Typeable                    (Typeable, cast, typeOf)
 import           Prelude
 
 import           ZkFold.Base.Algebra.Basic.Number
-import           ZkFold.Symbolic.Compiler         (Arithmetizable, SymbolicData (..))
+import           ZkFold.Symbolic.Compiler         (SymbolicData (..))
 
 -- Based on the November 2022 UPLC spec
 data Term name fun a where
@@ -16,7 +16,7 @@ data Term name fun a where
     Apply     :: Term name fun a -> Term name fun a -> Term name fun a
     Force     :: Term name fun a -> Term name fun a
     Delay     :: Term name fun a -> Term name fun a
-    Constant  :: (Eq c, Typeable c, SymbolicData a c, Arithmetizable a c, KnownNat (TypeSize a c)) => c -> Term name fun a
+    Constant  :: (Eq c, Typeable c, SymbolicData a c, KnownNat (TypeSize a c)) => c -> Term name fun a
     Builtin   :: fun -> Term name fun a
     Error     :: Term name fun a
 

--- a/src/ZkFold/Symbolic/Data/ByteString.hs
+++ b/src/ZkFold/Symbolic/Data/ByteString.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes        #-}
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
@@ -64,7 +63,6 @@ newtype ByteString (n :: Natural) (backend :: (Type -> Type) -> Type) = ByteStri
 deriving stock instance Haskell.Show (b (Vector n)) => Haskell.Show (ByteString n b)
 deriving stock instance Haskell.Eq (b (Vector n)) => Haskell.Eq (ByteString n b)
 deriving anyclass instance NFData (b (Vector n)) => NFData (ByteString n b)
-deriving newtype instance Arithmetic a => Arithmetizable a (ByteString n (ArithmeticCircuit a))
 
 instance Arithmetic a => FieldElementData (Interpreter a) (ByteString n (Interpreter a)) where
     type TypeSize (Interpreter a) (ByteString n (Interpreter a)) = n
@@ -360,11 +358,11 @@ instance Finite (Zp p) => BitState ByteString n (Interpreter (Zp p)) where
 --------------------------------------------------------------------------------
 
 instance Arithmetic a => SymbolicData a (ByteString n (ArithmeticCircuit a)) where
+    type Support a (ByteString n (ArithmeticCircuit a)) = ()
     type TypeSize a (ByteString n (ArithmeticCircuit a)) = n
 
-    pieces (ByteString bits) = bits
-
-    restore c o = ByteString $ c `withOutputs` o
+    pieces (ByteString bits) _ = bits
+    restore = ByteString . ($ ())
 
 instance (Arithmetic a, KnownNat n) => ShiftBits (ByteString n (ArithmeticCircuit a)) where
     shiftBits bs@(ByteString oldBits) s

--- a/src/ZkFold/Symbolic/Data/Eq/Structural.hs
+++ b/src/ZkFold/Symbolic/Data/Eq/Structural.hs
@@ -15,16 +15,17 @@ newtype Structural a = Structural a
 
 instance
     ( SymbolicData a x
+    , Support a x ~ ()
     , n ~ TypeSize a x
     , Eq (Bool (ArithmeticCircuit a)) (ArithmeticCircuit a (Vector n))
     ) => Eq (Bool (ArithmeticCircuit a)) (Structural x) where
 
     Structural x == Structural y =
-        let x' = pieces @a x
-            y' = pieces y
+        let x' = pieces @a x ()
+            y' = pieces y ()
          in x' == y'
 
     Structural x /= Structural y =
-        let x' = pieces @a x
-            y' = pieces y
+        let x' = pieces @a x ()
+            y' = pieces y ()
          in x' /= y'

--- a/src/ZkFold/Symbolic/Data/FFA.hs
+++ b/src/ZkFold/Symbolic/Data/FFA.hs
@@ -36,7 +36,6 @@ type Size = 7
 newtype FFA (p :: Natural) b = FFA (b (Vector Size))
 
 deriving newtype instance Arithmetic a => SymbolicData a (FFA p (ArithmeticCircuit a))
-deriving newtype instance Arithmetic a => Arithmetizable a (FFA p (ArithmeticCircuit a))
 
 coprimesDownFrom :: KnownNat n => Natural -> Vector n Natural
 coprimesDownFrom n = unfold (uncurry step) ([], [n,n-!1..0])

--- a/src/ZkFold/Symbolic/Data/Ord.hs
+++ b/src/ZkFold/Symbolic/Data/Ord.hs
@@ -81,7 +81,7 @@ deriving newtype instance (Arithmetic a, Haskell.Ord a) => Ord (Bool (Interprete
 deriving newtype instance Arithmetic a => Ord (Bool (ArithmeticCircuit a)) (FieldElement (ArithmeticCircuit a))
 
 -- | Every @SymbolicData@ type can be compared lexicographically.
-instance (SymbolicData a x, TypeSize a x ~ 1) => Ord (Bool (ArithmeticCircuit a)) (Lexicographical x) where
+instance (SymbolicData a x, Support a x ~ (), TypeSize a x ~ 1) => Ord (Bool (ArithmeticCircuit a)) (Lexicographical x) where
     x <= y = y >= x
 
     x <  y = y > x
@@ -94,10 +94,10 @@ instance (SymbolicData a x, TypeSize a x ~ 1) => Ord (Bool (ArithmeticCircuit a)
 
     min x y = bool @(Bool (ArithmeticCircuit a)) x y $ x > y
 
-getBitsBE :: forall a x . (SymbolicData a x, TypeSize a x ~ 1) => x -> ArithmeticCircuit a (V.Vector (NumberOfBits a))
+getBitsBE :: forall a x . (SymbolicData a x, Support a x ~ (), TypeSize a x ~ 1) => x -> ArithmeticCircuit a (V.Vector (NumberOfBits a))
 -- ^ @getBitsBE x@ returns a list of circuits computing bits of @x@, eldest to
 -- youngest.
-getBitsBE x = let expansion = binaryExpansion $ hmap (Par1 . V.item) (pieces @a @x x)
+getBitsBE x = let expansion = binaryExpansion $ hmap (Par1 . V.item) (pieces @a @x x ())
                in expansion { acOutput = V.reverse $ acOutput expansion }
 
 circuitGE :: forall a f . (Arithmetic a, Z.Zip f, Foldable f) => ArithmeticCircuit a f -> ArithmeticCircuit a f -> Bool (ArithmeticCircuit a)

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -61,7 +61,6 @@ deriving instance Generic (UInt n r backend)
 deriving instance (NFData (backend (Vector (NumberOfRegisters (BaseField backend) n r)))) => NFData (UInt n r backend)
 deriving instance (Haskell.Eq (backend (Vector (NumberOfRegisters (BaseField backend) n r)))) => Haskell.Eq (UInt n r backend)
 deriving instance (Haskell.Show (BaseField backend), Haskell.Show (backend (Vector (NumberOfRegisters (BaseField backend) n r)))) => Haskell.Show (UInt n r backend)
-deriving newtype instance Arithmetic a => Arithmetizable a (UInt n r (ArithmeticCircuit a))
 
 instance Arithmetic a => FieldElementData (Interpreter a) (UInt n r (Interpreter a)) where
     type TypeSize (Interpreter a) (UInt n r (Interpreter a)) = NumberOfRegisters a n r
@@ -217,11 +216,11 @@ instance (Finite (Zp p), KnownNat n, KnownRegisterSize r) => Iso (UInt n r (Inte
 --------------------------------------------------------------------------------
 
 instance Arithmetic a => SymbolicData a (UInt n r (ArithmeticCircuit a)) where
+    type Support a (UInt n r (ArithmeticCircuit a)) = ()
     type TypeSize a (UInt n r (ArithmeticCircuit a)) = NumberOfRegisters a n r
 
-    pieces (UInt c) = c
-
-    restore c o = UInt $ c `withOutputs` o
+    pieces (UInt c) _ = c
+    restore = UInt . ($ ())
 
 
 instance

--- a/tests/Tests/Blake2b.hs
+++ b/tests/Tests/Blake2b.hs
@@ -41,7 +41,7 @@ blake2bSimple =
 blake2bAC :: Spec
 blake2bAC =
     let bs = compile @(Zp BLS12_381_Scalar) (blake2b_512 @8 @(ArithmeticCircuit (Zp BLS12_381_Scalar))) :: ByteString 512 (ArithmeticCircuit (Zp BLS12_381_Scalar))
-        ac = pieces @(Zp BLS12_381_Scalar) bs
+        ac = pieces @(Zp BLS12_381_Scalar) bs ()
     in it "simple test with cardano-crypto " $ acSizeN ac == 564239
 
 specBlake2b :: IO ()


### PR DESCRIPTION
As mentioned in the title, the hierarchy is simplified by merging Arithmetizable and SymbolicData in one instance via the following trick: added the `Support` type which is unconstrained in the definition of a class; the constraint for it to be Symbolic too is added later, in the `compile` signature.