### PR TITLE
fix permutations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ cabal.project.local~
 .ghc.environment.*
 compiled_scripts/*
 stack.yaml*
+.DS_Store

--- a/src/ZkFold/Base/Algebra/Basic/Permutations.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Permutations.hs
@@ -56,8 +56,12 @@ fromPermutation :: Permutation n -> [Natural]
 fromPermutation (Permutation perm) = fromVector perm
 
 applyPermutation :: KnownNat n => Permutation n -> Vector n a -> Vector n a
-applyPermutation (Permutation ps) as = fmap (index as . (\ix -> ix - 1) . fromConstant) ps
-  -- subtract 1 from 1-based Natural index to get 0-based Zp n index ^
+applyPermutation (Permutation ps) as =
+    let
+        -- 1-indexed Natural to 0-indexed Zp n
+        naturalToZp ix = fromConstant ix - 1
+    in
+        fmap (index as . naturalToZp) ps
 
 applyCycle :: V.Vector Natural -> Permutation n -> Permutation n
 applyCycle c (Permutation perm) = Permutation $ fmap f perm

--- a/src/ZkFold/Base/Algebra/Basic/Permutations.hs
+++ b/src/ZkFold/Base/Algebra/Basic/Permutations.hs
@@ -34,7 +34,7 @@ type IndexPartition a = Map a IndexSet
 
 mkIndexPartition :: Ord a => V.Vector a -> IndexPartition a
 mkIndexPartition vs =
-    let f i = singleton i $ fmap snd $ V.filter (\(v, _) -> v == i) $ V.zip vs [1 .. length vs]
+    let f i = singleton i $ fmap snd $ V.filter (\(v, _) -> v == i) $ V.zip vs [0 .. length vs P.- 1]
     in V.foldl union empty $ fmap f vs
 
 ------------------------------------- Permutations -------------------------------------------
@@ -70,5 +70,5 @@ applyCycle c (Permutation perm) = Permutation $ fmap (fromConstant . f . toConst
 fromCycles :: KnownNat n => IndexPartition a -> Permutation n
 fromCycles p =
     let n = toInteger $ V.length $ V.concat $ elems p
-    in foldr applyCycle (Permutation $ fromJust $ toVector [fromConstant x | x <- [1 .. n]]) $ elems p
+    in foldr applyCycle (Permutation $ fromJust $ toVector [fromConstant x | x <- [0 .. n P.- 1]]) $ elems p
 

--- a/src/ZkFold/Base/Protocol/Plonkup/Setup.hs
+++ b/src/ZkFold/Base/Protocol/Plonkup/Setup.hs
@@ -81,7 +81,7 @@ plonkupSetup Plonkup {..} =
             1 -> k1 * (omega^i)
             2 -> k2 * (omega^i)
             _ -> error "setup: invalid index"
-        s = fromList $ map (f . toConstant) $ fromPermutation @(PlonkupPermutationSize n) $ sigma
+        s = fromList $ map f $ fromPermutation @(PlonkupPermutationSize n) $ sigma
         sigma1s = toPolyVec $ V.take (fromIntegral $ value @n) s
         sigma2s = toPolyVec $ V.take (fromIntegral $ value @n) $ V.drop (fromIntegral $ value @n) s
         sigma3s = toPolyVec $ V.take (fromIntegral $ value @n) $ V.drop (fromIntegral $ 2 * value @n) s

--- a/tests/Tests/Permutations.hs
+++ b/tests/Tests/Permutations.hs
@@ -23,4 +23,4 @@ specPermutations = hspec $ do
                 \v ->
                     let ts = mkIndexPartition @Integer $ V.fromList $ fromVector @100 v
                         p = fromPermutation @100 $ fromCycles ts
-                    in sort p == sort (V.toList $ V.concat $ elems (fmap (fmap fromIntegral) ts))
+                    in sort p == sort (V.toList $ V.concat $ elems ts)


### PR DESCRIPTION
Use 1-indexed `Natural` indices for permutations and transform to 0-indexed `Zp n` indices at the right moment.