### PR TITLE
Drop bs-aeson-orphans; use our combinators

### DIFF
--- a/src/ZkFold/Base/Protocol/Plonkup/LookupConstraint.hs
+++ b/src/ZkFold/Base/Protocol/Plonkup/LookupConstraint.hs
@@ -1,11 +1,12 @@
 module ZkFold.Base.Protocol.Plonkup.LookupConstraint where
 
-import           Data.Binary                                         (Binary, encode)
-import           Data.ByteString                                     (ByteString, toStrict)
+import           Data.Binary                                         (Binary)
+import           Data.ByteString                                     (ByteString)
 import           Prelude                                             hiding (Num (..), drop, length, sum, take, (!!),
                                                                       (/), (^))
 import           Test.QuickCheck                                     (Arbitrary (..))
 
+import           ZkFold.Base.Data.ByteString                         (toByteString)
 import           ZkFold.Base.Data.Vector                             (Vector)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal
 
@@ -13,7 +14,7 @@ newtype LookupConstraint i a = LookupConstraint { lkVar :: Var (Vector i) }
     deriving (Show, Eq)
 
 instance (Arbitrary a, Binary a) => Arbitrary (LookupConstraint i a) where
-    arbitrary = LookupConstraint . NewVar . toStrict . encode @a <$> arbitrary
+    arbitrary = LookupConstraint . NewVar . toByteString @a <$> arbitrary
 
 toLookupConstraint :: forall a i . ByteString -> LookupConstraint i a
 toLookupConstraint = LookupConstraint . NewVar

--- a/src/ZkFold/Base/Protocol/Plonkup/PlonkConstraint.hs
+++ b/src/ZkFold/Base/Protocol/Plonkup/PlonkConstraint.hs
@@ -4,8 +4,7 @@
 module ZkFold.Base.Protocol.Plonkup.PlonkConstraint where
 
 import           Control.Monad                                       (guard, return)
-import           Data.Binary                                         (Binary, encode)
-import           Data.ByteString                                     (toStrict)
+import           Data.Binary                                         (Binary)
 import           Data.Containers.ListUtils                           (nubOrd)
 import           Data.Eq                                             (Eq (..))
 import           Data.Function                                       (($), (.))
@@ -24,6 +23,7 @@ import           Text.Show                                           (Show)
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Polynomials.Multivariate        (Poly, evalMonomial, evalPolynomial, polynomial,
                                                                       var, variables)
+import           ZkFold.Base.Data.ByteString                         (toByteString)
 import           ZkFold.Base.Data.Vector                             (Vector)
 import           ZkFold.Prelude                                      (length, replicate, replicateA, take)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal
@@ -48,7 +48,7 @@ instance (Arbitrary a, Binary a, KnownNat i) => Arbitrary (PlonkConstraint i a) 
         qo <- arbitrary
         qc <- arbitrary
         k <- elements [1, 2, 3]
-        xs0 <- sort <$> replicateA k (Just . NewVar . toStrict . encode @a <$> arbitrary)
+        xs0 <- sort <$> replicateA k (Just . NewVar . toByteString @a <$> arbitrary)
         let (x, y, z) = case replicate (3 -! k) Nothing ++ xs0 of
               [x', y', z'] -> (x', y', z')
               _            -> error "impossible"

--- a/src/ZkFold/Base/Protocol/Protostar.hs
+++ b/src/ZkFold/Base/Protocol/Protostar.hs
@@ -4,10 +4,9 @@ module ZkFold.Base.Protocol.Protostar where
 
 
 import           Control.DeepSeq                                     (NFData)
-import           Data.Binary                                         (decode)
-import           Data.ByteString                                     (fromStrict)
 import           Data.Map.Strict                                     (Map)
 import qualified Data.Map.Strict                                     as M
+import           Data.Maybe                                          (fromJust)
 import           GHC.Generics                                        (Generic)
 import           Prelude                                             (($), (==))
 import qualified Prelude                                             as P
@@ -15,6 +14,7 @@ import qualified Prelude                                             as P
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Base.Algebra.Polynomials.Multivariate        (evalMonomial, evalPolynomial, var)
+import           ZkFold.Base.Data.ByteString                         (fromByteString)
 import           ZkFold.Base.Data.Vector                             (Vector)
 import           ZkFold.Base.Protocol.Protostar.SpecialSound
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal
@@ -68,7 +68,7 @@ instance (Arithmetic a, KnownNat n) => SpecialSoundProtocol a (RecursiveCircuit 
     --
     algebraicMap rc _ _ _ =
         let
-            varF (NewVar ix) = var (toConstant (decode @VarField $ fromStrict ix) P.+ value @n)
+            varF (NewVar ix) = var (toConstant (fromJust $ fromByteString @VarField ix) P.+ value @n)
             varF (InVar ix)  = var (toConstant ix)
         in
             [ evalPolynomial evalMonomial varF poly

--- a/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Map.hs
+++ b/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Map.hs
@@ -6,8 +6,6 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Map (
         ArithmeticCircuitTest(..)
     ) where
 
-import           Data.Binary                                         (encode)
-import           Data.ByteString                                     (toStrict)
 import           Data.Functor.Rep                                    (Representable (..))
 import           Data.Map                                            hiding (drop, foldl, foldr, fromList, map, null,
                                                                       splitAt, take, toList)
@@ -20,6 +18,7 @@ import           Test.QuickCheck                                     (Arbitrary 
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Polynomials.Multivariate
+import           ZkFold.Base.Data.ByteString                         (toByteString)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (Arithmetic, ArithmeticCircuit (..), Var (..),
                                                                       VarField, getAllVars)
 
@@ -47,8 +46,8 @@ instance (Arithmetic a, Arbitrary (i a), Arbitrary (ArithmeticCircuit a i f), Re
 mapVarArithmeticCircuit :: (Field a, Eq a, Functor o, Ord (Rep i), Representable i, Foldable i) => ArithmeticCircuitTest a i o -> ArithmeticCircuitTest a i o
 mapVarArithmeticCircuit (ArithmeticCircuitTest ac wi) =
     let vars = [v | NewVar v <- getAllVars ac]
-        asc = [ toStrict (encode @VarField (fromConstant @Natural x)) | x <- [0..] ]
-        forward = Map.fromList $ zip vars asc
+        asc = [ toByteString @VarField (fromConstant @Natural x) | x <- [0..] ]
+        forward = Map.fromAscList $ zip vars asc
         backward = Map.fromAscList $ zip asc vars
         varF (InVar v)  = InVar v
         varF (NewVar v) = NewVar (forward ! v)

--- a/zkfold-base.cabal
+++ b/zkfold-base.cabal
@@ -233,7 +233,6 @@ library
       -- TODO: remove `blake2` after refactoring of ZK protocols
       blake2                                < 0.4,
       bytestring                           < 0.12,
-      bytestring-aeson-orphans                   ,
       containers                            < 0.7,
       cryptohash-sha256                    < 0.12,
       deepseq                          <= 1.5.0.0,


### PR DESCRIPTION
This PR
* drops dependency on `bytestring-aeson-orphans` and adds our own `FromJSON`/`ToJSON` instances for `ByteString`
* reuses existing combinators from `ZkFold.Base.Data.ByteString` instead of `toStrict . encode` etc. in Circuit-related code