### PR TITLE
Migrated Ord to Symbolic API

### DIFF
--- a/examples/Examples/Eq.hs
+++ b/examples/Examples/Eq.hs
@@ -7,10 +7,10 @@ import           Prelude                                     hiding (Bool, Eq (.
 
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
+import           ZkFold.Symbolic.Class                       (Symbolic)
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Data.Bool                   (Bool (..))
 import           ZkFold.Symbolic.Data.Eq                     (Eq (..))
-import           ZkFold.Symbolic.Class                       (Symbolic)
 import           ZkFold.Symbolic.Data.FieldElement           (FieldElement)
 
 -- | (==) operation

--- a/examples/Examples/LEQ.hs
+++ b/examples/Examples/LEQ.hs
@@ -7,13 +7,14 @@ import           Prelude                                     hiding (Bool, Eq (.
 
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
+import           ZkFold.Symbolic.Class                       (Symbolic)
 import           ZkFold.Symbolic.Compiler
-import           ZkFold.Symbolic.Data.Bool                   (Bool (..))
+import           ZkFold.Symbolic.Data.Bool                   (Bool)
 import           ZkFold.Symbolic.Data.FieldElement           (FieldElement)
-import           ZkFold.Symbolic.Data.Ord                    (Ord (..))
+import           ZkFold.Symbolic.Data.Ord                    ((<=))
 
 -- | (<=) operation
-leq :: Ord (Bool c) (FieldElement c) => FieldElement c -> FieldElement c -> Bool c
+leq :: Symbolic c => FieldElement c -> FieldElement c -> Bool c
 leq x y = x <= y
 
 exampleLEQ :: IO ()

--- a/src/ZkFold/Base/Protocol/ARK/Plonk.hs
+++ b/src/ZkFold/Base/Protocol/ARK/Plonk.hs
@@ -106,11 +106,7 @@ instance forall n l c1 c2 t plonk f g1.
         , KnownNat l
         , KnownNat (PlonkPermutationSize n)
         , KnownNat (PlonkPolyExtendedLength n)
-        , Eq (ScalarField c1)
-        , Scale (ScalarField c1) (ScalarField c1)
-        , BinaryExpansion (ScalarField c1)
-        , Bits (ScalarField c1) ~ [ScalarField c1]
-        , FiniteField (ScalarField c1)
+        , Arithmetic f
         , AdditiveGroup (BaseField c1)
         , Pairing c1 c2
         , ToTranscript t (ScalarField c1)

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Combinators.hs
@@ -68,7 +68,7 @@ embedVar x = newAssigned $ const (fromConstant x)
 embedAll :: forall a n . (Arithmetic a, KnownNat n) => a -> ArithmeticCircuit a (Vector n)
 embedAll x = circuitF $ Vector <$> replicateM (fromIntegral $ value @n) (newAssigned $ const (fromConstant x))
 
-expansion :: MonadBlueprint i a m => Natural -> i -> m [i]
+expansion :: MonadCircuit i a m => Natural -> i -> m [i]
 -- ^ @expansion n k@ computes a binary expansion of @k@ if it fits in @n@ bits.
 expansion n k = do
     bits <- bitsOf n k
@@ -88,7 +88,7 @@ splitExpansion n1 n2 k = do
     constraint (\x -> x k - x l - scale (2 ^ n1 :: Natural) (x h))
     return (l, h)
 
-bitsOf :: MonadBlueprint i a m => Natural -> i -> m [i]
+bitsOf :: MonadCircuit i a m => Natural -> i -> m [i]
 -- ^ @bitsOf n k@ creates @n@ bits and sets their witnesses equal to @n@ smaller
 -- bits of @k@.
 bitsOf n k = for [0 .. n -! 1] $ \j ->
@@ -97,7 +97,7 @@ bitsOf n k = for [0 .. n -! 1] $ \j ->
         repr :: forall b . (BinaryExpansion b, Bits b ~ [b], Finite b) => b -> [b]
         repr = padBits (numberOfBits @b) . binaryExpansion
 
-horner :: MonadBlueprint i a m => [i] -> m i
+horner :: MonadCircuit i a m => [i] -> m i
 -- ^ @horner [b0,...,bn]@ computes the sum @b0 + 2 b1 + ... + 2^n bn@ using
 -- Horner's scheme.
 horner xs = case reverse xs of

--- a/src/ZkFold/Symbolic/Data/Eq/Structural.hs
+++ b/src/ZkFold/Symbolic/Data/Eq/Structural.hs
@@ -5,9 +5,9 @@ module ZkFold.Symbolic.Data.Eq.Structural where
 
 import           Prelude                    (type (~))
 
+import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.Class
-import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Data.Eq
 
 newtype Structural a = Structural a

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -293,12 +293,12 @@ instance (Arithmetic a, KnownNat n, KnownRegisterSize r, KnownNat (NumberOfRegis
     u1 >= u2 =
         let ByteString rs1 = from u1 :: ByteString n (ArithmeticCircuit a)
             ByteString rs2 = from u2 :: ByteString n (ArithmeticCircuit a)
-         in circuitGE rs1 rs2
+         in bitwiseGE rs1 rs2
 
     u1 > u2 =
         let ByteString rs1 = from u1 :: ByteString n (ArithmeticCircuit a)
             ByteString rs2 = from u2 :: ByteString n (ArithmeticCircuit a)
-         in circuitGT rs1 rs2
+         in bitwiseGT rs1 rs2
 
     max x y = bool @(Bool (ArithmeticCircuit a)) x y $ x < y
 

--- a/src/ZkFold/Symbolic/MonadCircuit.hs
+++ b/src/ZkFold/Symbolic/MonadCircuit.hs
@@ -9,6 +9,7 @@ import           Data.Eq                         (Eq)
 import           Data.Function                   (id)
 import           Data.Functor                    (Functor)
 import           Data.Functor.Identity           (Identity (..))
+import           Data.Ord                        (Ord)
 import           Data.Type.Equality              (type (~))
 
 import           ZkFold.Base.Algebra.Basic.Class
@@ -105,8 +106,9 @@ class Monad m => MonadCircuit i a m | m -> i, m -> a where
     newAssigned :: ClosedPoly i a -> m i
     newAssigned p = newConstrained (\x i -> p x - x i) p
 
--- | Field of witnesses with decidable equality is called an ``arithmetic'' field.
-type Arithmetic a = (WitnessField a, Eq a)
+-- | Field of witnesses with decidable equality and ordering
+-- is called an ``arithmetic'' field.
+type Arithmetic a = (WitnessField a, Eq a, Ord a)
 
 -- | An example implementation of a @'MonadCircuit'@ which computes witnesses
 -- immediately and drops the constraints.

--- a/tests/Tests/Arithmetization/Test3.hs
+++ b/tests/Tests/Arithmetization/Test3.hs
@@ -9,16 +9,17 @@ import           Test.Hspec
 
 import           ZkFold.Base.Algebra.Basic.Class   (fromConstant)
 import           ZkFold.Base.Algebra.Basic.Field   (Zp)
+import           ZkFold.Symbolic.Class             (Symbolic)
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Data.Bool         (Bool (..))
 import           ZkFold.Symbolic.Data.FieldElement (FieldElement)
-import           ZkFold.Symbolic.Data.Ord          (Ord (..))
+import           ZkFold.Symbolic.Data.Ord          ((<=))
 import           ZkFold.Symbolic.Interpreter       (Interpreter (Interpreter))
 
 type R = ArithmeticCircuit (Zp 97)
 
 -- A comparison test
-testFunc :: Ord (Bool c) (FieldElement c) => FieldElement c -> FieldElement c -> Bool c
+testFunc :: Symbolic c => FieldElement c -> FieldElement c -> Bool c
 testFunc x y = x <= y
 
 specArithmetization3 :: Spec

--- a/tests/Tests/Arithmetization/Test4.hs
+++ b/tests/Tests/Arithmetization/Test4.hs
@@ -18,11 +18,11 @@ import           ZkFold.Base.Protocol.ARK.Plonk              (Plonk (..), PlonkP
                                                               plonkVerifierInput)
 import           ZkFold.Base.Protocol.ARK.Plonk.Internal     (getParams)
 import           ZkFold.Base.Protocol.NonInteractiveProof    (NonInteractiveProof (..))
+import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Compiler                    (ArithmeticCircuit (..), acValue, applyArgs, compile)
 import           ZkFold.Symbolic.Data.Bool                   (Bool (..))
 import           ZkFold.Symbolic.Data.Eq                     (Eq (..))
 import           ZkFold.Symbolic.Data.FieldElement           (FieldElement)
-import           ZkFold.Symbolic.Class
 
 type N = 1
 


### PR DESCRIPTION
Migrated basic `Ord` instances to Symbolic API.
Motivation for adding `Haskell.Ord a` to `Arithmetic a` is that this is actually implied anyway bc we can convert `a` to `Natural` via `BinaryExpansion a` and `Haskell.Eq a`