### PR TITLE
Made `SymbolicData` to be single-param

### DIFF
--- a/src/ZkFold/Symbolic/Algorithms/Hash/MiMC.hs
+++ b/src/ZkFold/Symbolic/Algorithms/Hash/MiMC.hs
@@ -4,6 +4,7 @@
 module ZkFold.Symbolic.Algorithms.Hash.MiMC where
 
 import           Data.List.NonEmpty                (NonEmpty ((:|)), nonEmpty)
+import           Data.Proxy                        (Proxy (..))
 import           Numeric.Natural                   (Natural)
 import           Prelude                           hiding (Eq (..), Num (..), any, length, not, (!!), (/), (^), (||))
 
@@ -39,5 +40,5 @@ mimcHashN xs k = go
 class MiMCHash a c x where
     mimcHash :: [a] -> a -> x -> FieldElement c
 
-instance (Symbolic c, BaseField c ~ a, SymbolicData c x, Support c x ~ ()) => MiMCHash a c x where
-    mimcHash xs k = mimcHashN xs k . fromVector . fmap FieldElement . unpacked . flip (pieces @c) ()
+instance (Symbolic c, BaseField c ~ a, SymbolicData x, Context x ~ c, Support x ~ Proxy c) => MiMCHash a c x where
+    mimcHash xs k = mimcHashN xs k . fromVector . fmap FieldElement . unpacked . flip pieces Proxy

--- a/src/ZkFold/Symbolic/Cardano/Types/Address.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/Address.hs
@@ -21,7 +21,7 @@ newtype Address context = Address (AddressType context, (PaymentCredential conte
 deriving instance (Haskell.Eq (ByteString 4 context), Haskell.Eq (ByteString 224 context))
     => Haskell.Eq (Address context)
 
-deriving instance HApplicative context => SymbolicData context (Address context)
+deriving instance HApplicative context => SymbolicData (Address context)
 
 deriving via (Structural (Address CtxCompilation))
          instance Eq (Bool CtxCompilation) (Address CtxCompilation)

--- a/src/ZkFold/Symbolic/Cardano/Types/Input.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/Input.hs
@@ -25,10 +25,10 @@ deriving instance
 deriving instance
     ( Symbolic context
     , KnownNat tokens
-    , KnownNat (TypeSize context (OutputRef context))
-    , KnownNat (TypeSize context (SingleAsset context))
-    , KnownNat (TypeSize context (Value tokens context))
-    ) => SymbolicData context (Input tokens datum context)
+    , KnownNat (TypeSize (OutputRef context))
+    , KnownNat (TypeSize (SingleAsset context))
+    , KnownNat (TypeSize (Value tokens context))
+    ) => SymbolicData (Input tokens datum context)
 
 txiOutputRef :: Input tokens datum context -> OutputRef context
 txiOutputRef (Input (ref, _)) = ref

--- a/src/ZkFold/Symbolic/Cardano/Types/Output.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/Output.hs
@@ -34,17 +34,17 @@ deriving instance
 
 deriving instance
     ( Symbolic context
-    , KnownNat (TypeSize context (Value tokens context))
-    , KnownNat (TypeSize context (SingleAsset context))
+    , KnownNat (TypeSize (Value tokens context))
+    , KnownNat (TypeSize (SingleAsset context))
     , KnownNat tokens
-    ) => SymbolicData context (Output tokens datum context)
+    ) => SymbolicData (Output tokens datum context)
 
 deriving via (Structural (Output tokens datum CtxCompilation))
          instance
-            ( ts ~ TypeSize CtxCompilation (Output tokens datum CtxCompilation)
+            ( ts ~ TypeSize (Output tokens datum CtxCompilation)
             , 1 <= ts
             , KnownNat tokens
-            , KnownNat (TypeSize CtxCompilation (Value tokens CtxCompilation))
+            , KnownNat (TypeSize (Value tokens CtxCompilation))
             ) => Eq (Bool CtxCompilation) (Output tokens datum CtxCompilation)
 
 txoAddress :: Output tokens datum context -> Address context

--- a/src/ZkFold/Symbolic/Cardano/Types/OutputRef.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/OutputRef.hs
@@ -21,7 +21,7 @@ deriving instance
     , Haskell.Eq (TxRefIndex context)
     ) => Haskell.Eq (OutputRef context)
 
-deriving instance HApplicative context => SymbolicData context (OutputRef context)
+deriving instance HApplicative context => SymbolicData (OutputRef context)
 
 outputRefId :: OutputRef context -> TxRefId context
 outputRefId (OutputRef (x, _)) = x

