### PR TITLE
Added `compileWithPayload` combinator

### DIFF
--- a/symbolic-base/src/ZkFold/Symbolic/Compiler.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeOperators       #-}
 
 module ZkFold.Symbolic.Compiler (
@@ -7,9 +6,13 @@ module ZkFold.Symbolic.Compiler (
     compile,
     compileIO,
     compileForceOne,
+    compileCircuit,
+    compileWithPayload,
+    solderWith,
     solder,
 ) where
 
+import           Control.DeepSeq                            (NFData)
 import           Data.Aeson                                 (FromJSON, ToJSON, ToJSONKey)
 import           Data.Binary                                (Binary)
 import           Data.Function                              (const, (.))
@@ -44,85 +47,86 @@ import           ZkFold.Symbolic.MonadCircuit               (MonadCircuit (..))
 forceOne :: (Symbolic c, Traversable f) => c f -> c f
 forceOne r = fromCircuitF r (\fi -> for fi $ \i -> constraint (\x -> x i - one) $> i)
 
--- | Arithmetizes an argument by feeding an appropriate amount of inputs.
-solder ::
-    forall a c p f s .
-    ( c ~ ArithmeticCircuit a p (Layout s)
-    , SymbolicData f
-    , Context f ~ c
-    , Support f ~ s
-    , SymbolicInput s
-    , Context s ~ c
-    , Symbolic c
-    ) => f -> c (Layout f)
-solder f = fromCircuit2F (pieces f input) b $ \r (Par1 i) -> do
-    constraint (\x -> one - x i)
-    return r
+-- | Arithmetizes an argument by feeding the given support.
+solderWith ::
+  ( SymbolicData f, Context f ~ c, Support f ~ s
+  , SymbolicInput s, Context s ~ c, Symbolic c
+  ) => c (Layout s) -> f -> c (Layout f)
+solderWith sLayout f = fromCircuit2F (pieces f input) b $ \r (Par1 i) -> do
+  constraint (\x -> one - x i)
+  return r
   where
     Bool b = isValid input
-    input = restore @(Support f) $ const idCircuit
+    input = restore (const sLayout)
+
+compileCircuit ::
+  ( SymbolicData y, Context y ~ c, Support y ~ Proxy c, Layout y ~ l
+  , c ~ ArithmeticCircuit a p i
+  ) => c l -> y
+compileCircuit = restore . const . optimize
+
+solder ::
+  ( SymbolicData f, Context f ~ c, Support f ~ s
+  , SymbolicInput s, Context s ~ c, Layout s ~ l
+  , c ~ ArithmeticCircuit a p l, Arithmetic a, Binary a, Binary (Rep p)
+  ) => f -> c (Layout f)
+solder = solderWith idCircuit
 
 -- | Compiles function `f` into an arithmetic circuit with all outputs equal to 1.
 compileForceOne ::
-    forall a c p f s l y .
-    ( c ~ ArithmeticCircuit a p l
-    , Arithmetic a
-    , Binary a
-    , SymbolicData f
-    , Context f ~ c
-    , Support f ~ s
-    , SymbolicInput s
-    , Context s ~ c
-    , Layout s ~ l
-    , Binary (Rep p)
-    , Binary (Rep l)
-    , Ord (Rep l)
-    , SymbolicData y
-    , Context y ~ c
-    , Support y ~ Proxy c
-    , Layout f ~ Layout y
-    , Traversable (Layout y)
-    ) => f -> y
-compileForceOne = restore . const . optimize . forceOne . solder @a
+  forall a c p f s l y .
+  ( c ~ ArithmeticCircuit a p l, Arithmetic a, Binary a
+  , Binary (Rep p), Binary (Rep l), Ord (Rep l)
+  , SymbolicData f, Context f ~ c, Support f ~ s
+  , SymbolicInput s, Context s ~ c, Layout s ~ l
+  , SymbolicData y, Context y ~ c, Support y ~ Proxy c
+  , Layout f ~ Layout y, Traversable (Layout y)
+  ) => f -> y
+compileForceOne = compileCircuit . forceOne . solder
 
 -- | Compiles function `f` into an arithmetic circuit.
 compile ::
-    forall a c p f s l y .
-    ( c ~ ArithmeticCircuit a p l
-    , SymbolicData f
-    , Context f ~ c
-    , Support f ~ s
-    , SymbolicInput s
-    , Context s ~ c
-    , Layout s ~ l
-    , SymbolicData y
-    , Context y ~ c
-    , Support y ~ Proxy c
-    , Layout f ~ Layout y
-    , Symbolic c
-    ) => f -> y
-compile = restore . const . optimize . solder @a
+  forall a p c f s l y .
+  ( c ~ ArithmeticCircuit a p l, Arithmetic a, Binary a, Binary (Rep p)
+  , SymbolicData f, Context f ~ c, Support f ~ s
+  , SymbolicInput s, Context s ~ c, Layout s ~ l
+  , SymbolicData y, Context y ~ c, Support y ~ Proxy c
+  , Layout f ~ Layout y
+  ) => f -> y
+compile = compileCircuit . solder
+
+compileWithPayload ::
+  forall a p c f s l y .
+  ( c ~ ArithmeticCircuit a l p, Arithmetic a, Binary a
+  , Binary (Rep p), Ord (Rep p), NFData (Rep p)
+  , Traversable l
+  , SymbolicData f, Context f ~ c, Support f ~ s
+  , SymbolicInput s, Context s ~ c, Layout s ~ l
+  , SymbolicData y, Context y ~ c, Support y ~ Proxy c
+  , Layout f ~ Layout y
+  ) => f -> y
+compileWithPayload = compileCircuit . solderWith payloadCircuit
 
 -- | Compiles a function `f` into an arithmetic circuit. Writes the result to a file.
 compileIO ::
-    forall a c p f s l .
-    ( c ~ ArithmeticCircuit a p l
-    , FromJSON a
-    , ToJSON a
-    , ToJSONKey a
-    , SymbolicData f
-    , Context f ~ c
-    , Support f ~ s
-    , ToJSON (Layout f (Var a l))
-    , SymbolicInput s
-    , Context s ~ c
-    , Layout s ~ l
-    , FromJSON (Rep l)
-    , ToJSON (Rep l)
-    , Symbolic c
-    ) => FilePath -> f -> IO ()
+  forall a c p f s l .
+  ( c ~ ArithmeticCircuit a p l
+  , FromJSON a
+  , ToJSON a
+  , ToJSONKey a
+  , SymbolicData f
+  , Context f ~ c
+  , Support f ~ s
+  , ToJSON (Layout f (Var a l))
+  , SymbolicInput s
+  , Context s ~ c
+  , Layout s ~ l
+  , FromJSON (Rep l)
+  , ToJSON (Rep l)
+  , Symbolic c
+  ) => FilePath -> f -> IO ()
 compileIO scriptFile f = do
-    let ac = optimize (solder @a f) :: c (Layout f)
+    let ac = optimize (solderWith idCircuit f) :: c (Layout f)
 
     putStrLn "\nCompiling the script...\n"
 

--- a/symbolic-base/src/ZkFold/Symbolic/Compiler.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler.hs
@@ -8,6 +8,7 @@ module ZkFold.Symbolic.Compiler (
     compileForceOne,
     compileCircuit,
     compileWithPayload,
+    solderWithPayload,
     solderWith,
     solder,
 ) where
@@ -72,6 +73,14 @@ solder ::
   ) => f -> c (Layout f)
 solder = solderWith idCircuit
 
