### PR TITLE
Symbolic `FieldElement`

### DIFF
--- a/examples/Examples/MiMCHash.hs
+++ b/examples/Examples/MiMCHash.hs
@@ -2,7 +2,6 @@
 
 module Examples.MiMCHash (exampleMiMC) where
 
-import           GHC.Generics                                   (Par1)
 import           Prelude                                        hiding (Eq (..), Num (..), any, not, (!!), (/), (^),
                                                                  (||))
 
@@ -12,6 +11,7 @@ import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381    (BLS12_381_Scala
 import           ZkFold.Symbolic.Algorithms.Hash.MiMC           (mimcHash2)
 import           ZkFold.Symbolic.Algorithms.Hash.MiMC.Constants (mimcConstants)
 import           ZkFold.Symbolic.Compiler
+import           ZkFold.Symbolic.Data.FieldElement              (FieldElement)
 
 type F = Zp BLS12_381_Scalar
 
@@ -21,4 +21,4 @@ exampleMiMC = do
 
     putStrLn "\nExample: MiMC hash function\n"
 
-    compileIO @F file (mimcHash2 @F @(ArithmeticCircuit F Par1) mimcConstants zero)
+    compileIO @F file (mimcHash2 @F @(FieldElement (ArithmeticCircuit F)) mimcConstants zero)

--- a/src/ZkFold/Symbolic/Algorithms/Hash/MiMC.hs
+++ b/src/ZkFold/Symbolic/Algorithms/Hash/MiMC.hs
@@ -4,7 +4,6 @@
 module ZkFold.Symbolic.Algorithms.Hash.MiMC where
 
 import           Data.List.NonEmpty                (NonEmpty ((:|)), nonEmpty)
-import           GHC.Generics                      (Par1)
 import           Numeric.Natural                   (Natural)
 import           Prelude                           hiding (Eq (..), Num (..), any, length, not, (!!), (/), (^), (||))
 
@@ -40,5 +39,5 @@ mimcHashN xs k = go
 class MiMCHash a c x where
     mimcHash :: [a] -> a -> x -> FieldElement c
 
-instance (Symbolic c, BaseField c ~ a, SymbolicData c x, Support c x ~ (), FromConstant a (c Par1), Ring (c Par1)) => MiMCHash a c x where
-    mimcHash xs k = FieldElement . mimcHashN xs k . fromVector . unpacked . flip pieces ()
+instance (Symbolic c, BaseField c ~ a, SymbolicData c x, Support c x ~ ()) => MiMCHash a c x where
+    mimcHash xs k = mimcHashN xs k . fromVector . fmap FieldElement . unpacked . flip (pieces @c) ()

--- a/src/ZkFold/Symbolic/Cardano/Contracts/BatchTransfer.hs
+++ b/src/ZkFold/Symbolic/Cardano/Contracts/BatchTransfer.hs
@@ -34,7 +34,6 @@ type Sig context =
     , StrictConv (context Par1) (UInt 256 Auto context)
     , FromConstant Natural (UInt 256 Auto context)
     , MultiplicativeSemigroup (UInt 256 Auto context)
-    , AdditiveMonoid (context Par1)
     , MiMCHash F context (TxOut context, TxOut context)
     , Eq (Bool context) (UInt 256 Auto context)
     , Eq (Bool context) (TxOut context)

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -1,172 +1,46 @@
 {-# LANGUAGE AllowAmbiguousTypes  #-}
 {-# LANGUAGE DerivingStrategies   #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans     #-}
 
 module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Instance where
 
-import           Control.Monad                                             (foldM, replicateM)
-import           Data.Aeson                                                hiding (Bool)
-import           Data.Map                                                  hiding (drop, foldl, foldl', foldr, map,
-                                                                            null, splitAt, take)
-import           Data.Traversable                                          (Traversable, for)
-import qualified Data.Zip                                                  as Z
-import           GHC.Generics                                              (Par1 (..))
-import           GHC.Num                                                   (integerToNatural)
-import           Prelude                                                   (Integer, Show, const, mempty, pure, return,
-                                                                            show, ($), (++), (.), (<$>), (>>=))
-import qualified Prelude                                                   as Haskell
-import           System.Random                                             (mkStdGen)
-import           Test.QuickCheck                                           (Arbitrary (arbitrary), Gen, chooseInteger,
-                                                                            elements)
+import           Data.Aeson                                             hiding (Bool)
+import           Data.Map                                               hiding (drop, foldl, foldl', foldr, map, null,
+                                                                         splitAt, take)
+import           GHC.Generics                                           (Par1 (..))
+import           GHC.Num                                                (integerToNatural)
+import           Prelude                                                (Show, mempty, pure, return, show, ($), (++),
+                                                                         (<$>))
+import qualified Prelude                                                as Haskell
+import           System.Random                                          (mkStdGen)
+import           Test.QuickCheck                                        (Arbitrary (arbitrary), Gen, chooseInteger,
+                                                                         elements)
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Number
-import           ZkFold.Base.Data.Par1                                     ()
-import qualified ZkFold.Base.Data.Vector                                   as V
-import           ZkFold.Base.Data.Vector                                   (Vector (..))
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embed, embedAll, embedV, expansion,
-                                                                            foldCircuit, getAllVars, horner, invertC,
-                                                                            isZeroC)
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal       hiding (constraint)
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint (MonadBlueprint (..), circuit, circuitF)
-import           ZkFold.Symbolic.Data.Bool
-import           ZkFold.Symbolic.Data.DiscreteField
-import           ZkFold.Symbolic.MonadCircuit                              (newAssigned)
+import           ZkFold.Base.Data.Par1                                  ()
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (getAllVars)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal    hiding (constraint)
+import           ZkFold.Symbolic.Data.FieldElement                      (FieldElement (..))
 
 ------------------------------------- Instances -------------------------------------
-
--- TODO: I had to add these constraints and I don't like them
-instance
-    ( KnownNat (n * Order a)
-    , KnownNat (Log2 (n * Order a - 1) + 1)
-    ) => Finite (ArithmeticCircuit a (Vector n)) where
-    type Order (ArithmeticCircuit a (Vector n)) = n * Order a
-
-instance (Arithmetic a, Z.Zip f, Traversable f) => AdditiveSemigroup (ArithmeticCircuit a f) where
-    r1 + r2 = circuitF $ do
-        is <- runCircuit r1
-        js <- runCircuit r2
-        for (Z.zip is js) $ \(i, j) -> newAssigned (\x -> x i + x j)
-
-instance (Arithmetic a, Scale c a, Traversable f) => Scale c (ArithmeticCircuit a f) where
-    scale c r = circuitF $ do
-        is <- runCircuit r
-        for is $ \i -> newAssigned (\x -> (c `scale` one :: a) `scale` x i)
-
-instance (Arithmetic a, KnownNat n) => AdditiveMonoid (ArithmeticCircuit a (Vector n)) where
-    zero = circuitF $ Vector <$> replicateM (Haskell.fromIntegral $ value @n) (newAssigned (const zero))
-
-instance Arithmetic a => AdditiveMonoid (ArithmeticCircuit a Par1) where
-    zero = embed zero
-
-instance (Arithmetic a, Z.Zip f, Traversable f, AdditiveMonoid (ArithmeticCircuit a f)) => AdditiveGroup (ArithmeticCircuit a f) where
-    negate r = circuitF $ do
-        is <- runCircuit r
-        for is $ \i -> newAssigned (\x -> negate (x i))
-
-    r1 - r2 = circuitF $ do
-        is <- runCircuit r1
-        js <- runCircuit r2
-        for (Z.zip is js) $ \(i, j) -> newAssigned (\x -> x i - x j)
-
-instance (Arithmetic a, Z.Zip f, Traversable f) => MultiplicativeSemigroup (ArithmeticCircuit a f) where
-    r1 * r2 = circuitF $ do
-        is <- runCircuit r1
-        js <- runCircuit r2
-        for (Z.zip is js) $ \(i, j) -> newAssigned (\x -> x i * x j)
-
-instance MultiplicativeMonoid (ArithmeticCircuit a f) => Exponent (ArithmeticCircuit a f) Natural where
-    (^) = natPow
-
-instance (Arithmetic a, KnownNat n) => MultiplicativeMonoid (ArithmeticCircuit a (Vector n)) where
-    one = embedV (pure one)
-
-instance Arithmetic a => MultiplicativeMonoid (ArithmeticCircuit a Par1) where
-    one = embed one
-
--- TODO: The constant will be replicated in all outputs. Is this the desired behaviour?
-instance (Arithmetic a, FromConstant b a, KnownNat n) => FromConstant b (ArithmeticCircuit a (Vector n)) where
-    fromConstant c = embedAll (fromConstant c)
-
-instance (Arithmetic a, FromConstant b a) => FromConstant b (ArithmeticCircuit a Par1) where
-    fromConstant c = embed (fromConstant c)
-
-instance (Arithmetic a, KnownNat n) => Semiring (ArithmeticCircuit a (Vector n))
-
-instance Arithmetic a => Semiring (ArithmeticCircuit a Par1)
-
-instance (Arithmetic a, KnownNat n) => Ring (ArithmeticCircuit a (Vector n))
-
-instance Arithmetic a => Ring (ArithmeticCircuit a Par1)
-
-instance (Arithmetic a, Field (ArithmeticCircuit a f)) => Exponent (ArithmeticCircuit a f) Integer where
-    (^) = intPowF
-
-instance (Arithmetic a, KnownNat n) => Field (ArithmeticCircuit a (Vector n)) where
-    finv = invertC
-    rootOfUnity n = embedAll <$> rootOfUnity n
-
-instance Arithmetic a => Field (ArithmeticCircuit a Par1) where
-    finv = invertC
-    rootOfUnity n = embed <$> rootOfUnity n
-
--- TODO: The only implementation that seems to make sense is when there is only one output.
--- It is true?
---
--- Anyway, @binaryExpansion@ of an arithmetic circuit will return copies of the same circuit with different outputs.
--- The whole point of this refactor was to avoid this.
---
--- Ideally, we want to return another ArithmeticCircuit with a number of outputs corresponding to the number of bits.
--- This does not align well with the type of @binaryExpansion@
-instance Arithmetic a => BinaryExpansion (ArithmeticCircuit a Par1) where
-    type Bits (ArithmeticCircuit a Par1) = ArithmeticCircuit a (Vector (NumberOfBits a))
-    binaryExpansion r = circuitF $ do
-        output <- runCircuit r
-        bits   <- expansion (numberOfBits @a) . unPar1 $ output
-        pure $ V.unsafeToVector bits
-    fromBinary bits = circuit $ runCircuit bits >>= horner . V.fromVector
-
-instance (Arithmetic a, Z.Zip f, Traversable f, Field (ArithmeticCircuit a f)) => DiscreteField' (ArithmeticCircuit a f) where
-    equal r1 r2 = isZeroC (r1 - r2)
-
-instance Arithmetic a => TrichotomyField (ArithmeticCircuit a Par1) where
-    trichotomy r1 r2 =
-        let
-            bits1 = binaryExpansion r1
-            bits2 = binaryExpansion r2
-            -- zip pairs of bits in {0,1} to orderings in {-1,0,1}
-            comparedBits = bits1 - bits2
-            -- least significant bit first,
-            -- reverse lexicographical ordering
-            reverseLexicographical x y = newAssigned $ \p -> p y * p y * (p y - p x) + p x
-        in
-            foldCircuit reverseLexicographical comparedBits
-
-instance (Arithmetic a, KnownNat n, 1 <= n) => DiscreteField (Bool (ArithmeticCircuit a)) (ArithmeticCircuit a (Vector n)) where
-    isZero x = Bool $ circuit $ do
-        bools <- runCircuit $ isZeroC x
-        foldM (\i j -> newAssigned (\p -> p i * p j)) (V.head bools) (V.tail bools)
-
-instance Arithmetic a => DiscreteField (Bool (ArithmeticCircuit a)) (ArithmeticCircuit a Par1) where
-    isZero = Bool . isZeroC
 
 instance (Arithmetic a, Arbitrary a) => Arbitrary (ArithmeticCircuit a Par1) where
     arbitrary = do
         k <- integerToNatural <$> chooseInteger (2, 10)
         let ac = mempty { acInput = [1..k], acOutput = pure k }
-        arbitrary' ac 10
+        fromFieldElement <$> arbitrary' (FieldElement ac) 10
 
-arbitrary' :: forall a . (Arithmetic a, Arbitrary a, FromConstant a a) => ArithmeticCircuit a Par1 -> Natural -> Gen (ArithmeticCircuit a Par1)
+arbitrary' :: forall a . (Arithmetic a, Arbitrary a, FromConstant a a) => FieldElement (ArithmeticCircuit a) -> Natural -> Gen (FieldElement (ArithmeticCircuit a))
 arbitrary' ac 0 = return ac
 arbitrary' ac iter = do
-    let vars = getAllVars ac
+    let vars = getAllVars (fromFieldElement ac)
     li <- elements vars
     ri <- elements vars
-    let (l, r) =( ac { acOutput = pure li }, ac { acOutput = pure ri })
+    let (l, r) = ( FieldElement (fromFieldElement ac) { acOutput = pure li }
+                 , FieldElement (fromFieldElement ac) { acOutput = pure ri })
     ac' <- elements [
         l + r
         , l * r

--- a/src/ZkFold/Symbolic/Data/ByteString.hs
+++ b/src/ZkFold/Symbolic/Data/ByteString.hs
@@ -403,7 +403,7 @@ bitwiseOperation (ByteString bits1) (ByteString bits2) cons = ByteString $ circu
 
 
 instance (Arithmetic a, KnownNat n) => BoolType (ByteString n (ArithmeticCircuit a)) where
-    false = ByteString zero
+    false = ByteString $ embedV (pure zero)
 
     true = not false
 

--- a/src/ZkFold/Symbolic/Data/FieldElement.hs
+++ b/src/ZkFold/Symbolic/Data/FieldElement.hs
@@ -117,10 +117,10 @@ instance Symbolic c => TrichotomyField (FieldElement c) where
         delta <- for (zip is js) $ \(bi, bj) -> newAssigned (\w -> w bi - w bj)
         -- least significant bit first,
         -- reverse lexicographical ordering
-        let reverseLexicographical u v = do
+        let reverseLexicographical v u = do
               is0 <- newAssigned (\p -> one - p u * p u)
               v' <- newAssigned (\p -> p is0 * p v)
-              newAssigned (\p -> p u + p v')
+              newAssigned (\p -> p v' + p u)
         Par1 <$> case delta of
           []     -> newAssigned zero
           (d:ds) -> foldlM reverseLexicographical d ds

--- a/src/ZkFold/Symbolic/Data/FieldElement.hs
+++ b/src/ZkFold/Symbolic/Data/FieldElement.hs
@@ -117,8 +117,10 @@ instance Symbolic c => TrichotomyField (FieldElement c) where
         delta <- for (zip is js) $ \(bi, bj) -> newAssigned (\w -> w bi - w bj)
         -- least significant bit first,
         -- reverse lexicographical ordering
-        let reverseLexicographical u v = newAssigned $ \p -> p v * p v * (p v - p u) + p u
-                                                      -- ^ Is this Plonk?
+        let reverseLexicographical u v = do
+              is0 <- newAssigned (\p -> one - p u * p u)
+              v' <- newAssigned (\p -> p is0 * p v)
+              newAssigned (\p -> p u + p v')
         Par1 <$> case delta of
           []     -> newAssigned zero
           (d:ds) -> foldlM reverseLexicographical d ds

--- a/src/ZkFold/Symbolic/Data/Ord.hs
+++ b/src/ZkFold/Symbolic/Data/Ord.hs
@@ -24,7 +24,6 @@ import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators (expansi
 import           ZkFold.Symbolic.Data.Bool                              (Bool (..))
 import           ZkFold.Symbolic.Data.Class
 import           ZkFold.Symbolic.Data.Conditional                       (Conditional (..))
-import           ZkFold.Symbolic.Data.FieldElement                      (FieldElement (..))
 import           ZkFold.Symbolic.MonadCircuit                           (MonadCircuit, newAssigned)
 
 -- TODO (Issue #23): add `compare`
@@ -61,9 +60,6 @@ newtype Lexicographical a = Lexicographical a
 -- (though not necessarily a most effective one)
 
 deriving newtype instance SymbolicData c a => SymbolicData c (Lexicographical a)
-
-deriving via (Lexicographical (FieldElement c))
-  instance Symbolic c => Ord (Bool c) (FieldElement c)
 
 -- | Every @SymbolicData@ type can be compared lexicographically.
 instance

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -41,7 +41,7 @@ import           ZkFold.Base.Data.Vector                                   (Vect
 import           ZkFold.Prelude                                            (drop, length, replicate, replicateA)
 import           ZkFold.Symbolic.Class                                     hiding (embed)
 import           ZkFold.Symbolic.Compiler
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embedV, expansion, splitExpansion)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embedV, expansion, splitExpansion, embed)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.ByteString
@@ -53,6 +53,7 @@ import           ZkFold.Symbolic.Data.Eq.Structural
 import           ZkFold.Symbolic.Data.Ord
 import           ZkFold.Symbolic.Interpreter                               (Interpreter (..))
 import           ZkFold.Symbolic.MonadCircuit                              (constraint, newAssigned)
+import Control.Applicative (pure)
 
 -- TODO (Issue #18): hide this constructor
 newtype UInt (n :: Natural) (r :: RegisterSize) (backend :: (Type -> Type) -> Type) = UInt (backend (Vector (NumberOfRegisters (BaseField backend) n r)))
@@ -329,7 +330,7 @@ instance
     , KnownNat (NumberOfRegisters a n r)
     , KnownRegisterSize r
     ) => AdditiveMonoid (UInt n r (ArithmeticCircuit a)) where
-    zero = UInt zero
+    zero = UInt $ embedV (pure zero)
 
 instance
     ( Arithmetic a
@@ -451,7 +452,7 @@ instance
     , (NumberOfRegisters a n r - 1) + 1 ~ NumberOfRegisters a n r
     ) => MultiplicativeMonoid (UInt n r (ArithmeticCircuit a)) where
 
-    one = UInt $ hliftA2 (\(Par1 h) t -> h V..: t) (one :: ArithmeticCircuit a Par1) (zero :: ArithmeticCircuit a (Vector (NumberOfRegisters a n r - 1)))
+    one = UInt $ hliftA2 (\(Par1 h) t -> h V..: t) (embed one :: ArithmeticCircuit a Par1) (embedV (pure zero) :: ArithmeticCircuit a (Vector (NumberOfRegisters a n r - 1)))
 
 
 instance

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -15,6 +15,7 @@ module ZkFold.Symbolic.Data.UInt (
     eea
 ) where
 
+import           Control.Applicative                                       (pure)
 import           Control.DeepSeq
 import           Control.Monad.State                                       (StateT (..))
 import           Data.Foldable                                             (foldr, foldrM, for_)
@@ -41,7 +42,7 @@ import           ZkFold.Base.Data.Vector                                   (Vect
 import           ZkFold.Prelude                                            (drop, length, replicate, replicateA)
 import           ZkFold.Symbolic.Class                                     hiding (embed)
 import           ZkFold.Symbolic.Compiler
-import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embedV, expansion, splitExpansion, embed)
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Combinators    (embed, embedV, expansion, splitExpansion)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.MonadBlueprint
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.ByteString
@@ -53,7 +54,6 @@ import           ZkFold.Symbolic.Data.Eq.Structural
 import           ZkFold.Symbolic.Data.Ord
 import           ZkFold.Symbolic.Interpreter                               (Interpreter (..))
 import           ZkFold.Symbolic.MonadCircuit                              (constraint, newAssigned)
-import Control.Applicative (pure)
 
 -- TODO (Issue #18): hide this constructor
 newtype UInt (n :: Natural) (r :: RegisterSize) (backend :: (Type -> Type) -> Type) = UInt (backend (Vector (NumberOfRegisters (BaseField backend) n r)))

--- a/src/ZkFold/Symbolic/Interpreter.hs
+++ b/src/ZkFold/Symbolic/Interpreter.hs
@@ -2,12 +2,11 @@ module ZkFold.Symbolic.Interpreter (Interpreter (..)) where
 
 import           Control.DeepSeq                  (NFData)
 import           Data.Eq                          (Eq)
-import           Data.Function                    (($), (.))
+import           Data.Function                    (($))
 import           Data.Functor                     ((<$>))
-import           GHC.Generics                     (Generic, Par1 (Par1))
+import           GHC.Generics                     (Generic)
 import           Text.Show                        (Show)
 
-import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Control.HApplicative
 import           ZkFold.Base.Data.HFunctor
 import           ZkFold.Base.Data.Package
@@ -30,43 +29,3 @@ instance Package (Interpreter a) where
 instance Arithmetic a => Symbolic (Interpreter a) where
   type BaseField (Interpreter a) = a
   symbolicF (Interpreter x) f _ = Interpreter (f x)
-
-value :: Interpreter a Par1 -> a
-value (Interpreter (Par1 x)) = x
-
-const :: a -> Interpreter a Par1
-const = Interpreter . Par1
-
-instance MultiplicativeSemigroup a => MultiplicativeSemigroup (Interpreter a Par1) where
-  (value -> x) * (value -> y) = const (x * y)
-
-instance Exponent a p => Exponent (Interpreter a Par1) p where
-  (value -> x) ^ p = const (x ^ p)
-
-instance MultiplicativeMonoid a => MultiplicativeMonoid (Interpreter a Par1) where
-  one = const one
-
-instance Scale c a => Scale c (Interpreter a Par1) where
-  scale k (value -> x) = const (scale k x)
-
-instance AdditiveSemigroup a => AdditiveSemigroup (Interpreter a Par1) where
-  (value -> x) + (value -> y) = const (x + y)
-
-instance AdditiveMonoid a => AdditiveMonoid (Interpreter a Par1) where
-  zero = const zero
-
-instance AdditiveGroup a => AdditiveGroup (Interpreter a Par1) where
-  negate (value -> x) = const (negate x)
-  (value -> x) - (value -> y) = const (x - y)
-
-instance FromConstant c a => FromConstant c (Interpreter a Par1) where
-  fromConstant = const . fromConstant
-
-instance Semiring a => Semiring (Interpreter a Par1)
-
-instance Ring a => Ring (Interpreter a Par1)
-
-instance Field a => Field (Interpreter a Par1) where
-  finv (value -> x) = const (finv x)
-  (value -> x) // (value -> y) = const (x // y)
-  rootOfUnity n = const <$> rootOfUnity n


### PR DESCRIPTION
Migrated `FieldElement` to `Symbolic` API, removed algebraic instances of contexts

Note: in TrichotomyField instance, the constraint might not be Plonk.