### PR TITLE
Update `WitnessField`

### DIFF
--- a/src/ZkFold/Base/Algebra/Basic/Class.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Class.hs
@@ -269,16 +269,20 @@ intScale n a | n < 0     = naturalFromInteger (-n) `scale` negate a
 -}
 class (AdditiveMonoid a, MultiplicativeMonoid a, FromConstant Natural a) => Semiring a
 
-{- | A Euclidean domain @R@ is an integral domain which can be endowed
-with at least one function @f : R\{0} -> R+@ s.t.
-If @a@ and @b@ are in @R@ and @b@ is nonzero, then there exist @q@ and @r@ in @R@ such that
-@a = bq + r@ and either @r = 0@ or @f(r) < f(b)@.
+{- | A semi-Euclidean-domain @a@ is a semiring without zero divisors which can
+be endowed with at least one function @f : a\{0} -> R+@ s.t. if @x@ and @y@ are
+in @a@ and @y@ is nonzero, then there exist @q@ and @r@ in @a@ such that
+@x = qy + r@ and either @r = 0@ or @f(r) < f(y)@.
 
-@q@ and @r@ are called respectively a quotient and a remainder of the division (or Euclidean division) of @a@ by @b@.
+@q@ and @r@ are called respectively a quotient and a remainder of the division
+(or Euclidean division) of @x@ by @y@.
 
-The function @divMod@ associated with this class produces @q@ and @r@ given @a@ and @b@.
+The function @divMod@ associated with this class produces @q@ and @r@
+given @a@ and @b@.
+
+This is a generalization of a notion of Euclidean domains to semirings.
 -}
-class Semiring a => EuclideanDomain a where
+class Semiring a => SemiEuclidean a where
     {-# MINIMAL divMod | (div, mod) #-}
 
     divMod :: a -> a -> (a, a)
@@ -479,7 +483,7 @@ instance AdditiveMonoid Natural where
 
 instance Semiring Natural
 
-instance EuclideanDomain Natural where
+instance SemiEuclidean Natural where
     divMod = Haskell.divMod
 
 instance BinaryExpansion Natural where
@@ -517,7 +521,7 @@ instance FromConstant Natural Integer where
 
 instance Semiring Integer
 
-instance EuclideanDomain Integer where
+instance SemiEuclidean Integer where
     divMod = Haskell.divMod
 
 instance Ring Integer

--- a/src/ZkFold/Base/Algebra/Basic/Class.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Class.hs
@@ -279,9 +279,10 @@ If @a@ and @b@ are in @R@ and @b@ is nonzero, then there exist @q@ and @r@ in @R
 The function @divMod@ associated with this class produces @q@ and @r@ given @a@ and @b@.
 -}
 class Semiring a => EuclideanDomain a where
-    {-# MINIMAL divMod #-}
+    {-# MINIMAL divMod | (div, mod) #-}
 
     divMod :: a -> a -> (a, a)
+    divMod n d = (n `div` d, n `mod` d)
 
     div :: a -> a -> a
     div n d = Haskell.fst $ divMod n d

--- a/src/ZkFold/Base/Algebra/Basic/Field.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Field.hs
@@ -95,7 +95,7 @@ instance KnownNat p => FromConstant Natural (Zp p) where
 
 instance KnownNat p => Semiring (Zp p)
 
-instance KnownNat p => EuclideanDomain (Zp p) where
+instance KnownNat p => SemiEuclidean (Zp p) where
     divMod a b = let (q, r) = Haskell.divMod (fromZp a) (fromZp b)
                   in (toZp . fromIntegral $ q, toZp . fromIntegral $ r)
 

--- a/src/ZkFold/Base/Algebra/Basic/Sources.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Sources.hs
@@ -2,7 +2,7 @@
 
 module ZkFold.Base.Algebra.Basic.Sources (Sources (..)) where
 
-import           Data.Function                   (const, id, (.))
+import           Data.Function                   (const, id)
 import           Data.Kind                       (Type)
 import           Data.Maybe                      (Maybe (..))
 import           Data.Monoid                     (Monoid (..))
@@ -28,12 +28,14 @@ instance {-# OVERLAPPING #-} FromConstant (Sources a i) (Sources a i) where
 instance {-# OVERLAPPING #-} Ord i => Scale (Sources a i) (Sources a i) where
   scale = (<>)
 
+instance {-# OVERLAPPABLE #-} FromConstant c (Sources a i) where
+  fromConstant = const empty
+
+instance {-# OVERLAPPABLE #-} MultiplicativeMonoid c => Scale c (Sources a i) where
+  scale = const id
+
 instance Ord i => AdditiveSemigroup (Sources a i) where
   (+) = (<>)
-
-instance {-# OVERLAPPABLE #-}
-    MultiplicativeMonoid c => Scale c (Sources a i) where
-  scale = const id
 
 instance Ord i => AdditiveMonoid (Sources a i) where
   zero = mempty
@@ -59,9 +61,6 @@ instance Exponent (Sources a i) Integer where
 instance Ord i => MultiplicativeGroup (Sources a i) where
   invert = id
 
-instance {-# OVERLAPPABLE #-} FromConstant c (Sources a i) where
-  fromConstant = const empty
-
 instance Ord i => Semiring (Sources a i)
 
 instance Ord i => Ring (Sources a i)
@@ -71,8 +70,8 @@ instance Ord i => Field (Sources a i) where
   rootOfUnity _ = Just mempty
 
 instance ToConstant (Sources (a :: Type) i) where
-  type Const (Sources a i) = Sources (Const a) i
-  toConstant = Sources . runSources
+  type Const (Sources a i) = Sources a i
+  toConstant = id
 
 instance (Finite a, Ord i) => BinaryExpansion (Sources a i) where
   type Bits (Sources a i) = [Sources a i]

--- a/src/ZkFold/Base/Algebra/Basic/Sources.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Sources.hs
@@ -77,6 +77,6 @@ instance (Finite a, Ord i) => BinaryExpansion (Sources a i) where
   type Bits (Sources a i) = [Sources a i]
   binaryExpansion = replicate (numberOfBits @a)
 
-instance Ord i => EuclideanDomain (Sources a i) where
+instance Ord i => SemiEuclidean (Sources a i) where
   div = (<>)
   mod = (<>)

--- a/src/ZkFold/Base/Algebra/Basic/Sources.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Sources.hs
@@ -1,9 +1,17 @@
 {-# LANGUAGE DerivingStrategies #-}
 
-module ZkFold.Base.Algebra.Basic.Sources where
+module ZkFold.Base.Algebra.Basic.Sources (Sources (..)) where
 
+import           Data.Function                   (const, id, (.))
+import           Data.Kind                       (Type)
+import           Data.Maybe                      (Maybe (..))
+import           Data.Monoid                     (Monoid (..))
+import           Data.Ord                        (Ord)
+import           Data.Semigroup                  (Semigroup (..))
 import           Data.Set                        (Set)
-import           Prelude                         hiding (replicate)
+import qualified Data.Set                        as Set
+import           Numeric.Natural                 (Natural)
+import           Prelude                         (Integer)
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Prelude
@@ -11,14 +19,21 @@ import           ZkFold.Prelude
 newtype Sources a i = Sources { runSources :: Set i }
     deriving newtype (Semigroup, Monoid)
 
-instance MultiplicativeSemigroup c => Exponent (Sources a i) c where
-  (^) = const
+empty :: Sources a i
+empty = Sources Set.empty
 
-instance MultiplicativeMonoid c => Scale c (Sources a i) where
-  scale = const id
+instance {-# OVERLAPPING #-} FromConstant (Sources a i) (Sources a i) where
+  fromConstant = id
+
+instance {-# OVERLAPPING #-} Ord i => Scale (Sources a i) (Sources a i) where
+  scale = (<>)
 
 instance Ord i => AdditiveSemigroup (Sources a i) where
   (+) = (<>)
+
+instance {-# OVERLAPPABLE #-}
+    MultiplicativeMonoid c => Scale c (Sources a i) where
+  scale = const id
 
 instance Ord i => AdditiveMonoid (Sources a i) where
   zero = mempty
@@ -32,14 +47,20 @@ instance Finite a => Finite (Sources a i) where
 instance Ord i => MultiplicativeSemigroup (Sources a i) where
   (*) = (<>)
 
+instance Exponent (Sources a i) Natural where
+  (^) = const
+
 instance Ord i => MultiplicativeMonoid (Sources a i) where
   one = mempty
+
+instance Exponent (Sources a i) Integer where
+  (^) = const
 
 instance Ord i => MultiplicativeGroup (Sources a i) where
   invert = id
 
-instance Ord i => FromConstant c (Sources a i) where
-  fromConstant _ = mempty
+instance {-# OVERLAPPABLE #-} FromConstant c (Sources a i) where
+  fromConstant = const empty
 
 instance Ord i => Semiring (Sources a i)
 
@@ -47,8 +68,16 @@ instance Ord i => Ring (Sources a i)
 
 instance Ord i => Field (Sources a i) where
   finv = id
-  rootOfUnity _ = Just (Sources mempty)
+  rootOfUnity _ = Just mempty
+
+instance ToConstant (Sources (a :: Type) i) where
+  type Const (Sources a i) = Sources (Const a) i
+  toConstant = Sources . runSources
 
 instance (Finite a, Ord i) => BinaryExpansion (Sources a i) where
   type Bits (Sources a i) = [Sources a i]
   binaryExpansion = replicate (numberOfBits @a)
+
+instance Ord i => EuclideanDomain (Sources a i) where
+  div = (<>)
+  mod = (<>)

--- a/src/ZkFold/Symbolic/Algorithms/Hash/Blake2b.hs
+++ b/src/ZkFold/Symbolic/Algorithms/Hash/Blake2b.hs
@@ -15,8 +15,8 @@ import           Prelude                                           hiding (Num (
                                                                     replicate, splitAt, truncate, (!!), (&&), (^))
 
 import           ZkFold.Base.Algebra.Basic.Class                   (AdditiveGroup (..), AdditiveSemigroup (..),
-                                                                    EuclideanDomain (..), Exponent (..),
-                                                                    FromConstant (..), MultiplicativeSemigroup (..),
+                                                                    Exponent (..), FromConstant (..),
+                                                                    MultiplicativeSemigroup (..), SemiEuclidean (..),
                                                                     divMod, one, zero, (-!))
 import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Prelude                                    (length, replicate, splitAt, (!!))

--- a/src/ZkFold/Symbolic/Class.hs
+++ b/src/ZkFold/Symbolic/Class.hs
@@ -8,6 +8,7 @@ import           Data.Functor                     (Functor (fmap), (<$>))
 import           Data.Kind                        (Type)
 import           Data.Type.Equality               (type (~))
 import           GHC.Generics                     (Par1 (Par1), type (:.:) (unComp1))
+import           Numeric.Natural                  (Natural)
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Control.HApplicative (HApplicative (hpair, hunit))
@@ -49,7 +50,7 @@ class (HApplicative c, Package c, Arithmetic (BaseField c)) => Symbolic c where
     -- | A wrapper around @'symbolicF'@ which extracts the pure computation
     -- from the circuit computation using the @'Witnesses'@ newtype.
     fromCircuitF :: c f -> CircuitFun f g (BaseField c) -> c g
-    fromCircuitF x f = symbolicF x (runWitnesses @(BaseField c) . f) f
+    fromCircuitF x f = symbolicF x (runWitnesses @Natural @(BaseField c) . f) f
 
 -- | Embeds the pure value(s) into generic context @c@.
 embed :: (Symbolic c, Foldable f, Functor f) => f (BaseField c) -> c f

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit.hs
@@ -69,7 +69,7 @@ desugarRange :: (Arithmetic a, MonadCircuit i a m) => i -> a -> m ()
 desugarRange i b
   | b == negate one = return ()
   | otherwise = do
-    let bs = binaryExpansion b
+    let bs = binaryExpansion (toConstant b)
     is <- expansion (length bs) i
     case dropWhile ((== one) . fst) (zip bs is) of
       [] -> return ()

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
@@ -196,7 +196,7 @@ instance o ~ U1 => Monoid (ArithmeticCircuit a i o) where
 type VarField = Zp BLS12_381_Scalar
 
 toField :: Arithmetic a => a -> VarField
-toField = toZp . fromConstant . fromBinary @Natural . castBits . binaryExpansion
+toField = fromConstant . toConstant
 
 -- TODO: Remove the hardcoded constant.
 toVar ::

--- a/src/ZkFold/Symbolic/Data/Combinators.hs
+++ b/src/ZkFold/Symbolic/Data/Combinators.hs
@@ -187,11 +187,12 @@ bitsOf :: MonadCircuit i a m => Natural -> i -> m [i]
 bitsOf n k = for [0 .. n -! 1] $ \j ->
     newConstrained (\x i -> let xi = x i in xi * (xi - one)) (repr j . ($ k))
     where
+        repr :: WitnessField n x => Natural -> x -> x
         repr j =
-            fromConstant
-            . (`mod` fromConstant @Natural 2)
-            . (`div` fromConstant @Natural (2 ^ j))
-            . toConstant
+              fromConstant
+              . (`mod` fromConstant @Natural 2)
+              . (`div` fromConstant @Natural (2 ^ j))
+              . toConstant
 
 horner :: MonadCircuit i a m => [i] -> m i
 -- ^ @horner [b0,...,bn]@ computes the sum @b0 + 2 b1 + ... + 2^n bn@ using

--- a/src/ZkFold/Symbolic/Data/FieldElement.hs
+++ b/src/ZkFold/Symbolic/Data/FieldElement.hs
@@ -92,8 +92,9 @@ instance
 instance Symbolic c => BinaryExpansion (FieldElement c) where
   type Bits (FieldElement c) = c (Vector (NumberOfBits (BaseField c)))
   binaryExpansion (FieldElement c) = hmap unsafeToVector $ symbolicF c
-    (\(Par1 v) -> padBits (numberOfBits @(BaseField c)) $ binaryExpansion v)
-    (\(Par1 i) -> expansion (numberOfBits @(BaseField c)) i)
+    (padBits n . fmap fromConstant . binaryExpansion . toConstant . unPar1)
+    (expansion n . unPar1)
+    where n = numberOfBits @(BaseField c)
   fromBinary bits =
     FieldElement $ symbolicF bits (Par1 . foldr (\x y -> x + y + y) zero)
       $ fmap Par1 . horner . fromVector

--- a/src/ZkFold/Symbolic/Data/Ord.hs
+++ b/src/ZkFold/Symbolic/Data/Ord.hs
@@ -91,9 +91,9 @@ getBitsBE ::
 -- ^ @getBitsBE x@ returns a list of circuits computing bits of @x@, eldest to
 -- youngest.
 getBitsBE x =
-  hmap unsafeToVector
+  hmap (V.reverse . unsafeToVector)
     $ symbolicF (pieces x Proxy)
-        (map fromConstant . padBits n . binaryExpansion . toConstant . V.item)
+        (padBits n . map fromConstant . binaryExpansion . toConstant . V.item)
         (expansion n . V.item)
   where n = numberOfBits @(BaseField c)
 

--- a/src/ZkFold/Symbolic/Data/Ord.hs
+++ b/src/ZkFold/Symbolic/Data/Ord.hs
@@ -11,6 +11,7 @@ import           Data.Data                        (Proxy (..))
 import           Data.Foldable                    (Foldable, toList)
 import           Data.Function                    ((.))
 import           Data.Functor                     ((<$>))
+import           Data.List                        (map)
 import qualified Data.Zip                         as Z
 import           GHC.Generics                     (Par1 (..))
 import           Prelude                          (type (~), ($))
@@ -91,8 +92,10 @@ getBitsBE ::
 -- youngest.
 getBitsBE x =
   hmap unsafeToVector
-    $ symbolicF (pieces x Proxy) (binaryExpansion . V.item)
-      $ expansion (numberOfBits @(BaseField c)) . V.item
+    $ symbolicF (pieces x Proxy)
+        (map fromConstant . padBits n . binaryExpansion . toConstant . V.item)
+        (expansion n . V.item)
+  where n = numberOfBits @(BaseField c)
 
 bitwiseGE :: forall c f . (Symbolic c, Z.Zip f, Foldable f) => c f -> c f -> Bool c
 -- ^ Given two lists of bits of equal length, compares them lexicographically.

--- a/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/src/ZkFold/Symbolic/Data/UInt.hs
@@ -102,7 +102,7 @@ cast n =
 eea
     :: forall n c r
     .  Symbolic c
-    => EuclideanDomain (UInt n r c)
+    => SemiEuclidean (UInt n r c)
     => KnownNat n
     => KnownNat (NumberOfRegisters (BaseField c) n r)
     => AdditiveGroup (UInt n r c)
@@ -200,7 +200,7 @@ instance
     , KnownRegisterSize rs
     , r ~ NumberOfRegisters (BaseField c) n rs
     , NFData (c (Vector r))
-    ) => EuclideanDomain (UInt n rs c) where
+    ) => SemiEuclidean (UInt n rs c) where
     divMod numerator d = bool @(Bool c) (q, r) (zero, zero) (d == zero)
         where
             (q, r) = Haskell.foldl longDivisionStep (zero, zero) [value @n -! 1, value @n -! 2 .. 0]

--- a/src/ZkFold/Symbolic/MonadCircuit.hs
+++ b/src/ZkFold/Symbolic/MonadCircuit.hs
@@ -18,7 +18,7 @@ import           ZkFold.Base.Algebra.Basic.Class
 -- | A @'WitnessField'@ should support all algebraic operations
 -- used inside an arithmetic circuit.
 type WitnessField n a = ( FiniteField a, ToConstant a, Const a ~ n
-                        , FromConstant n a, EuclideanDomain n)
+                        , FromConstant n a, SemiEuclidean n)
 
 -- | A type of witness builders. @i@ is a type of variables, @a@ is a base field.
 --

--- a/src/ZkFold/Symbolic/MonadCircuit.hs
+++ b/src/ZkFold/Symbolic/MonadCircuit.hs
@@ -17,7 +17,8 @@ import           ZkFold.Base.Algebra.Basic.Class
 
 -- | A @'WitnessField'@ should support all algebraic operations
 -- used inside an arithmetic circuit.
-type WitnessField a = (FiniteField a, BinaryExpansion a, Bits a ~ [a])
+type WitnessField n a = ( FiniteField a, ToConstant a, Const a ~ n
+                        , FromConstant n a, EuclideanDomain n)
 
 -- | A type of witness builders. @i@ is a type of variables, @a@ is a base field.
 --
@@ -27,7 +28,7 @@ type WitnessField a = (FiniteField a, BinaryExpansion a, Bits a ~ [a])
 --
 -- NOTE: the property above is correct by construction for each function of a
 -- suitable type, you don't have to check it yourself.
-type Witness i a = forall x . (Algebra a x, WitnessField x) => (i -> x) -> x
+type Witness i a = forall x n . (Algebra a x, WitnessField n x) => (i -> x) -> x
 
 -- | A type of constraints for new variables.
 -- @i@ is a type of variables, @a@ is a base field.
@@ -109,14 +110,14 @@ class Monad m => MonadCircuit i a m | m -> i, m -> a where
 
 -- | Field of witnesses with decidable equality and ordering
 -- is called an ``arithmetic'' field.
-type Arithmetic a = (WitnessField a, ToConstant a, Const a ~ Natural, Eq a, Ord a)
+type Arithmetic a = (WitnessField Natural a, Eq a, Ord a)
 
 -- | An example implementation of a @'MonadCircuit'@ which computes witnesses
 -- immediately and drops the constraints.
-newtype Witnesses a x = Witnesses { runWitnesses :: x }
+newtype Witnesses n a x = Witnesses { runWitnesses :: x }
   deriving (Functor, Applicative, Monad) via Identity
 
-instance WitnessField a => MonadCircuit a a (Witnesses a) where
+instance WitnessField n a => MonadCircuit a a (Witnesses n a) where
     newRanged _ w = return (w id)
     newConstrained _ w = return (w id)
     constraint _ = return ()

--- a/tests/Tests/ArithmeticCircuit.hs
+++ b/tests/Tests/ArithmeticCircuit.hs
@@ -4,6 +4,7 @@
 module Tests.ArithmeticCircuit (exec1, it, specArithmeticCircuit) where
 
 import           Data.Bool                                   (bool)
+import           Data.Functor                                ((<$>))
 import           GHC.Generics                                (U1 (..))
 import           Prelude                                     (IO, Show, String, id, ($))
 import qualified Prelude                                     as Haskell
@@ -54,7 +55,8 @@ specArithmeticCircuit' = hspec $ do
         --    in withMaxSuccess 1 $ checkClosedCircuit r .&&. exec1 r === one
         it "computes binary expansion" $ \(x :: a) ->
           let rs = binaryExpansion (fromConstant x :: FieldElement (ArithmeticCircuit a U1))
-           in checkClosedCircuit rs .&&. V.fromVector (exec rs) === padBits (numberOfBits @a) (binaryExpansion x)
+              as = padBits (numberOfBits @a) $ fromConstant <$> binaryExpansion (toConstant x)
+           in checkClosedCircuit rs .&&. V.fromVector (exec rs) === as
         it "internalizes equality" $ \(x :: a) (y :: a) ->
           let Bool r = (fromConstant x :: FieldElement (ArithmeticCircuit a U1)) == fromConstant y
            in checkClosedCircuit @a r .&&. exec1 r === bool zero one (x Haskell.== y)

--- a/tests/Tests/ArithmeticCircuit.hs
+++ b/tests/Tests/ArithmeticCircuit.hs
@@ -22,6 +22,7 @@ import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.Eq
 import           ZkFold.Symbolic.Data.FieldElement
+import           ZkFold.Symbolic.Data.Ord                    ((<=))
 
 correctHom0 :: forall a . (Arithmetic a, Scale a a, Show a) => (forall b . Field b => b) -> Property
 correctHom0 f = let r = fromFieldElement f in withMaxSuccess 1 $ checkClosedCircuit r .&&. exec1 r === f @a
@@ -63,6 +64,9 @@ specArithmeticCircuit' = hspec $ do
         it "internal equality is reflexive" $ \(x :: a) ->
           let Bool r = (fromConstant x :: FieldElement (ArithmeticCircuit a U1)) == fromConstant x
            in checkClosedCircuit @a r .&&. exec1 r === one
+        it "<=s correctly" $ withMaxSuccess 10 $ \(x :: a) (y :: a) ->
+          let Bool r = (fromConstant x :: FieldElement (ArithmeticCircuit a U1)) <= fromConstant y
+           in checkClosedCircuit @a r .&&. exec1 r === bool zero one (x Haskell.<= y)
 
 specArithmeticCircuit :: IO ()
 specArithmeticCircuit = do


### PR DESCRIPTION
This PR updates `WitnessField` typealias by replacing `BinaryExpansion` constraint with a conversion to the "unbounded natural numbers" type which is a `EuclideanDomain`. Also some minor improvements along the way.

Branches out from #244, so maybe that one has to be merged first.