--- a/src/ZkFold/Symbolic/Cardano/Types/Transaction.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/Transaction.hs
@@ -39,17 +39,17 @@ deriving instance
     , KnownNat inputs
     , KnownNat outputs
     , KnownNat mint
-    , KnownNat (TypeSize context (SingleAsset context))
-    , KnownNat (TypeSize context (UTCTime context))
-    , KnownNat (TypeSize context (OutputRef context))
-    , KnownNat (TypeSize context (Value tokens context))
-    , KnownNat (TypeSize context (Output tokens datum context))
-    , KnownNat (TypeSize context (Vector outputs (Output tokens datum context)))
-    , KnownNat (TypeSize context (Input tokens datum context))
-    , KnownNat (TypeSize context (Vector inputs (Input tokens datum context)))
-    , KnownNat (TypeSize context (Vector rinputs (Input tokens datum context)))
-    , KnownNat (TypeSize context (Value mint context))
-    ) => SymbolicData context (Transaction inputs rinputs outputs tokens mint datum context)
+    , KnownNat (TypeSize (SingleAsset context))
+    , KnownNat (TypeSize (UTCTime context))
+    , KnownNat (TypeSize (OutputRef context))
+    , KnownNat (TypeSize (Value tokens context))
+    , KnownNat (TypeSize (Output tokens datum context))
+    , KnownNat (TypeSize (Vector outputs (Output tokens datum context)))
+    , KnownNat (TypeSize (Input tokens datum context))
+    , KnownNat (TypeSize (Vector inputs (Input tokens datum context)))
+    , KnownNat (TypeSize (Vector rinputs (Input tokens datum context)))
+    , KnownNat (TypeSize (Value mint context))
+    ) => SymbolicData (Transaction inputs rinputs outputs tokens mint datum context)
 
 txRefInputs :: Transaction inputs rinputs outputs tokens mint datum context -> Vector rinputs (Input tokens datum context)
 txRefInputs (Transaction (ris, _)) = ris