+solderWithPayload ::
+  ( SymbolicData f, Context f ~ c, Support f ~ s
+  , SymbolicInput s, Context s ~ c, Layout s ~ l
+  , c ~ ArithmeticCircuit a l p, Arithmetic a, Binary a
+  , Traversable l, Binary (Rep p), Ord (Rep p), NFData (Rep p)
+  ) => f -> c (Layout f)
+solderWithPayload = solderWith payloadCircuit
+
 -- | Compiles function `f` into an arithmetic circuit with all outputs equal to 1.
 compileForceOne ::
   forall a c p f s l y .
@@ -105,7 +114,7 @@ compileWithPayload ::
   , SymbolicData y, Context y ~ c, Support y ~ Proxy c
   , Layout f ~ Layout y
   ) => f -> y
-compileWithPayload = compileCircuit . solderWith payloadCircuit
+compileWithPayload = compileCircuit . solderWithPayload
 
 -- | Compiles a function `f` into an arithmetic circuit. Writes the result to a file.
 compileIO ::

--- a/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit.hs
@@ -33,7 +33,8 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit (
         acOutput,
         -- Testing functions
         checkCircuit,
-        checkClosedCircuit
+        checkClosedCircuit,
+        isConstantInput
     ) where
 
 import           Control.DeepSeq                                     (NFData)
