### PR TITLE
Merged Conditional into a single instance

### DIFF
--- a/examples/Examples/Fibonacci.hs
+++ b/examples/Examples/Fibonacci.hs
@@ -7,14 +7,15 @@ import           Prelude                                     hiding (Bool, Eq (.
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
+import           ZkFold.Symbolic.Class                       (Symbolic)
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Data.Bool                   (Bool (..))
-import           ZkFold.Symbolic.Data.Conditional            (Conditional, bool)
+import           ZkFold.Symbolic.Data.Conditional            (bool)
 import           ZkFold.Symbolic.Data.Eq                     (Eq (..))
 import           ZkFold.Symbolic.Data.FieldElement           (FieldElement)
 
 -- | The Fibonacci index function. If `x` is a Fibonacci number, returns its index (up until `nMax`). Otherwise, returns `0`.
-fibonacciIndex :: forall c . (Ring (FieldElement c), Eq (Bool c) (FieldElement c), Conditional (Bool c) (FieldElement c)) => Integer -> FieldElement c -> FieldElement c
+fibonacciIndex :: forall c . (Symbolic c, Ring (FieldElement c), Eq (Bool c) (FieldElement c)) => Integer -> FieldElement c -> FieldElement c
 fibonacciIndex nMax x = foldl (\m k -> bool m (fromConstant @Integer @(FieldElement c) k) (fib k one one == x :: Bool c)) zero [1..nMax]
     where
         fib :: Integer -> FieldElement c -> FieldElement c -> FieldElement c

--- a/src/ZkFold/Symbolic/Class.hs
+++ b/src/ZkFold/Symbolic/Class.hs
@@ -68,6 +68,18 @@ fromCircuit2F ::
 -- | Runs the binary @'CircuitFun'@ in a generic context.
 fromCircuit2F x y m = fromCircuitF (hpair x y) (uncurryP m)
 
+symbolic3F ::
+    (Symbolic c, BaseField c ~ a) => c f -> c g -> c h -> (f a -> g a -> h a -> k a) ->
+    (forall i m. MonadCircuit i a m => f i -> g i -> h i -> m (k i)) -> c k
+-- | Runs the ternary function from @f@, @g@ and @h@ into @k@ in a context @c@.
+symbolic3F x y z f m = symbolic2F (hpair x y) z (uncurryP f) (uncurryP m)
+
+fromCircuit3F ::
+    Symbolic c => c f -> c g -> c h ->
+    (forall i m. MonadCircuit i (BaseField c) m => f i -> g i -> h i -> m (k i)) -> c k
+-- | Runs the ternary @'CircuitFun'@ in a generic context.
+fromCircuit3F x y z m = fromCircuit2F (hpair x y) z (uncurryP m)
+
 symbolicVF ::
     (Symbolic c, BaseField c ~ a, Foldable f, Functor f) =>
     f (c g) -> (f (g a) -> h a) ->

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -17,8 +17,7 @@ import qualified Data.Zip                                                  as Z
 import           GHC.Generics                                              (Par1 (..))
 import           GHC.Num                                                   (integerToNatural)
 import           Prelude                                                   (Integer, Show, const, mempty, pure, return,
-                                                                            show, type (~), ($), (++), (.), (<$>),
-                                                                            (>>=))
+                                                                            show, ($), (++), (.), (<$>), (>>=))
 import qualified Prelude                                                   as Haskell
 import           System.Random                                             (mkStdGen)
 import           Test.QuickCheck                                           (Arbitrary (arbitrary), Gen, chooseInteger,
@@ -37,7 +36,6 @@ import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       hidin
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint (..), circuit, circuitF)
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.Class                                (SymbolicData (..))
-import           ZkFold.Symbolic.Data.Conditional
 import           ZkFold.Symbolic.Data.DiscreteField
 import           ZkFold.Symbolic.Data.Eq
 import           ZkFold.Symbolic.MonadCircuit                              (newAssigned)
@@ -171,26 +169,6 @@ instance Arithmetic a => DiscreteField (Bool (ArithmeticCircuit a)) (ArithmeticC
 instance (Arithmetic a, DiscreteField (Bool (ArithmeticCircuit a)) (ArithmeticCircuit a f)) => Eq (Bool (ArithmeticCircuit a)) (ArithmeticCircuit a f) where
     x == y = isZero (x - y)
     x /= y = not $ isZero (x - y)
-
-instance
-    ( Arithmetic a
-    , SymbolicData (ArithmeticCircuit a) x
-    , n ~ TypeSize (ArithmeticCircuit a) x
-    , KnownNat n
-    ) => Conditional (Bool (ArithmeticCircuit a)) x where
-
-    bool brFalse brTrue (Bool b) = restore ac
-        where
-            f' = pieces brFalse
-            t' = pieces brTrue
-            ac i = circuitF (solve i)
-
-            solve :: forall i m . MonadBlueprint i a m => Support (ArithmeticCircuit a) x -> m (Vector n i)
-            solve i = do
-                ts <- runCircuit (t' i)
-                fs <- runCircuit (f' i)
-                bs <- unPar1 <$> runCircuit b
-                V.zipWithM (\x y -> newAssigned $ \p -> p bs * (p x - p y) + p y) ts fs
 
 instance (Arithmetic a, Arbitrary a) => Arbitrary (ArithmeticCircuit a Par1) where
     arbitrary = do

--- a/src/ZkFold/Symbolic/Data/Conditional.hs
+++ b/src/ZkFold/Symbolic/Data/Conditional.hs
@@ -25,7 +25,9 @@ gif b x y = bool y x b
 (?) = gif
 
 instance (Symbolic c, SymbolicData c x) => Conditional (Bool c) x where
-    bool x y (Bool b) =
-      restore $ \s -> fromCircuit3F b (pieces x s) (pieces y s) $ \(Par1 c) ->
-          zipWithM $ \i j -> newAssigned $ \w -> w c * (w j - w i) + w i
-                                          -- ^ Is this really Plonk constraint?
+    bool x y (Bool b) = restore $ \s ->
+      fromCircuit3F b (pieces x s) (pieces y s) $ \(Par1 c) ->
+        zipWithM $ \i j -> do
+          i' <- newAssigned (\w -> (one - w c) * w i)
+          j' <- newAssigned (\w -> w c * w j)
+          newAssigned (\w -> w i' + w j')

--- a/src/ZkFold/Symbolic/Data/Conditional.hs
+++ b/src/ZkFold/Symbolic/Data/Conditional.hs
@@ -1,25 +1,31 @@
 module ZkFold.Symbolic.Data.Conditional where
 
 import           Data.Function                   (($))
-import           Data.Zip                        (zipWith)
-import           GHC.Generics                    (Par1 (..))
+import           GHC.Generics                    (Par1 (Par1))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Symbolic.Data.Bool       (Bool (Bool))
+import           ZkFold.Base.Data.Vector         (zipWithM)
+import           ZkFold.Symbolic.Class
+import           ZkFold.Symbolic.Data.Bool       (Bool (Bool), BoolType)
 import           ZkFold.Symbolic.Data.Class
-import           ZkFold.Symbolic.Interpreter     (Interpreter (..))
+import           ZkFold.Symbolic.MonadCircuit    (newAssigned)
 
-class Conditional b a where
+class BoolType b => Conditional b a where
+    -- | Properties:
+    --
+    -- [On true] @bool onFalse onTrue 'true' == onTrue@
+    --
+    -- [On false] @bool onFalse onTrue 'false' == onFalse@
     bool :: a -> a -> b -> a
 
-    gif :: b -> a -> a -> a
-    gif b x y = bool y x b
+gif :: Conditional b a => b -> a -> a -> a
+gif b x y = bool y x b
 
-    (?) :: b -> a -> a -> a
-    (?) = gif
+(?) :: Conditional b a => b -> a -> a -> a
+(?) = gif
 
-instance (Ring a, SymbolicData (Interpreter a) x) => Conditional (Bool (Interpreter a)) x where
-    bool x y (Bool (Interpreter (Par1 b))) =
-       restore $ \i -> Interpreter $ zipWith (\x' y' -> (one - b) * x' + b * y')
-          (runInterpreter $ pieces x i)
-          (runInterpreter $ pieces y i)
+instance (Symbolic c, SymbolicData c x) => Conditional (Bool c) x where
+    bool x y (Bool b) =
+      restore $ \s -> fromCircuit3F b (pieces x s) (pieces y s) $ \(Par1 c) ->
+          zipWithM $ \i j -> newAssigned $ \w -> w c * (w j - w i) + w i
+                                          -- ^ Is this really Plonk constraint?

--- a/src/ZkFold/Symbolic/Data/Ed25519.hs
+++ b/src/ZkFold/Symbolic/Data/Ed25519.hs
@@ -64,7 +64,6 @@ instance
     , SymbolicData c (UInt 256 Auto c)
     , AdditiveMonoid (UInt 256 Auto c)
     , Eq (Bool c) (UInt 256 Auto c)
-    , Conditional (Bool c) (Point (Ed25519 c))
     , S.BaseField c ~ a
     , r ~ NumberOfRegisters a 256 Auto
     , KnownNat r
@@ -104,9 +103,7 @@ instance
     , Extend (UInt 256 Auto c) (UInt 512 Auto c)
     , Shrink (UInt 512 Auto c) (UInt 256 Auto c)
     , Eq (Bool c) (UInt 512 Auto c)
-    , Conditional (Bool c) (UInt 512 Auto c, UInt 512 Auto c, UInt 512 Auto c)
     , BitState ByteString 256 c
-    , Conditional (Bool c) (Point (Ed25519 c))
     , Eq (Bool c) (UInt 256 Auto c)
     , FromConstant Natural (UInt 256 Auto c)
     , FromConstant Natural (UInt 512 Auto c)
@@ -144,12 +141,13 @@ instance
 
 acAdd25519
     :: forall c
-    .  AdditiveGroup (UInt 512 Auto c)
+    .  Symbolic c
+    => AdditiveGroup (UInt 512 Auto c)
     => EuclideanDomain (UInt 512 Auto c)
     => Extend (UInt 256 Auto c) (UInt 512 Auto c)
     => Shrink (UInt 512 Auto c) (UInt 256 Auto c)
     => Eq (Bool c) (UInt 512 Auto c)
-    => Conditional (Bool c) (UInt 512 Auto c, UInt 512 Auto c, UInt 512 Auto c)
+    => KnownNat (TypeSize c (UInt 512 Auto c))
     => Point (Ed25519 c)
     -> Point (Ed25519 c)
     -> Point (Ed25519 c)
@@ -205,12 +203,13 @@ acAdd25519 (Point x1 y1) (Point x2 y2) = Point (shrink x3) (shrink y3)
 
 acDouble25519
     :: forall c
-    .  EuclideanDomain (UInt 512 Auto c)
+    .  Symbolic c
+    => EuclideanDomain (UInt 512 Auto c)
     => AdditiveGroup (UInt 512 Auto c)
     => Extend (UInt 256 Auto c) (UInt 512 Auto c)
     => Shrink (UInt 512 Auto c) (UInt 256 Auto c)
     => Eq (Bool c) (UInt 512 Auto c)
-    => Conditional (Bool c) (UInt 512 Auto c, UInt 512 Auto c, UInt 512 Auto c)
+    => KnownNat (TypeSize c (UInt 512 Auto c))
     => Point (Ed25519 c)
     -> Point (Ed25519 c)
 acDouble25519 Inf = Inf

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -127,11 +127,12 @@ cast n =
 --
 eea
     :: forall n b r
-    .  EuclideanDomain (UInt n r b)
+    .  Symbolic b
+    => EuclideanDomain (UInt n r b)
     => KnownNat n
+    => KnownNat (NumberOfRegisters (BaseField b) n r)
     => AdditiveGroup (UInt n r b)
     => Eq (Bool b) (UInt n r b)
-    => Conditional (Bool b) (UInt n r b, UInt n r b, UInt n r b)
     => UInt n r b -> UInt n r b -> (UInt n r b, UInt n r b, UInt n r b)
 eea a b = eea' 1 a b one zero zero one
     where
@@ -253,6 +254,7 @@ instance
     , KnownNat (r + r)
     , KnownRegisterSize rs
     , r ~ NumberOfRegisters (BaseField b) n rs
+    , Symbolic b
     , NFData (b (Vector r))
     , Ord (Bool b) (UInt n rs b)
     , AdditiveGroup (UInt n rs b)
@@ -262,8 +264,6 @@ instance
     , BitState ByteString n b
     , Iso (ByteString n b) (UInt n rs b)
     , Eq (Bool b) (UInt n rs b)
-    , Conditional (Bool b) (UInt n rs b)
-    , Conditional (Bool b) (UInt n rs b, UInt n rs b)
     , 1 + (r - 1) ~ r
     , 1 <= r
     ) => EuclideanDomain (UInt n rs b) where

--- a/tests/Tests/Arithmetization/Test1.hs
+++ b/tests/Tests/Arithmetization/Test1.hs
@@ -11,16 +11,17 @@ import           Test.Hspec
 import           Test.QuickCheck
 
 import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Symbolic.Class             (Symbolic)
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Data.Bool         (Bool (..))
-import           ZkFold.Symbolic.Data.Conditional  (Conditional (..))
+import           ZkFold.Symbolic.Data.Conditional  ((?))
 import           ZkFold.Symbolic.Data.Eq           (Eq (..))
 import           ZkFold.Symbolic.Data.FieldElement (FieldElement)
 import           ZkFold.Symbolic.Interpreter       (Interpreter)
 import           ZkFold.Symbolic.MonadCircuit      (Arithmetic)
 
 -- f x y = if (2 / x > y) then (x ^ 2 + 3 * x + 5) else (4 * x ^ 3)
-testFunc :: forall c . (Field (FieldElement c), Eq (Bool c) (FieldElement c), Conditional (Bool c) (FieldElement c)) => FieldElement c -> FieldElement c -> FieldElement c
+testFunc :: forall c . (Symbolic c, Field (FieldElement c), Eq (Bool c) (FieldElement c)) => FieldElement c -> FieldElement c -> FieldElement c
 testFunc x y =
     let c  = fromConstant @Integer @(FieldElement c)
         g1 = x ^ (2 :: Natural) + c 3 * x + c 5


### PR DESCRIPTION
Merges two conditional instances into one, getting rid of most `Conditional` constraints in signatures (except for one in `Ledger.Types`, as here an instance of `SymbolicData` for `List` is required)

Also a question about circuit for conditionals: does this really introduce a Plonk constraint? The resulting constraint actually mentions 4 variables.