### PR TITLE
Added `SymbolicData.Payload` associated type

### DIFF
--- a/symbolic-base/src/ZkFold/Base/Protocol/Protostar/RecursiveCircuit.hs
+++ b/symbolic-base/src/ZkFold/Base/Protocol/Protostar/RecursiveCircuit.hs
@@ -45,6 +45,7 @@ protostar :: forall a n k p i o ctx f pi m c .
     , Support [f] ~ Proxy ctx
     , Ring (PolyVec f 3)
     , HomomorphicCommit m c
+    , p ~ Payload (IVCInstanceProof pi f c m) :*: U1
     , i ~ Layout (IVCInstanceProof pi f c m) :*: U1
     , o ~ (((Par1 :*: Layout [FieldElement ctx]) :*: (Par1 :*: (Par1 :*: Par1))) :*: (Par1 :*: Par1))
     ) => (forall ctx' . Symbolic ctx' => Vector n (FieldElement ctx') -> Vector k (FieldElement ctx') -> Vector n (FieldElement ctx'))
@@ -62,6 +63,7 @@ protostar func =
         stepCircuit' =
             hlmap (\(x :*: u :*: y) -> Comp1 (Par1 <$> x) :*: Comp1 (Par1 <$> u) :*: Comp1 (Par1 <$> y) :*: U1)
             $ hmap (\(Comp1 x') -> unPar1 <$> x')
+            $ hpmap (\_ -> Comp1 (tabulate $ const U1) :*: Comp1 (tabulate $ const U1) :*: Comp1 (tabulate $ const U1) :*: U1)
             $ compile @a stepFunction
 
         -- The circuit for one step of the recursion with extra witness

--- a/symbolic-base/src/ZkFold/Symbolic/Algorithms/Hash/MiMC.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Algorithms/Hash/MiMC.hs
@@ -48,4 +48,4 @@ hash :: forall context x a .
     , Support x ~ Proxy context
     , Foldable (Layout x)
     ) => x -> FieldElement context
-hash = mimcHashN mimcConstants (zero :: a) . fmap FieldElement . unpacked . hmap toList . flip pieces Proxy
+hash = mimcHashN mimcConstants (zero :: a) . fmap FieldElement . unpacked . hmap toList . flip arithmetize Proxy

--- a/symbolic-base/src/ZkFold/Symbolic/Class.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Class.hs
@@ -42,7 +42,9 @@ type family FunBody (fs :: [Type -> Type]) (g :: Type -> Type) (i :: Type) (m ::
 
 -- | A Symbolic DSL for performant pure computations with arithmetic circuits.
 -- @c@ is a generic context in which computations are performed.
-class (HApplicative c, Package c, Arithmetic (BaseField c)) => Symbolic c where
+class ( HApplicative c, Package c, Arithmetic (BaseField c)
+      , ResidueField (Const (WitnessField c)) (WitnessField c)
+      ) => Symbolic c where
     -- | Base algebraic field over which computations are performed.
     type BaseField c :: Type
     -- | Type of witnesses usable inside circuit construction

--- a/symbolic-base/src/ZkFold/Symbolic/Compiler.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler.hs
@@ -58,7 +58,7 @@ compileWith ::
   -- | Function to compile.
   f -> y
 compileWith opts sLayout f =
-  restore . const . optimize . opts $ fromCircuit2F (pieces f input) b $
+  restore . const . optimize . opts $ fromCircuit2F (arithmetize f input) b $
     \r (Par1 i) -> do
       constraint (\x -> one - x i)
       return r

--- a/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit.hs
@@ -27,6 +27,7 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit (
         acPrint,
         -- Variable mapping functions
         hlmap,
+        hpmap,
         mapVarArithmeticCircuit,
         -- Arithmetization type fields
         acWitness,
@@ -68,12 +69,12 @@ import           ZkFold.Symbolic.Class                               (fromCircui
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Instance ()
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (Arithmetic, ArithmeticCircuit (..), Constraint,
                                                                       SysVar (..), Var (..), WitVar (WExVar), acInput,
-                                                                      crown, eval, eval1, exec, exec1, hlmap,
+                                                                      crown, eval, eval1, exec, exec1, hlmap, hpmap,
                                                                       witnessGenerator)
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Map
+import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Witness  (WitnessF)
 import           ZkFold.Symbolic.Data.Combinators                    (expansion)
 import           ZkFold.Symbolic.MonadCircuit                        (MonadCircuit (..))
-import ZkFold.Symbolic.Compiler.ArithmeticCircuit.Witness (WitnessF)
 
 --------------------------------- High-level functions --------------------------------
 

--- a/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit.hs
@@ -11,6 +11,7 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit (
         emptyCircuit,
         idCircuit,
         payloadCircuit,
+        inputPayload,
         guessOutput,
         -- low-level functions
         eval,
@@ -72,6 +73,7 @@ import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (Arithmetic
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Map
 import           ZkFold.Symbolic.Data.Combinators                    (expansion)
 import           ZkFold.Symbolic.MonadCircuit                        (MonadCircuit (..))
+import ZkFold.Symbolic.Compiler.ArithmeticCircuit.Witness (WitnessF)
 
 --------------------------------- High-level functions --------------------------------
 
@@ -117,6 +119,9 @@ payloadCircuit ::
 payloadCircuit =
   uncurry crown $ swap $ flip runState emptyCircuit $
     for (tabulate id) $ unconstrained . pure . WExVar
+
+inputPayload :: Representable p => p (WitnessF a (WitVar p i))
+inputPayload = tabulate $ pure . WExVar
 
 guessOutput ::
   (Arithmetic a, Binary a, Binary (Rep p), Binary (Rep i), Binary (Rep o)) =>

--- a/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
@@ -123,7 +123,7 @@ imapWitVar f (WSysVar v) = WSysVar (imapSysVar f v)
 pmapWitVar ::
   (Representable p, Representable q) =>
   (forall x. q x -> p x) -> WitVar p i -> WitVar q i
-pmapWitVar f (WExVar r) = index (f (tabulate WExVar)) r
+pmapWitVar f (WExVar r)  = index (f (tabulate WExVar)) r
 pmapWitVar _ (WSysVar v) = WSysVar v
 
 data Var a i

--- a/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Internal.hs
@@ -20,6 +20,7 @@ module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal (
         crown,
         -- input mapping
         hlmap,
+        hpmap,
         -- evaluation functions
         witnessGenerator,
         eval,
@@ -119,6 +120,12 @@ imapWitVar ::
 imapWitVar _ (WExVar r)  = WExVar r
 imapWitVar f (WSysVar v) = WSysVar (imapSysVar f v)
 
+pmapWitVar ::
+  (Representable p, Representable q) =>
+  (forall x. q x -> p x) -> WitVar p i -> WitVar q i
+pmapWitVar f (WExVar r) = index (f (tabulate WExVar)) r
+pmapWitVar _ (WSysVar v) = WSysVar v
+
 data Var a i
   = SysVar (SysVar i)
   | ConstVar a
@@ -171,6 +178,11 @@ hlmap f (ArithmeticCircuit s r w o) = ArithmeticCircuit
   , acWitness = fmap (imapWitVar f) <$> w
   , acOutput = imapVar f <$> o
   }
+
+hpmap ::
+  (Representable p, Representable q) => (forall x. q x -> p x) ->
+  ArithmeticCircuit a p i o -> ArithmeticCircuit a q i o
+hpmap f ac = ac { acWitness = fmap (pmapWitVar f) <$> acWitness ac }
 
 --------------------------- Symbolic compiler context --------------------------
 

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Class.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Class.hs
@@ -7,10 +7,12 @@ module ZkFold.Symbolic.Data.Class (
     ) where
 
 import           Control.Applicative              ((<*>))
+import           Data.Bifunctor                   (bimap)
 import           Data.Function                    (flip, (.))
 import           Data.Functor                     ((<$>))
 import           Data.Functor.Rep                 (Representable (..))
 import           Data.Kind                        (Type)
+import           Data.Tuple                       (fst)
 import           Data.Type.Equality               (type (~))
 import           Data.Typeable                    (Proxy (..))
 import           GHC.Generics                     (U1 (..), (:*:) (..), (:.:) (..))
@@ -22,6 +24,7 @@ import           ZkFold.Base.Data.HFunctor        (hmap)
 import           ZkFold.Base.Data.Package         (Package, pack)
 import           ZkFold.Base.Data.Product         (fstP, sndP)
 import           ZkFold.Base.Data.Vector          (Vector)
+import           ZkFold.Symbolic.Class            (Symbolic (WitnessField))
 
 -- | A class for Symbolic data types.
 class SymbolicData x where
@@ -35,6 +38,9 @@ class SymbolicData x where
     type Layout x :: Type -> Type
     type Layout x = GLayout (G.Rep x)
 
+    type Payload x :: Type -> Type
+    type Payload x = GPayload (G.Rep x)
+
     -- | Returns the circuit that makes up `x`.
     arithmetize :: x -> Support x -> Context x (Layout x)
     default arithmetize
@@ -47,32 +53,48 @@ class SymbolicData x where
       => x -> Support x -> Context x (Layout x)
     arithmetize x = garithmetize (G.from x)
 
-    -- | Restores `x` from the circuit's outputs.
-    restore :: (Support x -> Context x (Layout x)) -> x
-    default restore
+    payload :: x -> Support x -> Payload x (WitnessField (Context x))
+    default payload
       :: ( G.Generic x
          , GSymbolicData (G.Rep x)
          , Context x ~ GContext (G.Rep x)
          , Support x ~ GSupport (G.Rep x)
-         , Layout x ~ GLayout (G.Rep x)
+         , Payload x ~ GPayload (G.Rep x)
          )
-      => (Support x -> Context x (Layout x)) -> x
+      => x -> Support x -> Payload x (WitnessField (Context x))
+    payload x = gpayload (G.from x)
+
+    -- | Restores `x` from the circuit's outputs.
+    restore ::
+      Context x ~ c =>
+      (Support x -> (c (Layout x), Payload x (WitnessField c))) -> x
+    default restore ::
+      ( Context x ~ c, G.Generic x, GSymbolicData (G.Rep x)
+      , Context x ~ GContext (G.Rep x)
+      , Support x ~ GSupport (G.Rep x)
+      , Layout x ~ GLayout (G.Rep x)
+      , Payload x ~ GPayload (G.Rep x)) =>
+      (Support x -> (c (Layout x), Payload x (WitnessField c))) -> x
     restore f = G.to (grestore f)
 
 instance SymbolicData (c (f :: Type -> Type)) where
     type Context (c f) = c
     type Support (c f) = Proxy c
     type Layout (c f) = f
+    type Payload (c f) = U1
 
     arithmetize x _ = x
-    restore f = f Proxy
+    payload _ _ = U1
+    restore f = fst (f Proxy)
 
 instance HApplicative c => SymbolicData (Proxy (c :: (Type -> Type) -> Type)) where
     type Context (Proxy c) = c
     type Support (Proxy c) = Proxy c
     type Layout (Proxy c) = U1
+    type Payload (Proxy c) = U1
 
     arithmetize _ _ = hpure U1
+    payload _ _ = U1
     restore _ = Proxy
 
 instance
@@ -134,25 +156,34 @@ instance
     type Context (Vector n x) = Context x
     type Support (Vector n x) = Support x
     type Layout (Vector n x) = Vector n :.: Layout x
+    type Payload (Vector n x) = Vector n :.: Payload x
 
-    arithmetize xs i = pack (flip arithmetize i <$> xs)
-    restore f = tabulate (\i -> restore (hmap (flip index i . unComp1) . f))
+    arithmetize xs s = pack (flip arithmetize s <$> xs)
+    payload xs s = Comp1 (flip payload s <$> xs)
+    restore f = tabulate (\i -> restore (bimap (hmap (ix i)) (ix i) . f))
+      where ix i = flip index i . unComp1
 
 instance SymbolicData f => SymbolicData (x -> f) where
     type Context (x -> f) = Context f
     type Support (x -> f) = (x, Support f)
     type Layout (x -> f) = Layout f
+    type Payload (x -> f) = Payload f
 
     arithmetize f (x, i) = arithmetize (f x) i
+    payload f (x, i) = payload (f x) i
     restore f x = restore (f . (x,))
 
 class GSymbolicData u where
     type GContext u :: (Type -> Type) -> Type
     type GSupport u :: Type
     type GLayout u :: Type -> Type
+    type GPayload u :: Type -> Type
 
     garithmetize :: u x -> GSupport u -> GContext u (GLayout u)
-    grestore :: (GSupport u -> GContext u (GLayout u)) -> u x
+    gpayload :: u x -> GSupport u -> GPayload u (WitnessField (GContext u))
+    grestore ::
+      GContext u ~ c =>
+      (GSupport u -> (c (GLayout u), GPayload u (WitnessField c))) -> u x
 
 instance
     ( GSymbolicData u
@@ -165,20 +196,28 @@ instance
     type GContext (u :*: v) = GContext u
     type GSupport (u :*: v) = GSupport u
     type GLayout (u :*: v) = GLayout u :*: GLayout v
+    type GPayload (u :*: v) = GPayload u :*: GPayload v
 
     garithmetize (a :*: b) = hliftA2 (:*:) <$> garithmetize a <*> garithmetize b
-    grestore f = grestore (hmap fstP . f) :*: grestore (hmap sndP . f)
+    gpayload (a :*: b) = (:*:) <$> gpayload a <*> gpayload b
+    grestore f =
+      grestore (bimap (hmap fstP) fstP . f)
+      :*: grestore (bimap (hmap sndP) sndP . f)
 
 instance GSymbolicData f => GSymbolicData (G.M1 i c f) where
     type GContext (G.M1 i c f) = GContext f
     type GSupport (G.M1 i c f) = GSupport f
     type GLayout (G.M1 i c f) = GLayout f
+    type GPayload (G.M1 i c f) = GPayload f
     garithmetize (G.M1 a) = garithmetize a
+    gpayload (G.M1 a) = gpayload a
     grestore f = G.M1 (grestore f)
 
 instance SymbolicData x => GSymbolicData (G.Rec0 x) where
     type GContext (G.Rec0 x) = Context x
     type GSupport (G.Rec0 x) = Support x
     type GLayout (G.Rec0 x) = Layout x
+    type GPayload (G.Rec0 x) = Payload x
     garithmetize (G.K1 x) = arithmetize x
+    gpayload (G.K1 x) = payload x
     grestore f = G.K1 (restore f)

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Combinators.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Combinators.hs
@@ -6,16 +6,17 @@
 
 module ZkFold.Symbolic.Data.Combinators where
 
+import           Control.Applicative              (Applicative)
 import           Control.Monad                    (mapM)
 import           Data.Foldable                    (foldlM)
-import           Data.Functor.Rep                 (Representable, mzipRep)
+import           Data.Functor.Rep                 (Representable, mzipRep, mzipWithRep)
 import           Data.Kind                        (Type)
 import           Data.List                        (find, splitAt)
 import           Data.List.Split                  (chunksOf)
 import           Data.Maybe                       (fromMaybe)
 import           Data.Proxy                       (Proxy (..))
 import           Data.Ratio                       ((%))
-import           Data.Traversable                 (Traversable, for)
+import           Data.Traversable                 (Traversable, for, sequenceA)
 import           Data.Type.Bool                   (If)
 import           Data.Type.Ord
 import           GHC.Base                         (const, return)
@@ -29,6 +30,13 @@ import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Number (value)
 import           ZkFold.Symbolic.Class            (Arithmetic)
 import           ZkFold.Symbolic.MonadCircuit
+
+mzipWithMRep ::
+  (Representable f, Traversable f, Applicative m) =>
+  (a -> b -> m c) -> f a -> f b -> m (f c)
+mzipWithMRep f x y = sequenceA (mzipWithRep f x y)
+
+--------------------------------------------------------------------------------------------------
 
 -- | A class for isomorphic types.
 -- The @Iso b a@ context ensures that transformations in both directions are defined

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Conditional.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Conditional.hs
@@ -39,7 +39,7 @@ instance ( SymbolicData x, Context x ~ c, Symbolic c
          , Representable (Layout x), Traversable (Layout x)
          ) => Conditional (Bool c) x where
     bool x y (Bool b) = restore $ \s ->
-      fromCircuit3F b (pieces x s) (pieces y s) $ \(Par1 c) ->
+      fromCircuit3F b (arithmetize x s) (arithmetize y s) $ \(Par1 c) ->
         mzipWithMRep $ \i j -> do
           i' <- newAssigned (\w -> (one - w c) * w i)
           j' <- newAssigned (\w -> w c * w j)

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Conditional.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Conditional.hs
@@ -3,10 +3,9 @@
 
 module ZkFold.Symbolic.Data.Conditional where
 
-import           Control.Applicative                (Applicative)
 import           Control.Monad.Representable.Reader (Representable, mzipWithRep)
 import           Data.Function                      (($))
-import           Data.Traversable                   (Traversable, sequenceA)
+import           Data.Traversable                   (Traversable)
 import           Data.Type.Equality                 (type (~))
 import           GHC.Generics                       (Par1 (Par1))
 
@@ -14,6 +13,7 @@ import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Data.Bool          (Bool (Bool), BoolType)
 import           ZkFold.Symbolic.Data.Class
+import           ZkFold.Symbolic.Data.Combinators   (mzipWithMRep)
 import           ZkFold.Symbolic.MonadCircuit       (newAssigned)
 
 class BoolType b => Conditional b a where
@@ -29,11 +29,6 @@ gif b x y = bool y x b
 
 (?) :: Conditional b a => b -> a -> a -> a
 (?) = gif
-
-mzipWithMRep ::
-  (Representable f, Traversable f, Applicative m) =>
-  (a -> b -> m c) -> f a -> f b -> m (f c)
-mzipWithMRep f x y = sequenceA (mzipWithRep f x y)
 
 instance ( SymbolicData x, Context x ~ c, Symbolic c
          , Representable (Layout x), Traversable (Layout x)

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Ed25519.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Ed25519.hs
@@ -35,6 +35,7 @@ instance
     type Context (Point (Ed25519 c)) = c
     type Support (Point (Ed25519 c)) = Support (FFA Ed25519_Base c)
     type Layout (Point (Ed25519 c)) = Layout (FFA Ed25519_Base c, FFA Ed25519_Base c)
+    type Payload (Point (Ed25519 c)) = Payload (FFA Ed25519_Base c, FFA Ed25519_Base c)
 
     -- (0, 0) is never on a Twisted Edwards curve for any curve parameters.
     -- We can encode the point at infinity as (0, 0), therefore.
@@ -45,7 +46,8 @@ instance
     --
     arithmetize Inf         = arithmetize (zero :: FFA Ed25519_Base c, zero :: FFA Ed25519_Base c)
     arithmetize (Point x y) = arithmetize (x, y)
-
+    payload Inf         = payload (zero :: FFA Ed25519_Base c, zero :: FFA Ed25519_Base c)
+    payload (Point x y) = payload (x, y)
     restore f = Point x y
         where
             (x, y) = restore f
@@ -90,6 +92,7 @@ instance
     , l ~ Layout (Point c)
     , Representable l
     , Traversable l
+    , Representable (Payload (Point c))
     , ctx ~ Context (Point c)
     , Symbolic ctx
     , a ~ S.BaseField ctx

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Ed25519.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Ed25519.hs
@@ -43,8 +43,8 @@ instance
     -- It will need additional checks in pointDouble because of the denominator becoming zero, though.
     -- TODO: Think of a better solution
     --
-    pieces Inf         = pieces (zero :: FFA Ed25519_Base c, zero :: FFA Ed25519_Base c)
-    pieces (Point x y) = pieces (x, y)
+    arithmetize Inf         = arithmetize (zero :: FFA Ed25519_Base c, zero :: FFA Ed25519_Base c)
+    arithmetize (Point x y) = arithmetize (x, y)
 
     restore f = Point x y
         where

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Eq/Structural.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Eq/Structural.hs
@@ -26,11 +26,11 @@ instance
     ) => Eq (Bool c) (Structural x) where
 
     Structural x == Structural y =
-        let x' = pieces x Proxy
-            y' = pieces y Proxy
+        let x' = arithmetize x Proxy
+            y' = arithmetize y Proxy
          in x' == y'
 
     Structural x /= Structural y =
-        let x' = pieces x Proxy
-            y' = pieces y Proxy
+        let x' = arithmetize x Proxy
+            y' = arithmetize y Proxy
          in x' /= y'

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Input.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Input.hs
@@ -33,6 +33,7 @@ class
     , Ord (R.Rep (Layout d))
     , NFData (R.Rep (Layout d))
     , R.Representable (Payload d)
+    , Binary (R.Rep (Payload d))
     ) => SymbolicInput d where
     isValid :: d -> Bool (Context d)
     default isValid ::

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Input.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Input.hs
@@ -32,6 +32,7 @@ class
     , Binary (R.Rep (Layout d))
     , Ord (R.Rep (Layout d))
     , NFData (R.Rep (Layout d))
+    , R.Representable (Payload d)
     ) => SymbolicInput d where
     isValid :: d -> Bool (Context d)
     default isValid ::

--- a/symbolic-base/src/ZkFold/Symbolic/Data/List.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/List.hs
@@ -3,6 +3,7 @@
 module ZkFold.Symbolic.Data.List where
 
 import           Control.Applicative              (Applicative)
+import           Data.Function                    (const)
 import           Data.Functor.Rep                 (Representable)
 import           Data.Kind                        (Type)
 import           Data.Proxy                       (Proxy (..))
@@ -65,7 +66,7 @@ infixr 5 .:
 x .: List{..} = List incSum incSize (x:lWitness)
     where
         xRepr :: context (Layout x)
-        xRepr = pieces x (Proxy @context)
+        xRepr = arithmetize x (Proxy @context)
 
         incSum :: context (Layout x)
         incSum = fromCircuit3F lHash xRepr lSize $
@@ -105,11 +106,11 @@ head
     => Context x ~ context
     => Support x ~ Proxy context
     => List context x -> x
-head xs@List{..} = bool (restore $ \_ -> unsafeHead) (restore $ \_ -> embed $ pure zero) (null xs)
+head xs@List{..} = bool (restore $ const unsafeHead) (restore $ \_ -> embed $ pure zero) (null xs)
     where
         xRepr :: context (Layout x)
         xRepr = case lWitness of
-                  (x:_) -> pieces x Proxy
+                  (x:_) -> arithmetize x Proxy
                   _     -> embed $ pure zero
 
         -- | Head is a circuit comprised of variables satisfying the equation for prepending (i.e. (.:))
@@ -145,7 +146,7 @@ tail xs@List{..} = bool unsafeTail xs (null xs)
 
         xRepr :: context (Layout x)
         xRepr = case lWitness of
-                  (x:_) -> pieces x Proxy
+                  (x:_) -> arithmetize x Proxy
                   _     -> embed $ pure zero
 
         decSum :: context (Layout x)

--- a/symbolic-base/src/ZkFold/Symbolic/Data/List.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/List.hs
@@ -2,29 +2,28 @@
 
 module ZkFold.Symbolic.Data.List where
 
-import           Control.Applicative              (Applicative)
-import           Data.Bifunctor                   (first)
+import           Control.Monad                    (return)
 import           Data.Function                    (const)
-import           Data.Functor.Rep                 (Representable, pureRep)
+import           Data.Functor.Rep                 (Representable, pureRep, tabulate)
 import           Data.Proxy                       (Proxy (..))
-import           Data.Traversable                 (Traversable)
-import           Data.Zip                         (Zip)
-import           GHC.Generics                     (Par1 (..))
-import           Prelude                          (fmap, fst, pure, type (~), undefined, ($), (.), (<$>))
+import           Data.Traversable                 (Traversable, traverse)
+import           Data.Tuple                       (snd)
+import           GHC.Generics                     (Par1 (..), (:*:) (..))
+import           Prelude                          (fmap, fst, type (~), undefined, ($), (.), (<$>))
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Data.Utils           (zipWithM)
+import           ZkFold.Base.Data.HFunctor        (hmap)
+import           ZkFold.Base.Data.Product         (fstP, sndP)
 import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Data.Bool        (Bool (..))
 import           ZkFold.Symbolic.Data.Class
 import           ZkFold.Symbolic.Data.Combinators
-import           ZkFold.Symbolic.Data.Conditional
 import           ZkFold.Symbolic.MonadCircuit
 
 data List c x = List
   { lHash    :: c (Layout x)
   , lSize    :: c Par1
-  , lWitness :: [(Layout x (WitnessField c), Support x -> (Layout x (WitnessField c), Payload x (WitnessField c)))]
+  , lWitness :: [(Layout x (WitnessField c), Layout x (WitnessField c), Payload x (WitnessField c))]
   -- ^ TODO: As the name suggests, this is only needed in witness cinstruction in uncons.
   -- This list is never used in circuit itlest.
   -- Think of a better solution for carrying witnesses.
@@ -37,9 +36,9 @@ data List c x = List
 emptyList
     :: forall context x
     .  Symbolic context
-    => Applicative (Layout x)
+    => Representable (Layout x)
     => List context x
-emptyList = List (embed $ pure zero) (embed $ Par1 zero) []
+emptyList = List (embed $ pureRep zero) (embed $ Par1 zero) []
 
 -- | A list is empty if it's size is 0, in which case the first element of @runInvert@ is @one@.
 --
@@ -55,90 +54,65 @@ infixr 5 .:
     :: forall context x
     .  Symbolic context
     => Traversable (Layout x)
-    => Zip (Layout x)
+    => Representable (Layout x)
     => SymbolicData x
     => Context x ~ context
     => Support x ~ Proxy context
     => x
     -> List context x
     -> List context x
-x .: List{..} = List incSum incSize ((witnessF lHash, \s -> (witnessF (arithmetize x s), payload x s)):lWitness)
+x .: List{..} = List incSum incSize ((witnessF lHash, witnessF (arithmetize x Proxy), payload x Proxy):lWitness)
     where
         xRepr :: context (Layout x)
         xRepr = arithmetize x (Proxy @context)
 
-        incSum :: context (Layout x)
-        incSum = fromCircuit3F lHash xRepr lSize $
-            \vHash vRepr (Par1 s) -> zipWithM (\h r -> newAssigned (\p -> p h + p r * (p s + one))) vHash vRepr
-
         incSize :: context Par1
         incSize = fromCircuitF lSize (\(Par1 s) -> Par1 <$> newAssigned (\p -> p s + one))
 
-uncons
-    :: forall context x
-    .  Symbolic context
-    => SymbolicData x
-    => Applicative (Layout x)
-    => Traversable (Layout x)
-    => Representable (Layout x)
-    => Zip (Layout x)
-    => SymbolicData (List context x) -- TODO: Implement this
-    => Representable (Layout (List context x))
-    => Traversable (Layout (List context x))
-    => Context x ~ context
-    => Context (List context x) ~ context
-    => Support x ~ Proxy context
-    => List context x
-    -> (x, List context x)
-uncons l = (head l, tail l)
+        incSum :: context (Layout x)
+        incSum = fromCircuit3F lHash xRepr incSize $
+            \vHash vRepr (Par1 s) -> mzipWithMRep (hashF s) vHash vRepr
+
+hashF :: MonadCircuit i a w m => i -> i -> i -> m i
+hashF s h t = newAssigned (($ h) + ($ t) * ($ s))
+
+uncons ::
+  forall c x.
+  (Symbolic c, SymbolicData x) =>
+  (Context x ~ c, Support x ~ Proxy c, Representable (Payload x)) =>
+  (Representable (Layout x), Traversable (Layout x)) =>
+  List c x -> (x, List c x)
+uncons l@List{..} = case lWitness of
+  [] -> (restore $ const (lHash, tabulate (const zero)), l)
+  ((tHash, hdL, hdP):tWitness) ->
+    ( restore $ const (hmap fstP preimage, hdP)
+    , List (hmap sndP preimage) decSize tWitness)
+    where
+      decSize = fromCircuitF lSize $ \(Par1 i) ->
+        Par1 <$> newAssigned (($ i) - one)
+
+      preimage :: c (Layout x :*: Layout x)
+      preimage = fromCircuit2F lSize lHash $ \(Par1 s) y -> do
+        tH :*: hH <- traverse unconstrained (tHash :*: hdL)
+        hash <- mzipWithMRep (hashF s) hH tH
+        _ <- mzipWithMRep (\i j -> constraint (($ i) - ($ j))) hash y
+        return (hH :*: tH)
 
 -- | TODO: Is there really a nicer way to handle empty lists?
 --
-head
-    :: forall context x
-    .  Symbolic context
-    => SymbolicData x
-    => Context x ~ context
-    => List context x -> x
-head l = case lWitness l of
-  []    -> restore $ const (embed (pureRep zero), pureRep zero)
-  (w:_) -> restore $ first _ . w
+head ::
+  (Symbolic c, SymbolicData x) =>
+  (Context x ~ c, Support x ~ Proxy c, Representable (Payload x)) =>
+  (Representable (Layout x), Traversable (Layout x)) =>
+  List c x -> x
+head = fst . uncons
 
-tail
-    :: forall context x
-    .  Symbolic context
-    => Applicative (Layout x)
-    => Traversable (Layout x)
-    => Zip (Layout x)
-    => SymbolicData x
-    => SymbolicData (List context x) -- TODO: Implement this
-    => Representable (Layout (List context x))
-    => Traversable (Layout (List context x))
-    => Context x ~ context
-    => Context (List context x) ~ context
-    => Support x ~ Proxy context
-    => List context x
-    -> List context x
-tail xs@List{..} = bool unsafeTail xs (null xs)
-    where
-        tailId :: [a] -> [a]
-        tailId []      = []
-        tailId (_:xs') = xs'
-
-        unsafeTail :: List context x
-        unsafeTail = List decSum decSize (tailId lWitness)
-
-        xRepr :: context (Layout x)
-        xRepr = case lWitness of
-                  (x:_) -> arithmetize x Proxy
-                  _     -> embed $ pure zero
-
-        decSum :: context (Layout x)
-        decSum = fromCircuit3F lHash xRepr lSize $
-            \vHash vRepr (Par1 s) -> zipWithM (\h r -> newAssigned (\p -> p h - p r * p s)) vHash vRepr
-
-        decSize :: context Par1
-        decSize = fromCircuitF lSize (\(Par1 s) -> Par1 <$> newAssigned (\p -> p s - one))
+tail ::
+  (Symbolic c, SymbolicData x) =>
+  (Context x ~ c, Support x ~ Proxy c, Representable (Payload x)) =>
+  (Representable (Layout x), Traversable (Layout x)) =>
+  List c x -> List c x
+tail = snd . uncons
 
 {-- TODO: Foldable relies on Haskell types such as Bool (i.e. null = foldr (\_ _ -> False) True)
    I am not sure this is suitable for Symbolic interface

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Maybe.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Maybe.hs
@@ -7,19 +7,16 @@ module ZkFold.Symbolic.Data.Maybe (
     Maybe, maybe, just, nothing, fromMaybe, fromJust, isNothing, isJust, find
 ) where
 
-import           Data.Function                    ((.))
+import           Data.Functor                     ((<$>))
 import           Data.Functor.Rep                 (Representable, pureRep)
 import           Data.Proxy                       (Proxy)
 import           Data.Traversable                 (Traversable)
-import           GHC.Generics                     (Par1 (..), Generic)
+import           GHC.Generics                     (Generic, Par1 (..))
 import           Prelude                          (foldr, type (~), ($))
 import qualified Prelude                          as Haskell
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Control.HApplicative (HApplicative)
-import           ZkFold.Base.Data.HFunctor        (HFunctor, hmap)
-import qualified ZkFold.Base.Data.Vector          as V
-import           ZkFold.Base.Data.Vector          (Vector)
 import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.Class
@@ -40,26 +37,18 @@ just = Maybe true
 
 nothing ::
   forall x c .
-  (SymbolicData x, Representable (Layout x), Context x ~ c, Symbolic c) =>
+  ( SymbolicData x, Representable (Layout x)
+  , Representable (Payload x), Context x ~ c, Symbolic c) =>
   Maybe c x
-nothing = Maybe false (let c = embed @c $ pureRep zero in restore (Haskell.const c))
+nothing =
+  Maybe false $ restore $ Haskell.const (embed (pureRep zero), pureRep zero)
 
-fromMaybe
-    :: forall c x
-    .  HFunctor c
-    => Ring (c (Vector 1))
-    => SymbolicData x
-    => Context x ~ c
-    => Layout x ~ Vector 1
-    => x
-    -> Maybe c x
-    -> x
-fromMaybe a (Maybe (Bool h) t) = restore $ \i ->
-  let
-    as = arithmetize a i
-    ts = arithmetize t i
-  in
-    (ts - as) * hmap (V.singleton . unPar1) h + as
+fromMaybe ::
+  forall c x .
+  ( Symbolic c, SymbolicData x, Context x ~ c, Traversable (Layout x)
+  , Representable (Layout x), Representable (Payload x)) =>
+  x -> Maybe c x -> x
+fromMaybe a (Maybe j t) = bool a t j
 
 isNothing :: Symbolic c => Maybe c x -> Bool c
 isNothing (Maybe h _) = not h
@@ -72,15 +61,15 @@ instance
     ) => SymbolicData (Maybe c x) where
 
 maybe :: forall a b c .
-    (Symbolic c, SymbolicData b, Context b ~ c) =>
-    (Representable (Layout b), Traversable (Layout b)) =>
+    ( Symbolic c, SymbolicData b, Context b ~ c, Representable (Layout b)
+    , Traversable (Layout b), Representable (Payload b)) =>
     b -> (a -> b) -> Maybe c a -> b
-maybe d h x@(Maybe _ v) = bool @(Bool c) d (h v) $ isJust x
+maybe d h m = fromMaybe d (h <$> m)
 
 find :: forall a c t .
-    (Symbolic c, SymbolicData a, Context a ~ c, Support a ~ Proxy c) =>
-    (Representable (Layout a), Traversable (Layout a)) =>
-    Haskell.Foldable t =>
+    ( Symbolic c, SymbolicData a, Context a ~ c, Support a ~ Proxy c
+    , Representable (Layout a), Traversable (Layout a)
+    , Representable (Payload a), Haskell.Foldable t) =>
     (a -> Bool c) -> t a -> Maybe c a
 find p = let n = nothing in
     foldr (\i r -> maybe @a @_ @c (bool @(Bool c) n (just i) $ p i) (Haskell.const r) r) n

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Ord.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Ord.hs
@@ -72,6 +72,7 @@ instance
     , Support x ~ Proxy c
     , Representable (Layout x)
     , Traversable (Layout x)
+    , Representable (Payload x)
     ) => Ord (Bool c) (Lexicographical x) where
 
     x <= y = y >= x

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Ord.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Ord.hs
@@ -92,7 +92,7 @@ getBitsBE ::
   x -> c []
 -- ^ @getBitsBE x@ returns a list of circuits computing bits of @x@, eldest to
 -- youngest.
-getBitsBE x = symbolicF (pieces x Proxy)
+getBitsBE x = symbolicF (arithmetize x Proxy)
     (concatMap (reverse . padBits n . map fromConstant . binaryExpansion . toConstant))
     (fmap (concatMap reverse) . traverse (expansion n) . toList)
   where n = numberOfBits @(BaseField c)

--- a/symbolic-base/test/Tests/Arithmetization/Test1.hs
+++ b/symbolic-base/test/Tests/Arithmetization/Test1.hs
@@ -30,8 +30,8 @@ testFunc x y =
         g3 = c 2 // x
     in (g3 == y :: Bool c) ? g1 $ g2
 
-testResult :: forall a . Arithmetic a => ArithmeticCircuit a U1 (Par1 :*: Par1 :*: U1) Par1 -> a -> a -> Haskell.Bool
-testResult r x y = fromConstant (unPar1 $ eval r U1 (Par1 x :*: Par1 y :*: U1)) Haskell.==
+testResult :: forall a . Arithmetic a => ArithmeticCircuit a (U1 :*: U1 :*: U1) (Par1 :*: Par1 :*: U1) Par1 -> a -> a -> Haskell.Bool
+testResult r x y = fromConstant (unPar1 $ eval r (U1 :*: U1 :*: U1) (Par1 x :*: Par1 y :*: U1)) Haskell.==
     testFunc @(Interpreter a) (fromConstant x) (fromConstant y)
 
 specArithmetization1 :: forall a . (Arithmetic a, Arbitrary a, Binary a, Show a) => Spec

--- a/symbolic-base/test/Tests/Arithmetization/Test2.hs
+++ b/symbolic-base/test/Tests/Arithmetization/Test2.hs
@@ -26,7 +26,7 @@ tautology x y = (x /= y) || (x == y)
 testTautology :: forall a . (Arithmetic a, Binary a) => a -> a -> Haskell.Bool
 testTautology x y =
     let Bool ac = compile @a tautology
-        b       = unPar1 (eval ac U1 (Par1 x :*: Par1 y :*: U1))
+        b       = unPar1 (eval ac (U1 :*: U1 :*: U1) (Par1 x :*: Par1 y :*: U1))
     in b Haskell.== one
 
 specArithmetization2 :: Spec

--- a/symbolic-base/test/Tests/Arithmetization/Test3.hs
+++ b/symbolic-base/test/Tests/Arithmetization/Test3.hs
@@ -18,7 +18,7 @@ import           ZkFold.Symbolic.Data.FieldElement (FieldElement)
 import           ZkFold.Symbolic.Data.Ord          ((<=))
 import           ZkFold.Symbolic.Interpreter       (Interpreter (Interpreter))
 
-type R = ArithmeticCircuit (Zp 97) U1 (Par1 :*: Par1 :*: U1)
+type R = ArithmeticCircuit (Zp 97) (U1 :*: U1 :*: U1) (Par1 :*: Par1 :*: U1)
 
 -- A comparison test
 testFunc :: Symbolic c => FieldElement c -> FieldElement c -> Bool c
@@ -29,4 +29,4 @@ specArithmetization3 = do
     describe "Arithmetization test 3" $ do
         it "should pass" $ do
             let Bool r = compile @(Zp 97) (testFunc @R) :: Bool R
-            Bool (Interpreter (eval r U1 (Par1 3 :*: Par1 5 :*: U1))) `shouldBe` testFunc (fromConstant (3 :: Natural)) (fromConstant (5 :: Natural))
+            Bool (Interpreter (eval r (U1 :*: U1 :*: U1) (Par1 3 :*: Par1 5 :*: U1))) `shouldBe` testFunc (fromConstant (3 :: Natural)) (fromConstant (5 :: Natural))

--- a/symbolic-base/test/Tests/Arithmetization/Test4.hs
+++ b/symbolic-base/test/Tests/Arithmetization/Test4.hs
@@ -27,14 +27,14 @@ lockedByTxId targetValue inputValue = inputValue == fromConstant targetValue
 
 testSameValue :: F -> Haskell.Bool
 testSameValue targetValue =
-    let Bool ac = compile @F (lockedByTxId @F targetValue) :: Bool (ArithmeticCircuit F U1 (Par1 :*: U1))
-        b       = unPar1 (eval ac U1 (Par1 targetValue :*: U1))
+    let Bool ac = compile @F (lockedByTxId @F targetValue) :: Bool (ArithmeticCircuit F (U1 :*: U1) (Par1 :*: U1))
+        b       = unPar1 (eval ac (U1 :*: U1) (Par1 targetValue :*: U1))
     in b Haskell.== one
 
 testDifferentValue :: F -> F -> Haskell.Bool
 testDifferentValue targetValue otherValue =
-    let Bool ac = compile @F (lockedByTxId @F targetValue) :: Bool (ArithmeticCircuit F U1 (Par1 :*: U1))
-        b       = unPar1 (eval ac U1 (Par1 otherValue :*: U1))
+    let Bool ac = compile @F (lockedByTxId @F targetValue) :: Bool (ArithmeticCircuit F (U1 :*: U1) (Par1 :*: U1))
+        b       = unPar1 (eval ac (U1 :*: U1) (Par1 otherValue :*: U1))
     in b Haskell.== zero
 
 specArithmetization4 :: Spec

--- a/symbolic-base/test/Tests/Blake2b.hs
+++ b/symbolic-base/test/Tests/Blake2b.hs
@@ -19,7 +19,7 @@ import           ZkFold.Symbolic.Algorithms.Hash.Blake2b
 import           ZkFold.Symbolic.Class                       (Symbolic)
 import           ZkFold.Symbolic.Compiler
 import           ZkFold.Symbolic.Data.ByteString             (ByteString)
-import           ZkFold.Symbolic.Data.Class                  (pieces)
+import           ZkFold.Symbolic.Data.Class                  (arithmetize)
 import           ZkFold.Symbolic.Interpreter                 (Interpreter)
 
 -- TODO: We need a proper test for both numeric and symbolic blake2b hashing
@@ -34,7 +34,7 @@ blake2bSimple =
 blake2bAC :: Spec
 blake2bAC =
     let cs = compile blake2b_512 :: ByteString 512 (ArithmeticCircuit (Zp BLS12_381_Scalar) U1 (Vector 8 :*: U1))
-        ac = pieces cs Proxy
+        ac = arithmetize cs Proxy
     in it "simple test with cardano-crypto " $ acSizeN ac == 564239
 
 specBlake2b :: IO ()

--- a/symbolic-base/test/Tests/Blake2b.hs
+++ b/symbolic-base/test/Tests/Blake2b.hs
@@ -33,7 +33,7 @@ blake2bSimple =
 
 blake2bAC :: Spec
 blake2bAC =
-    let cs = compile blake2b_512 :: ByteString 512 (ArithmeticCircuit (Zp BLS12_381_Scalar) U1 (Vector 8 :*: U1))
+    let cs = compile blake2b_512 :: ByteString 512 (ArithmeticCircuit (Zp BLS12_381_Scalar) (U1 :*: U1) (Vector 8 :*: U1))
         ac = arithmetize cs Proxy
     in it "simple test with cardano-crypto " $ acSizeN ac == 564239
 

--- a/symbolic-base/test/Tests/Compiler.hs
+++ b/symbolic-base/test/Tests/Compiler.hs
@@ -20,7 +20,7 @@ import           Text.Show                                   (Show)
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
 import           ZkFold.Symbolic.Class                       (Arithmetic, Symbolic)
-import           ZkFold.Symbolic.Compiler                    (compileWith, guessOutput, isConstantInput, payloadCircuit)
+import           ZkFold.Symbolic.Compiler                    (compileWith, guessOutput, isConstantInput)
 import           ZkFold.Symbolic.Data.Bool                   ((&&))
 import           ZkFold.Symbolic.Data.ByteString             (ByteString)
 
@@ -36,7 +36,8 @@ instance Arbitrary (U1 a) where
 specCompilerG :: forall a. (Arbitrary a, Arithmetic a, Binary a, Show a) => IO ()
 specCompilerG = hspec $ describe "Compiler specification" $ do
   prop "Guessing with payload is constant in input" $ isConstantInput $
-    compileWith (guessOutput @a @_ @U1) payloadCircuit (U1 :*: U1 :*: U1) testFunction
+    compileWith @a guessOutput
+      (\(p :*: q) U1 -> (U1 :*: U1 :*: U1, p :*: q :*: U1)) testFunction
 
 specCompiler :: IO ()
 specCompiler = specCompilerG @(Zp BLS12_381_Scalar)

--- a/symbolic-base/test/Tests/Compiler.hs
+++ b/symbolic-base/test/Tests/Compiler.hs
@@ -36,7 +36,7 @@ instance Arbitrary (U1 a) where
 specCompilerG :: forall a. (Arbitrary a, Arithmetic a, Binary a, Show a) => IO ()
 specCompilerG = hspec $ describe "Compiler specification" $ do
   prop "Guessing with payload is constant in input" $ isConstantInput $
-    compileWith (guessOutput @a @_ @U1) payloadCircuit testFunction
+    compileWith (guessOutput @a @_ @U1) payloadCircuit (U1 :*: U1 :*: U1) testFunction
 
 specCompiler :: IO ()
 specCompiler = specCompilerG @(Zp BLS12_381_Scalar)

--- a/symbolic-base/test/Tests/Protostar.hs
+++ b/symbolic-base/test/Tests/Protostar.hs
@@ -1,5 +1,6 @@
 module Tests.Protostar (specProtostar) where
 
+import           Data.Functor.Rep                                 (tabulate)
 import           GHC.Generics                                     (Par1 (..), U1 (..), type (:*:) (..), type (:.:) (..))
 import           GHC.IsList                                       (IsList (..))
 import           Prelude                                          hiding (Num (..), replicate, sum, (+))
@@ -23,7 +24,8 @@ import           ZkFold.Base.Protocol.Protostar.NARK              (InstanceProof
                                                                    instanceProof)
 import           ZkFold.Prelude                                   (replicate)
 import           ZkFold.Symbolic.Class                            (Symbolic)
-import           ZkFold.Symbolic.Compiler                         (ArithmeticCircuit, acSizeM, acSizeN, compile, hlmap)
+import           ZkFold.Symbolic.Compiler                         (ArithmeticCircuit, acSizeM, acSizeN, compile, hlmap,
+                                                                   hpmap)
 import           ZkFold.Symbolic.Data.FieldElement                (FieldElement (..))
 
 type F = Zp BLS12_381_Scalar
@@ -44,6 +46,7 @@ testFunction p x =
 testCircuit :: PAR -> AC
 testCircuit p =
     hlmap (\x -> Comp1 (Par1 <$> x) :*: U1)
+    $ hpmap (\_ -> Comp1 (tabulate $ const U1) :*: U1)
     $ hmap (\(Comp1 x') -> unPar1 <$> x')
     $ compile @F $ testFunction p
 

--- a/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Address.hs
+++ b/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Address.hs
@@ -3,6 +3,7 @@
 
 module ZkFold.Symbolic.Cardano.Types.Address where
 
+import           GHC.Generics                        (Generic)
 import           Prelude                             hiding (Bool, Eq, length, splitAt, (*), (+))
 import qualified Prelude                             as Haskell
 
@@ -23,20 +24,14 @@ data Address context = Address {
         paymentCredential :: PaymentCredential context,
         stakingCredential :: StakingCredential context
     }
+    deriving (Generic)
 
 deriving instance (Haskell.Eq (ByteString 4 context), Haskell.Eq (ByteString 224 context))
     => Haskell.Eq (Address context)
 
-
 deriving via (Structural (Address context))
          instance (Symbolic context) => Eq (Bool context) (Address context)
 
-instance HApplicative context => SymbolicData (Address context) where
-  type Context (Address context) = Context (AddressType context, PaymentCredential context, StakingCredential context)
-  type Support (Address context) = Support (AddressType context, PaymentCredential context, StakingCredential context)
-  type Layout (Address context) = Layout (AddressType context, PaymentCredential context, StakingCredential context)
-  pieces (Address a b c) = pieces (a, b, c)
-  restore f = let (a, b, c) = restore f in Address a b c
-
-instance (Symbolic context) => SymbolicInput (Address context)  where
+instance HApplicative context => SymbolicData (Address context)
+instance Symbolic context => SymbolicInput (Address context) where
     isValid (Address a p s) = isValid (a, p, s)

--- a/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Input.hs
+++ b/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Input.hs
@@ -4,6 +4,7 @@
 
 module ZkFold.Symbolic.Cardano.Types.Input where
 
+import           GHC.Generics                            (Generic)
 import           Prelude                                 hiding (Bool, Eq, length, splitAt, (*), (+))
 import qualified Prelude                                 as Haskell
 
@@ -21,20 +22,14 @@ data Input tokens datum context = Input  {
         txiOutputRef :: OutputRef context,
         txiOutput    :: Output tokens datum context
     }
+    deriving (Generic)
 
 deriving instance
     ( Haskell.Eq (OutputRef context)
     , Haskell.Eq (Output tokens datum context)
     ) => Haskell.Eq (Input tokens datum context)
 
-instance (Symbolic context, KnownNat tokens) => SymbolicData (Input tokens datum context) where
-  type Context (Input tokens datum context) = Context (OutputRef context, Output tokens datum context)
-  type Support (Input tokens datum context) = Support (OutputRef context, Output tokens datum context)
-  type Layout (Input tokens datum context) = Layout (OutputRef context, Output tokens datum context)
-
-  pieces (Input a b) = pieces (a, b)
-  restore f = let (a, b) = restore f in Input a b
-
+instance (Symbolic context, KnownNat tokens) => SymbolicData (Input tokens datum context)
 instance
   ( Symbolic context
   , KnownNat tokens

--- a/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/OutputRef.hs
+++ b/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/OutputRef.hs
@@ -4,6 +4,7 @@
 
 module ZkFold.Symbolic.Cardano.Types.OutputRef where
 
+import           GHC.Generics                        (Generic)
 import           GHC.TypeNats                        (KnownNat)
 import           Prelude                             hiding (Bool, Eq, length, splitAt, (*), (+))
 import qualified Prelude                             as Haskell
@@ -22,20 +23,14 @@ data OutputRef context = OutputRef {
         outputRefId    :: TxRefId context,
         outputRefIndex :: TxRefIndex context
     }
+    deriving (Generic)
 
 deriving instance
     ( Haskell.Eq (TxRefId context)
     , Haskell.Eq (TxRefIndex context)
     ) => Haskell.Eq (OutputRef context)
 
-instance HApplicative context => SymbolicData (OutputRef context) where
-  type Context (OutputRef context) = Context (TxRefId context, TxRefIndex context)
-  type Support (OutputRef context) = Support (TxRefId context, TxRefIndex context)
-  type Layout (OutputRef context) = Layout (TxRefId context, TxRefIndex context)
-
-  pieces (OutputRef a b) = pieces (a, b)
-  restore f = let (a, b) = restore f in OutputRef a b
-
+instance HApplicative context => SymbolicData (OutputRef context)
 instance
     ( HApplicative context
     , Symbolic context

--- a/symbolic-examples/bench/BenchCompiler.hs
+++ b/symbolic-examples/bench/BenchCompiler.hs
@@ -24,7 +24,6 @@ metrics name circuit =
   <> "\nNumber of variables: " <> fromString (show $ acSizeM circuit)
   <> "\nNumber of range lookups: " <> fromString (show $ acSizeR circuit)
 
-
 benchmark ::
   ( Arithmetic a, NFData (o (Var a i)), NFData (Rep i)
   , Representable p, Representable i) =>

--- a/zkfold-ledger/src/ZkFold/Symbolic/Ledger/Types.hs
+++ b/zkfold-ledger/src/ZkFold/Symbolic/Ledger/Types.hs
@@ -82,6 +82,7 @@ type Signature context =
     , Support (List context (TransactionId context)) ~ Proxy context
     , Applicative (Layout (List context (TransactionId context)))
     , Traversable (Layout (List context (TransactionId context)))
+    , Representable (Layout (List context (TransactionId context)))
     , SymbolicData (List context (TransactionId context))
     , Zip (Layout (List context (TransactionId context)))
 
@@ -90,6 +91,7 @@ type Signature context =
     , SymbolicData (Input context)
     , Applicative (Layout (Input context))
     , Traversable (Layout (Input context))
+    , Representable (Layout (Input context))
     , Zip (Layout (Input context))
 
     , Context (Hash context) ~ context
@@ -97,6 +99,7 @@ type Signature context =
     , SymbolicData (Hash context)
     , Applicative (Layout (Hash context))
     , Traversable (Layout (Hash context))
+    , Representable (Layout (Hash context))
     , Zip (Layout (Hash context))
 
     , Context (Update context) ~ context
@@ -106,4 +109,5 @@ type Signature context =
     , Traversable (Layout (Update context))
     , Representable (Layout (Update context)) -- TODO: Remove after implementing @instance SymbolicData List@
     , SymbolicData (Update context)           -- TODO: Remove after implementing @instance SymbolicData List@
+    , Representable (Payload (Update context))
     )

--- a/zkfold-uplc/src/ZkFold/Symbolic/UPLC/Converter.hs
+++ b/zkfold-uplc/src/ZkFold/Symbolic/UPLC/Converter.hs
@@ -3,7 +3,7 @@
 module ZkFold.Symbolic.UPLC.Converter where
 
 import           Data.Function                               (($))
-import           GHC.Generics                                (Par1, U1)
+import           GHC.Generics                                (Par1)
 
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
@@ -27,7 +27,7 @@ data ScriptType
 -- 1. with arbitrary input;
 -- 2. with a single success/fail output;
 -- 3. over BLS base field.
-data SomeCircuit = forall i. SomeCircuit (ArithmeticCircuit (Zp BLS12_381_Scalar) U1 i Par1)
+data SomeCircuit = forall p i. SomeCircuit (ArithmeticCircuit (Zp BLS12_381_Scalar) p i Par1)
 
 -- | Converter itself.
 convert ::

--- a/zkfold-uplc/src/ZkFold/Symbolic/UPLC/Evaluation.hs
+++ b/zkfold-uplc/src/ZkFold/Symbolic/UPLC/Evaluation.hs
@@ -52,6 +52,7 @@ class
     -- TODO: Remove after Conditional becomes part of SymbolicData
     , Representable (Layout v)
     , Traversable (Layout v)
+    , Representable (Payload v)
     ) => IsData (t :: BuiltinType) v c | t c -> v, v -> t, v -> c where
   asPair :: v -> Maybe (ExValue c, ExValue c)
 


### PR DESCRIPTION
This PR resolves #375 by adding `Payload` type family to `SymbolicData` class. Consequently, this changes the interface a bit and some code around circuits/symbolic datatypes, so I invited everyone to take a look.