@@ -169,6 +170,12 @@ acPrint ac = do
     pPrint v
 
 ---------------------------------- Testing -------------------------------------
+
+isConstantInput ::
+  ( Arithmetic a, Show a, Representable p, Representable i
+  , Show (p a), Show (i a), Arbitrary (p a), Arbitrary (i a)
+  ) => ArithmeticCircuit a p i o -> Property
+isConstantInput c = property $ \x y p -> witnessGenerator c p x === witnessGenerator c p y
 
 checkClosedCircuit
     :: forall a o

--- a/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeOperators #-}
+
 module ZkFold.Symbolic.Compiler.ArithmeticCircuit (
         ArithmeticCircuit,
         Constraint,
@@ -7,7 +8,9 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit (
         -- high-level functions
         optimize,
         desugarRanges,
+        emptyCircuit,
         idCircuit,
+        payloadCircuit,
         guessOutput,
         -- low-level functions
         eval,
@@ -35,7 +38,7 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit (
 
 import           Control.DeepSeq                                     (NFData)
 import           Control.Monad                                       (foldM)
-import           Control.Monad.State                                 (execState)
+import           Control.Monad.State                                 (execState, runState)
 import           Data.Binary                                         (Binary)
 import           Data.Foldable                                       (for_)
 import           Data.Functor.Rep                                    (Representable (..), mzipRep)
@@ -43,6 +46,8 @@ import           Data.Map                                            hiding (dro
                                                                       take)
 import qualified Data.Map.Monoidal                                   as M
 import qualified Data.Set                                            as S
+import           Data.Traversable                                    (for)
+import           Data.Tuple                                          (swap)
 import           Data.Void                                           (absurd)
 import           GHC.Generics                                        (U1 (..), (:*:))
 import           Numeric.Natural                                     (Natural)
@@ -60,8 +65,9 @@ import           ZkFold.Prelude                                      (length)
 import           ZkFold.Symbolic.Class                               (fromCircuit2F)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Instance ()
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (Arithmetic, ArithmeticCircuit (..), Constraint,
-                                                                      SysVar (..), Var (..), acInput, eval, eval1, exec,
-                                                                      exec1, hlmap, witnessGenerator)
+                                                                      SysVar (..), Var (..), WitVar (WExVar), acInput,
+                                                                      crown, eval, eval1, exec, exec1, hlmap,
+                                                                      witnessGenerator)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Map
 import           ZkFold.Symbolic.Data.Combinators                    (expansion)
 import           ZkFold.Symbolic.MonadCircuit                        (MonadCircuit (..))
@@ -98,13 +104,18 @@ desugarRanges c =
   let r' = flip execState c {acOutput = U1} . traverse (uncurry desugarRange) $ [(SysVar v, k) | (k, s) <- M.toList (acRange c), v <- S.toList s]
    in r' { acRange = mempty, acOutput = acOutput c }
 
+emptyCircuit :: ArithmeticCircuit a p i U1
+emptyCircuit = ArithmeticCircuit empty M.empty empty U1
+
 idCircuit :: Representable i => ArithmeticCircuit a p i i
-idCircuit = ArithmeticCircuit
-  { acSystem = empty
-  , acRange = M.empty
-  , acWitness = empty
-  , acOutput = acInput
-  }
+idCircuit = emptyCircuit { acOutput = acInput }
+
+payloadCircuit ::
+  ( Representable p, Traversable p, Arithmetic a, Binary a
+  , Binary (Rep p), Binary (Rep l), Ord (Rep l)) => ArithmeticCircuit a p l p
+payloadCircuit =
+  uncurry crown $ swap $ flip runState emptyCircuit $
+    for (tabulate id) $ unconstrained . pure . WExVar
 
 guessOutput ::
   (Arithmetic a, Binary a, Binary (Rep p), Binary (Rep i), Binary (Rep o)) =>

--- a/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
@@ -14,9 +14,10 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (
         VarField,
         Arithmetic,
         Constraint,
-        -- variable getters
+        -- variable getters and setters
         acInput,
         getAllVars,
+        crown,
         -- input mapping
         hlmap,
         -- evaluation functions

--- a/symbolic-base/symbolic-base.cabal
+++ b/symbolic-base/symbolic-base.cabal
@@ -245,6 +245,7 @@ test-suite symbolic-base-test
       Tests.Binary
       Tests.Blake2b
       Tests.ByteString
+      Tests.Compiler
       Tests.FFA
       Tests.Field
       Tests.GroebnerBasis

--- a/symbolic-base/test/Main.hs
+++ b/symbolic-base/test/Main.hs
@@ -6,6 +6,7 @@ import           Tests.Arithmetization     (specArithmetization)
 import           Tests.Binary              (specBinary)
 import           Tests.Blake2b             (specBlake2b)
 import           Tests.ByteString          (specByteString)
+import           Tests.Compiler            (specCompiler)
 import           Tests.FFA                 (specFFA)
 import           Tests.Field               (specField)
 import           Tests.GroebnerBasis       (specGroebner)
@@ -32,6 +33,9 @@ main = do
     specPairing
     specUnivariate
     specGroebner
+
+    -- Compiler spec
+    specCompiler
 
     -- Symbolic types and operations
     specUInt

--- a/symbolic-base/test/Tests/Compiler.hs
+++ b/symbolic-base/test/Tests/Compiler.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeOperators       #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Tests.Compiler (specCompiler) where
+
+import           Control.Applicative                         ((<*>))
+import           Control.Monad                               (return)
+import           Data.Binary                                 (Binary)
+import           Data.Function                               (($))
+import           Data.Functor                                ((<$>))
+import           GHC.Generics                                (U1 (..), (:*:) (..))
+import           System.IO                                   (IO)
+import           Test.Hspec                                  (describe, hspec)
+import           Test.Hspec.QuickCheck                       (prop)
+import           Test.QuickCheck                             (Arbitrary (..))
+import           Text.Show                                   (Show)
+
+import           ZkFold.Base.Algebra.Basic.Field             (Zp)
+import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
+import           ZkFold.Symbolic.Class                       (Arithmetic, Symbolic)
+import           ZkFold.Symbolic.Compiler                    (compileCircuit, guessOutput, isConstantInput,
+                                                              solderWithPayload)
+import           ZkFold.Symbolic.Data.Bool                   ((&&))
+import           ZkFold.Symbolic.Data.ByteString             (ByteString)
+
+testFunction :: Symbolic c => ByteString 256 c -> ByteString 256 c -> ByteString 256 c
+testFunction = (&&)
+
+instance (Arbitrary (f a), Arbitrary (g a)) => Arbitrary ((f :*: g) a) where
+  arbitrary = (:*:) <$> arbitrary <*> arbitrary
+
+instance Arbitrary (U1 a) where
+  arbitrary = return U1
+
+specCompilerG :: forall a. (Arbitrary a, Arithmetic a, Binary a, Show a) => IO ()
+specCompilerG = hspec $ describe "Compiler specification" $ do
+  prop "Guessing with payload is constant in input" $ isConstantInput $
+    compileCircuit $ guessOutput @a @_ @U1 $ solderWithPayload testFunction
+
+specCompiler :: IO ()
+specCompiler = specCompilerG @(Zp BLS12_381_Scalar)

--- a/symbolic-base/test/Tests/Compiler.hs
+++ b/symbolic-base/test/Tests/Compiler.hs
@@ -20,8 +20,7 @@ import           Text.Show                                   (Show)
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
 import           ZkFold.Symbolic.Class                       (Arithmetic, Symbolic)
-import           ZkFold.Symbolic.Compiler                    (finalRestore, guessOutput, isConstantInput,
-                                                              payloadCircuit, solderWith)
+import           ZkFold.Symbolic.Compiler                    (compileWith, guessOutput, isConstantInput, payloadCircuit)
 import           ZkFold.Symbolic.Data.Bool                   ((&&))
 import           ZkFold.Symbolic.Data.ByteString             (ByteString)
 
@@ -37,7 +36,7 @@ instance Arbitrary (U1 a) where
 specCompilerG :: forall a. (Arbitrary a, Arithmetic a, Binary a, Show a) => IO ()
 specCompilerG = hspec $ describe "Compiler specification" $ do
   prop "Guessing with payload is constant in input" $ isConstantInput $
-    finalRestore $ guessOutput @a @_ @U1 $ solderWith payloadCircuit testFunction
+    compileWith (guessOutput @a @_ @U1) payloadCircuit testFunction
 
 specCompiler :: IO ()
 specCompiler = specCompilerG @(Zp BLS12_381_Scalar)

--- a/symbolic-base/test/Tests/Compiler.hs
+++ b/symbolic-base/test/Tests/Compiler.hs
@@ -20,8 +20,8 @@ import           Text.Show                                   (Show)
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
 import           ZkFold.Symbolic.Class                       (Arithmetic, Symbolic)
-import           ZkFold.Symbolic.Compiler                    (compileCircuit, guessOutput, isConstantInput,
-                                                              solderWithPayload)
+import           ZkFold.Symbolic.Compiler                    (finalRestore, guessOutput, isConstantInput,
+                                                              payloadCircuit, solderWith)
 import           ZkFold.Symbolic.Data.Bool                   ((&&))
 import           ZkFold.Symbolic.Data.ByteString             (ByteString)
 
@@ -37,7 +37,7 @@ instance Arbitrary (U1 a) where
 specCompilerG :: forall a. (Arbitrary a, Arithmetic a, Binary a, Show a) => IO ()
 specCompilerG = hspec $ describe "Compiler specification" $ do
   prop "Guessing with payload is constant in input" $ isConstantInput $
-    compileCircuit $ guessOutput @a @_ @U1 $ solderWithPayload testFunction
+    finalRestore $ guessOutput @a @_ @U1 $ solderWith payloadCircuit testFunction
 
 specCompiler :: IO ()
 specCompiler = specCompilerG @(Zp BLS12_381_Scalar)

--- a/symbolic-examples/src/ZkFold/Symbolic/Examples.hs
+++ b/symbolic-examples/src/ZkFold/Symbolic/Examples.hs
@@ -7,7 +7,6 @@ module ZkFold.Symbolic.Examples (ExampleOutput (..), examples) where
 import           Control.DeepSeq                             (NFData)
 import           Data.Function                               (const, ($), (.))
 import           Data.Functor.Rep                            (Rep, Representable)
-import           Data.Ord                                    (Ord)
 import           Data.Proxy                                  (Proxy)
 import           Data.String                                 (String)
 import           Data.Type.Equality                          (type (~))
@@ -53,7 +52,6 @@ exampleOutput ::
   , Support (Support f) ~ Proxy c
   , Layout (Support f) ~ i
   , Representable i
-  , Ord (Rep i)
   , NFData (Rep i)
   , NFData (o (Var A i))
   ) => f -> ExampleOutput


### PR DESCRIPTION
Resolves #370 by adding a new flavor of `compile` function which takes inputs from the payload instead of usual input variables