--- a/src/ZkFold/Symbolic/Cardano/Types/Value.hs
+++ b/src/ZkFold/Symbolic/Cardano/Types/Value.hs
@@ -27,8 +27,8 @@ deriving instance (Haskell.Eq (ByteString 224 context), Haskell.Eq (ByteString 2
 deriving instance
     ( Symbolic context
     , KnownNat n
-    , KnownNat (TypeSize context (SingleAsset context))
-    ) => SymbolicData context (Value n context)
+    , KnownNat (TypeSize (SingleAsset context))
+    ) => SymbolicData (Value n context)
 
 instance Symbolic context => Scale Natural (Value n context) where
     n `scale` Value v = Value $ fmap (\(pid, (aname, q)) -> (pid, (aname, n `scale` q))) v

--- a/src/ZkFold/Symbolic/Cardano/UPLC/Builtins.hs
+++ b/src/ZkFold/Symbolic/Cardano/UPLC/Builtins.hs
@@ -27,8 +27,8 @@ data BuiltinFunctions =
 -- TODO: use shortcuts to make these definitions more readable
 instance
     ( Typeable c
-    , S.SymbolicData c (c Par1)
-    , KnownNat (S.TypeSize c (c Par1))
+    , S.SymbolicData (c Par1)
+    , KnownNat (S.TypeSize (c Par1))
     , Semiring (c Par1)
     ) => PlutusBuiltinFunction c BuiltinFunctions where
 

--- a/src/ZkFold/Symbolic/Cardano/UPLC/Term.hs
+++ b/src/ZkFold/Symbolic/Cardano/UPLC/Term.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeOperators #-}
 
 module ZkFold.Symbolic.Cardano.UPLC.Term where
 
@@ -16,7 +16,7 @@ data Term name fun c where
     Apply     :: Term name fun c -> Term name fun c -> Term name fun c
     Force     :: Term name fun c -> Term name fun c
     Delay     :: Term name fun c -> Term name fun c
-    Constant  :: (Eq x, Typeable x, SymbolicData c x, KnownNat (TypeSize c x)) => x -> Term name fun c
+    Constant  :: (Eq x, Typeable x, SymbolicData x, Context x ~ c, KnownNat (TypeSize x)) => x -> Term name fun c
     Builtin   :: fun -> Term name fun c
     Error     :: Term name fun c
 

--- a/src/ZkFold/Symbolic/Cardano/UPLC/Type.hs
+++ b/src/ZkFold/Symbolic/Cardano/UPLC/Type.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
 
 module ZkFold.Symbolic.Cardano.UPLC.Type where
 
@@ -36,7 +37,7 @@ instance Semigroup (SomeType c) where
     _ <> _                                   = error "Semigroup (SomeType a): constructor mismatch"
 
 data SomeSymbolic c where
-    SomeData :: (Typeable t, SymbolicData c t, KnownNat (TypeSize c t)) => Proxy t -> SomeSymbolic c
+    SomeData :: (Typeable t, SymbolicData t, Context t ~ c, KnownNat (TypeSize t)) => Proxy t -> SomeSymbolic c
 
 getType :: SomeSymbolic c -> TypeRep
 getType (SomeData t)  = typeOf t

--- a/src/ZkFold/Symbolic/Data/Bool.hs
+++ b/src/ZkFold/Symbolic/Data/Bool.hs
@@ -60,7 +60,7 @@ deriving instance Eq (c Par1) => Eq (Bool c)
 instance (Eq a, MultiplicativeMonoid a) => Show (Bool (Interpreter a)) where
     show (fromBool -> x) = if x == one then "True" else "False"
 
-deriving newtype instance HFunctor c => SymbolicData c (Bool c)
+deriving newtype instance HFunctor c => SymbolicData (Bool c)
 
 instance Symbolic c => BoolType (Bool c) where
     true = Bool $ embed (Par1 one)

--- a/src/ZkFold/Symbolic/Data/ByteString.hs
+++ b/src/ZkFold/Symbolic/Data/ByteString.hs
@@ -59,7 +59,7 @@ newtype ByteString (n :: Natural) (context :: (Type -> Type) -> Type) = ByteStri
 deriving stock instance Haskell.Show (c (Vector n)) => Haskell.Show (ByteString n c)
 deriving stock instance Haskell.Eq (c (Vector n)) => Haskell.Eq (ByteString n c)
 deriving anyclass instance NFData (c (Vector n)) => NFData (ByteString n c)
-deriving newtype instance SymbolicData c (ByteString n c)
+deriving newtype instance SymbolicData (ByteString n c)
 
 instance
     ( FromConstant Natural (ByteString 8 c)

--- a/src/ZkFold/Symbolic/Data/Class.hs
+++ b/src/ZkFold/Symbolic/Data/Class.hs
@@ -15,7 +15,7 @@ import           Data.Function                    (const, flip, ($), (.))
 import           Data.Functor                     ((<$>))
 import           Data.Kind                        (Type)
 import           Data.Type.Equality               (type (~))
-import           Data.Typeable                    (Typeable)
+import           Data.Typeable                    (Proxy (..), Typeable)
 import           GHC.Generics                     (Par1 (..))
 
 import           ZkFold.Base.Algebra.Basic.Number (KnownNat, Natural, type (*), type (+), value)
@@ -26,94 +26,103 @@ import qualified ZkFold.Base.Data.Vector          as V
 import           ZkFold.Base.Data.Vector          (Vector)
 
 -- | A class for Symbolic data types.
--- Type `c` is the type of computational context.
--- Type `x` represents the data type.
-class SymbolicData c x where
-    type Support c x :: Type
-    type TypeSize c x :: Natural
+class SymbolicData x where
+    type Context x :: (Type -> Type) -> Type
+    type Support x :: Type
+    type TypeSize x :: Natural
 
     -- | Returns the circuit that makes up `x`.
-    pieces :: x -> Support c x -> c (Vector (TypeSize c x))
+    pieces :: x -> Support x -> Context x (Vector (TypeSize x))
 
     -- | Restores `x` from the circuit's outputs.
-    restore :: (Support c x -> c (Vector (TypeSize c x))) -> x
+    restore :: (Support x -> Context x (Vector (TypeSize x))) -> x
 
 -- | Returns the number of finite field elements needed to describe `x`.
-typeSize :: forall c x . KnownNat (TypeSize c x) => Natural
-typeSize = value @(TypeSize c x)
+typeSize :: forall x . KnownNat (TypeSize x) => Natural
+typeSize = value @(TypeSize x)
 
 -- A wrapper for `SymbolicData` types.
 data SomeData c where
-    SomeData :: (Typeable t, SymbolicData c t) => t -> SomeData c
+    SomeData :: (Typeable t, SymbolicData t, Context t ~ c) => t -> SomeData c
 
-instance SymbolicData c (c (Vector n)) where
-    type Support c (c (Vector n)) = ()
-    type TypeSize c (c (Vector n)) = n
+instance SymbolicData (c (Vector n)) where
+    type Context (c (Vector n)) = c
+    type Support (c (Vector n)) = Proxy c
+    type TypeSize (c (Vector n)) = n
 
     pieces x _ = x
-    restore f = f ()
+    restore f = f Proxy
 
-instance HFunctor c => SymbolicData c (c Par1) where
-    type Support c (c Par1) = ()
-    type TypeSize c (c Par1) = 1
+instance HFunctor c => SymbolicData (c Par1) where
+    type Context (c Par1) = c
+    type Support (c Par1) = Proxy c
+    type TypeSize (c Par1) = 1
 
     pieces = const . hmap (V.singleton . unPar1)
-    restore = hmap (Par1 . V.item) . ($ ())
+    restore = hmap (Par1 . V.item) . ($ Proxy)
 
-instance HApplicative c => SymbolicData c () where
-    type Support c () = ()
-    type TypeSize c () = 0
+instance HApplicative c => SymbolicData (Proxy (c :: (Type -> Type) -> Type)) where
+    type Context (Proxy c) = c
+    type Support (Proxy c) = Proxy c
+    type TypeSize (Proxy c) = 0
 
     pieces _ _ = hpure V.empty
-    restore _ = ()
+    restore _ = Proxy
 
 instance
-    ( HApplicative c
-    , SymbolicData c x
-    , SymbolicData c y
-    , Support c x ~ Support c y
-    , KnownNat (TypeSize c x)
-    ) => SymbolicData c (x, y) where
+    ( SymbolicData x
+    , SymbolicData y
+    , HApplicative (Context x)
+    , Context x ~ Context y
+    , Support x ~ Support y
+    , KnownNat (TypeSize x)
+    ) => SymbolicData (x, y) where
 
-    type Support c (x, y) = Support c x
-    type TypeSize c (x, y) = TypeSize c x + TypeSize c y
+    type Context (x, y) = Context x
+    type Support (x, y) = Support x
+    type TypeSize (x, y) = TypeSize x + TypeSize y
 
     pieces (a, b) = hliftA2 V.append <$> pieces a <*> pieces b
     restore f = (restore (hmap V.take . f), restore (hmap V.drop . f))
 
 instance
-    ( HApplicative c
-    , SymbolicData c x
-    , SymbolicData c y
-    , SymbolicData c z
-    , Support c x ~ Support c y
-    , Support c y ~ Support c z
-    , KnownNat (TypeSize c x)
-    , KnownNat (TypeSize c y)
-    ) => SymbolicData c (x, y, z) where
+    ( SymbolicData x
+    , SymbolicData y
+    , SymbolicData z
+    , HApplicative (Context x)
+    , Context x ~ Context y
+    , Context y ~ Context z
+    , Support x ~ Support y
+    , Support y ~ Support z
+    , KnownNat (TypeSize x)
+    , KnownNat (TypeSize y)
+    ) => SymbolicData (x, y, z) where
 
-    type Support c (x, y, z) = Support c (x, (y, z))
-    type TypeSize c (x, y, z) = TypeSize c (x, (y, z))
+    type Context (x, y, z) = Context (x, (y, z))
+    type Support (x, y, z) = Support (x, (y, z))
+    type TypeSize (x, y, z) = TypeSize (x, (y, z))
 
     pieces (a, b, c) = pieces (a, (b, c))
     restore f = let (a, (b, c)) = restore f in (a, b, c)
 
 instance
-    ( Package c
-    , SymbolicData c x
-    , KnownNat (TypeSize c x)
+    ( SymbolicData x
+    , Package (Context x)
+    , KnownNat (TypeSize x)
     , KnownNat n
-    ) => SymbolicData c (Vector n x) where
+    ) => SymbolicData (Vector n x) where
 
-    type Support c (Vector n x) = Support c x
-    type TypeSize c (Vector n x) = n * TypeSize c x
+    type Context (Vector n x) = Context x
+    type Support (Vector n x) = Support x
+    type TypeSize (Vector n x) = n * TypeSize x
 
     pieces xs i = packWith V.concat (flip pieces i <$> xs)
     restore f = V.generate (\i -> restore (hmap ((V.!! i) . V.chunks @n) . f))
 
-instance SymbolicData c f => SymbolicData c (x -> f) where
-    type Support c (x -> f) = (x, Support c f)
-    type TypeSize c (x -> f) = TypeSize c f
+instance SymbolicData f => SymbolicData (x -> f) where
+    type Context (x -> f) = Context f
+    type Support (x -> f) = (x, Support f)
+    type TypeSize (x -> f) = TypeSize f
 
     pieces f (x, i) = pieces (f x) i
     restore f x = restore (f . (x,))

--- a/src/ZkFold/Symbolic/Data/Conditional.hs
+++ b/src/ZkFold/Symbolic/Data/Conditional.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE TypeOperators #-}
+
 module ZkFold.Symbolic.Data.Conditional where
 
 import           Data.Function                   (($))
+import           Data.Type.Equality              (type (~))
 import           GHC.Generics                    (Par1 (Par1))
 
 import           ZkFold.Base.Algebra.Basic.Class
@@ -24,7 +27,7 @@ gif b x y = bool y x b
 (?) :: Conditional b a => b -> a -> a -> a
 (?) = gif
 
-instance (Symbolic c, SymbolicData c x) => Conditional (Bool c) x where
+instance (SymbolicData x, Context x ~ c, Symbolic c) => Conditional (Bool c) x where
     bool x y (Bool b) = restore $ \s ->
       fromCircuit3F b (pieces x s) (pieces y s) $ \(Par1 c) ->
         zipWithM $ \i j -> do

--- a/src/ZkFold/Symbolic/Data/Ed25519.hs
+++ b/src/ZkFold/Symbolic/Data/Ed25519.hs
@@ -35,10 +35,11 @@ instance
     , S.BaseField c ~ a
     , r ~ NumberOfRegisters a 256 rs
     , KnownNat r
-    ) => SymbolicData c (Point (Ed25519 c rs)) where
+    ) => SymbolicData (Point (Ed25519 c rs)) where
 
