### PR TITLE
Changed `NewVar` type to `ByteString`

### DIFF
--- a/src/ZkFold/Base/Protocol/Plonkup/LookupConstraint.hs
+++ b/src/ZkFold/Base/Protocol/Plonkup/LookupConstraint.hs
@@ -1,22 +1,19 @@
-{-# LANGUAGE TypeOperators #-}
-
 module ZkFold.Base.Protocol.Plonkup.LookupConstraint where
 
-import           GHC.TypeNats                                        (KnownNat)
-import           Numeric.Natural                                     (Natural)
+import           Data.Binary                                         (Binary, encode)
+import           Data.ByteString                                     (ByteString, toStrict)
 import           Prelude                                             hiding (Num (..), drop, length, sum, take, (!!),
                                                                       (/), (^))
 import           Test.QuickCheck                                     (Arbitrary (..))
 
-import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Data.Vector                             (Vector)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal
 
 newtype LookupConstraint i a = LookupConstraint { lkVar :: Var (Vector i) }
     deriving (Show, Eq)
 
-instance (Arbitrary a, Finite a, ToConstant a, Const a ~ Natural, KnownNat i) => Arbitrary (LookupConstraint i a) where
-    arbitrary = LookupConstraint . NewVar . toConstant @a <$> arbitrary
+instance (Arbitrary a, Binary a) => Arbitrary (LookupConstraint i a) where
+    arbitrary = LookupConstraint . NewVar . toStrict . encode @a <$> arbitrary
 
-toLookupConstraint :: forall a i . Natural -> LookupConstraint i a
+toLookupConstraint :: forall a i . ByteString -> LookupConstraint i a
 toLookupConstraint = LookupConstraint . NewVar

--- a/src/ZkFold/Base/Protocol/Plonkup/PlonkConstraint.hs
+++ b/src/ZkFold/Base/Protocol/Plonkup/PlonkConstraint.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE OverloadedLists      #-}
-{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module ZkFold.Base.Protocol.Plonkup.PlonkConstraint where
 
 import           Control.Monad                                       (guard, return)
+import           Data.Binary                                         (Binary, encode)
+import           Data.ByteString                                     (toStrict)
 import           Data.Containers.ListUtils                           (nubOrd)
 import           Data.Eq                                             (Eq (..))
 import           Data.Function                                       (($), (.))
@@ -13,7 +14,6 @@ import           Data.List                                           (find, head
 import           Data.Map                                            (Map)
 import qualified Data.Map                                            as Map
 import           Data.Maybe                                          (Maybe (..), mapMaybe, maybe)
-import           Data.Type.Equality                                  (type (~))
 import           GHC.IsList                                          (IsList (..))
 import           GHC.TypeNats                                        (KnownNat)
 import           Numeric.Natural                                     (Natural)
@@ -40,7 +40,7 @@ data PlonkConstraint i a = PlonkConstraint
     }
     deriving (Show, Eq)
 
-instance (Arbitrary a, Finite a, ToConstant a, Const a ~ Natural, KnownNat i) => Arbitrary (PlonkConstraint i a) where
+instance (Arbitrary a, Binary a, KnownNat i) => Arbitrary (PlonkConstraint i a) where
     arbitrary = do
         qm <- arbitrary
         ql <- arbitrary
@@ -48,7 +48,7 @@ instance (Arbitrary a, Finite a, ToConstant a, Const a ~ Natural, KnownNat i) =>
         qo <- arbitrary
         qc <- arbitrary
         k <- elements [1, 2, 3]
-        xs0 <- sort <$> replicateA k (Just . NewVar . toConstant @a <$> arbitrary)
+        xs0 <- sort <$> replicateA k (Just . NewVar . toStrict . encode @a <$> arbitrary)
         let (x, y, z) = case replicate (3 -! k) Nothing ++ xs0 of
               [x', y', z'] -> (x', y', z')
               _            -> error "impossible"

--- a/src/ZkFold/Base/Protocol/Protostar.hs
+++ b/src/ZkFold/Base/Protocol/Protostar.hs
@@ -4,6 +4,8 @@ module ZkFold.Base.Protocol.Protostar where
 
 
 import           Control.DeepSeq                                     (NFData)
+import           Data.Binary                                         (decode)
+import           Data.ByteString                                     (fromStrict)
 import           Data.Map.Strict                                     (Map)
 import qualified Data.Map.Strict                                     as M
 import           GHC.Generics                                        (Generic)
@@ -66,7 +68,7 @@ instance (Arithmetic a, KnownNat n) => SpecialSoundProtocol a (RecursiveCircuit 
     --
     algebraicMap rc _ _ _ =
         let
-            varF (NewVar ix) = var (ix P.+ value @n)
+            varF (NewVar ix) = var (toConstant (decode @VarField $ fromStrict ix) P.+ value @n)
             varF (InVar ix)  = var (toConstant ix)
         in
             [ evalPolynomial evalMonomial varF poly

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Map.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Map.hs
@@ -6,11 +6,14 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Map (
         ArithmeticCircuitTest(..)
     ) where
 
+import           Data.Binary                                         (encode)
+import           Data.ByteString                                     (toStrict)
 import           Data.Functor.Rep                                    (Representable (..))
 import           Data.Map                                            hiding (drop, foldl, foldr, fromList, map, null,
                                                                       splitAt, take, toList)
 import qualified Data.Map                                            as Map
 import           GHC.IsList                                          (IsList (..))
+import           Numeric.Natural                                     (Natural)
 import           Prelude                                             hiding (Num (..), drop, length, product, splitAt,
                                                                       sum, take, (!!), (^))
 import           Test.QuickCheck                                     (Arbitrary (arbitrary), Gen)
@@ -18,7 +21,7 @@ import           Test.QuickCheck                                     (Arbitrary 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Polynomials.Multivariate
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (Arithmetic, ArithmeticCircuit (..), Var (..),
-                                                                      getAllVars)
+                                                                      VarField, getAllVars)
 
 -- This module contains functions for mapping variables in arithmetic circuits.
 
@@ -44,13 +47,14 @@ instance (Arithmetic a, Arbitrary (i a), Arbitrary (ArithmeticCircuit a i f), Re
 mapVarArithmeticCircuit :: (Field a, Eq a, Functor o, Ord (Rep i), Representable i, Foldable i) => ArithmeticCircuitTest a i o -> ArithmeticCircuitTest a i o
 mapVarArithmeticCircuit (ArithmeticCircuitTest ac wi) =
     let vars = [v | NewVar v <- getAllVars ac]
-        forward = Map.fromAscList $ zip vars [0..]
-        backward = Map.fromAscList $ zip [0..] vars
+        asc = [ toStrict (encode @VarField (fromConstant @Natural x)) | x <- [0..] ]
+        forward = Map.fromList $ zip vars asc
+        backward = Map.fromAscList $ zip asc vars
         varF (InVar v)  = InVar v
         varF (NewVar v) = NewVar (forward ! v)
         mappedCircuit = ac
             {
-                acSystem  = fromList $ zip [0..] $ evalPolynomial evalMonomial (var . varF) <$> elems (acSystem ac),
+                acSystem  = fromList $ zip asc $ evalPolynomial evalMonomial (var . varF) <$> elems (acSystem ac),
                 -- TODO: the new arithmetic circuit expects the old input variables! We should make this safer.
                 acWitness = (`Map.compose` backward) $ (\f i m -> f i (Map.compose m forward)) <$> acWitness ac
             }

--- a/zkfold-base.cabal
+++ b/zkfold-base.cabal
@@ -230,6 +230,7 @@ library
       -- TODO: remove `blake2` after refactoring of ZK protocols
       blake2                                < 0.4,
       bytestring                           < 0.12,
+      bytestring-aeson-orphans                   ,
       containers                            < 0.7,
       cryptohash-sha256                    < 0.12,
       deepseq                          <= 1.5.0.0,


### PR DESCRIPTION
In preparation for #223, changed the new variables' type to `ByteString`. In this PR, only conversions from `VarField` and back are added, next PRs would actually change the algorithm.

For @vks4git: consider migrating from `Natural`s to `Var`s in Protostar code where applicable.