-    type Support c (Point (Ed25519 c rs)) = Support c (UInt 256 rs c)
-    type TypeSize c (Point (Ed25519 c rs)) = TypeSize c (UInt 256 rs c) + TypeSize c (UInt 256 rs c)
+    type Context (Point (Ed25519 c rs)) = c
+    type Support (Point (Ed25519 c rs)) = Support (UInt 256 rs c)
+    type TypeSize (Point (Ed25519 c rs)) = TypeSize (UInt 256 rs c) + TypeSize (UInt 256 rs c)
 
     -- (0, 0) is never on a Twisted Edwards curve for any curve parameters.
     -- We can encode the point at infinity as (0, 0), therefore.

--- a/src/ZkFold/Symbolic/Data/Eq/Structural.hs
+++ b/src/ZkFold/Symbolic/Data/Eq/Structural.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeOperators #-}
 
 module ZkFold.Symbolic.Data.Eq.Structural where
 
+import           Data.Proxy                 (Proxy (..))
 import           Prelude                    (type (~))
 
 import           ZkFold.Symbolic.Class
@@ -14,18 +14,18 @@ newtype Structural a = Structural a
 -- ^ A newtype wrapper for easy definition of Eq instances.
 
 instance
-    ( SymbolicData c x
-    , Support c x ~ ()
-    , n ~ TypeSize c x
+    ( SymbolicData x
+    , Context x ~ c
+    , Support x ~ Proxy c
     , Symbolic c
     ) => Eq (Bool c) (Structural x) where
 
     Structural x == Structural y =
-        let x' = pieces @c x ()
-            y' = pieces y ()
+        let x' = pieces x Proxy
+            y' = pieces y Proxy
          in x' == y'
 
     Structural x /= Structural y =
-        let x' = pieces @c x ()
-            y' = pieces y ()
+        let x' = pieces x Proxy
+            y' = pieces y Proxy
          in x' /= y'

--- a/src/ZkFold/Symbolic/Data/FFA.hs
+++ b/src/ZkFold/Symbolic/Data/FFA.hs
@@ -35,7 +35,7 @@ type Size = 7
 -- | Foreign-field arithmetic based on https://cr.yp.to/papers/mmecrt.pdf
 newtype FFA (p :: Natural) c = FFA (c (Vector Size))
 
-deriving newtype instance SymbolicData c (FFA p c)
+deriving newtype instance SymbolicData (FFA p c)
 
 coprimesDownFrom :: KnownNat n => Natural -> Vector n Natural
 coprimesDownFrom n = unfold (uncurry step) ([], [n,n-!1..0])

--- a/src/ZkFold/Symbolic/Data/FieldElement.hs
+++ b/src/ZkFold/Symbolic/Data/FieldElement.hs
@@ -38,7 +38,7 @@ deriving stock instance Haskell.Eq (c Par1) => Haskell.Eq (FieldElement c)
 
 deriving stock instance Haskell.Ord (c Par1) => Haskell.Ord (FieldElement c)
 
-deriving newtype instance HFunctor c => SymbolicData c (FieldElement c)
+deriving newtype instance HFunctor c => SymbolicData (FieldElement c)
 
 deriving newtype instance Symbolic c => Eq (Bool c) (FieldElement c)
 

--- a/src/ZkFold/Symbolic/Data/List.hs
+++ b/src/ZkFold/Symbolic/Data/List.hs
@@ -9,7 +9,7 @@ import           ZkFold.Base.Data.Vector    (Vector)
 import           ZkFold.Symbolic.Data.Bool  (Bool)
 import           ZkFold.Symbolic.Data.Class
 
-data List (context :: (Type -> Type) -> Type) x = List (context (Vector (TypeSize context x))) (context Par1)
+data List (context :: (Type -> Type) -> Type) x = List (context (Vector (TypeSize x))) (context Par1)
 
 emptyList :: List context x
 emptyList = undefined

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -58,7 +58,7 @@ deriving instance Generic (UInt n r context)
 deriving instance (NFData (context (Vector (NumberOfRegisters (BaseField context) n r)))) => NFData (UInt n r context)
 deriving instance (Haskell.Eq (context (Vector (NumberOfRegisters (BaseField context) n r)))) => Haskell.Eq (UInt n r context)
 deriving instance (Haskell.Show (BaseField context), Haskell.Show (context (Vector (NumberOfRegisters (BaseField context) n r)))) => Haskell.Show (UInt n r context)
-deriving newtype instance SymbolicData c (UInt n r c)
+deriving newtype instance SymbolicData (UInt n r c)
 
 instance (Symbolic c, KnownNat n, KnownRegisterSize r) => FromConstant Natural (UInt n r c) where
     fromConstant c = UInt . embed @c $ naturalToVector @c @n @r c

--- a/src/ZkFold/Symbolic/Data/UTCTime.hs
+++ b/src/ZkFold/Symbolic/Data/UTCTime.hs
@@ -16,6 +16,6 @@ newtype UTCTime c = UTCTime (UInt 11 Auto c)
 
 deriving newtype instance Eq (UInt 11 Auto c) => Eq (UTCTime c)
 
-deriving newtype instance SymbolicData c (UTCTime c)
+deriving newtype instance SymbolicData (UTCTime c)
 
 deriving newtype instance FromConstant Natural (UInt 11 Auto c) => FromConstant Natural (UTCTime c)

--- a/tests/Tests/Blake2b.hs
+++ b/tests/Tests/Blake2b.hs
@@ -4,6 +4,7 @@ module Tests.Blake2b where
 
 import           Crypto.Hash.BLAKE2.BLAKE2b                  (hash)
 import qualified Data.ByteString.Internal                    as BI
+import           Data.Data                                   (Proxy (Proxy))
 import           Numeric.Natural                             (Natural)
 import           Prelude                                     (Eq (..), IO, ($))
 import           Test.Hspec
@@ -35,14 +36,14 @@ blake2bSimple :: forall b .
     , Eq (b (Vector 512))
     ) => Spec
 blake2bSimple =
-    let a = blake2b_512 $ fromConstant @Natural @(ByteString 0 b) 0
+    let a = blake2b_512 @0 @b $ fromConstant (0 :: Natural)
         b = hash 64 BI.empty BI.empty
     in  it "computes blake2b_512 correctly on empty bytestring" $ a == fromConstant b
 
 blake2bAC :: Spec
 blake2bAC =
-    let bs = compile @(Zp BLS12_381_Scalar) (blake2b_512 @8 @(ArithmeticCircuit (Zp BLS12_381_Scalar))) :: ByteString 512 (ArithmeticCircuit (Zp BLS12_381_Scalar))
-        ac = pieces @(ArithmeticCircuit (Zp BLS12_381_Scalar)) bs ()
+    let bs = compile (blake2b_512 @8) :: ByteString 512 (ArithmeticCircuit (Zp BLS12_381_Scalar))
+        ac = pieces bs Proxy
     in it "simple test with cardano-crypto " $ acSizeN ac == 564239
 
 specBlake2b :: IO ()


### PR DESCRIPTION
Made `SymbolicData` into a single-parameter typeclass to improve type inference. Improved inference can already be seen in the `Blake2b` test.