### PR TITLE
Rewrite FFA

### DIFF
--- a/symbolic-base/bench/BenchEC.hs
+++ b/symbolic-base/bench/BenchEC.hs
@@ -31,18 +31,18 @@ benchOps desc p0 op = env (fromIntegral <$> randomRIO (1 :: Integer, 3)) $ \ ~n 
 
 main :: IO ()
 main = do
-  let a = fromConstant @Natural 0 :: FFA Ed25519_Scalar A
---  let b = fromConstant @Natural 1 :: FFA Ed25519_Scalar A
+  let a = fromConstant @Natural 0 :: FFAOld Ed25519_Scalar A
+--  let b = fromConstant @Natural 1 :: FFAOld Ed25519_Scalar A
   print a
-  let (FFA ap) = (a ^ (100000 :: Natural))
---  let (FFA ap) = (scale (100000 :: Natural) a)
+  let (FFAOld ap) = (a ^ (100000 :: Natural))
+--  let (FFAOld ap) = (scale (100000 :: Natural) a)
   print $ exec ap
   print a
 --  print $ a // a
 --  print $ b // a
 --  defaultMain
 --      [ bgroup "EC operations"
---        [ benchOps "FFA Interpreter" (gen :: PtFFA I) scale
---        , benchOps "FFA Circuit" (gen :: PtFFA A) scale
+--        [ benchOps "FFAOld Interpreter" (gen :: PtFFA I) scale
+--        , benchOps "FFAOld Circuit" (gen :: PtFFA A) scale
 --        ]
 --      ]

--- a/symbolic-base/src/ZkFold/Base/Algebra/Basic/DFT.hs
+++ b/symbolic-base/src/ZkFold/Base/Algebra/Basic/DFT.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Use even" #-}
 module ZkFold.Base.Algebra.Basic.DFT (genericDft) where
 
 import           Control.Monad                   (forM_)

--- a/symbolic-base/src/ZkFold/Symbolic/Algorithms/Hash/Blake2b.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Algorithms/Hash/Blake2b.hs
@@ -30,7 +30,7 @@ import           ZkFold.Symbolic.Data.Bool                         (BoolType (..
 import           ZkFold.Symbolic.Data.ByteString                   (ByteString (..), Resize (..), ShiftBits (..),
                                                                     concat, reverseEndianness, toWords)
 import           ZkFold.Symbolic.Data.Combinators                  (Iso (..), RegisterSize (..))
-import           ZkFold.Symbolic.Data.UInt                         (UInt (..))
+import           ZkFold.Symbolic.Data.UInt                         (UInt)
 
 
 -- TODO: This module is not finished yet. The hash computation is not correct.

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Ed25519.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Ed25519.hs
@@ -34,7 +34,7 @@ instance
     , NFData (c (V.Vector Size))
     ) => EllipticCurve (AcEd25519 c)  where
 
-    type BaseField (AcEd25519 c) = FFA Ed25519_Base c
+    type BaseField (AcEd25519 c) = FFAOld Ed25519_Base c
     type ScalarField (AcEd25519 c) = FieldElement c
     type BooleanOf (AcEd25519 c) = Bool c
 
@@ -68,10 +68,10 @@ instance
             upper :: Natural
             upper = value @bits -! 1
 
-a :: Symbolic ctx => FFA Ed25519_Base ctx
+a :: Symbolic ctx => FFAOld Ed25519_Base ctx
 a = fromConstant @P.Integer (-1)
 
-d :: Symbolic ctx => FFA Ed25519_Base ctx
+d :: Symbolic ctx => FFAOld Ed25519_Base ctx
 d = fromConstant @P.Integer (-121665) // fromConstant @Natural 121666
 
 acAdd25519

--- a/symbolic-base/src/ZkFold/Symbolic/Data/FFA.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/FFA.hs
@@ -1,31 +1,34 @@
-{-# LANGUAGE AllowAmbiguousTypes  #-}
-{-# LANGUAGE DerivingStrategies   #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE AllowAmbiguousTypes      #-}
+{-# LANGUAGE DerivingStrategies       #-}
+{-# LANGUAGE KindSignatures           #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE UndecidableInstances     #-}
 
-module ZkFold.Symbolic.Data.FFA0 where
-  -- (FFA0 (..), Size, coprimesDownFrom, coprimes)
+module ZkFold.Symbolic.Data.FFA where
+  -- (FFAOld (..), Size, coprimesDownFrom, coprimes)
 
 import           Control.Applicative              (pure)
 import           Control.DeepSeq                  (NFData, force)
 import           Control.Monad                    (Monad, forM, return, (>>=))
-import           Data.Foldable                    (any, foldlM)
+import           Data.Bits                        (Bits (..))
+import           Data.Foldable                    (any, foldlM, for_)
+import qualified Data.Foldable                    as F
 import           Data.Function                    (const, ($), (.))
 import           Data.Functor                     (fmap, (<$>))
-import           Data.List                        (dropWhile, (++))
+import           Data.List                        (dropWhile, mapAccumL, (++))
 import           Data.Ratio                       ((%))
+import           Data.Semialign
 import           Data.Traversable                 (for, traverse)
 import           Data.Tuple                       (fst, snd, uncurry)
-import           Data.Zip                         (zipWith)
-import           Prelude                          (Integer, error, undefined, Int)
-import qualified Prelude                          as Haskell
-
-import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.Basic.Field  (Zp, inv)
-import qualified ZkFold.Base.Algebra.Basic.Field  as PrimeField
 import qualified Data.Vector                      as V
-import qualified Data.Foldable                    as F
+import           Data.Zip                         (zipWith)
+import           Prelude                          (Int, Integer, error, undefined)
+import qualified Prelude                          as Haskell
+import qualified Prelude                          as P
+
+import           ZkFold.Base.Algebra.Basic.Class  hiding (invert)
+import qualified ZkFold.Base.Algebra.Basic.Field  as PrimeField
+import           ZkFold.Base.Algebra.Basic.Field  (Zp, inv)
 import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Base.Data.Utils           (zipWithM)
 import           ZkFold.Base.Data.Vector
@@ -40,17 +43,17 @@ import           ZkFold.Symbolic.Data.Input
 import           ZkFold.Symbolic.Data.Ord         (blueprintGE)
 import           ZkFold.Symbolic.Interpreter
 import           ZkFold.Symbolic.MonadCircuit     (MonadCircuit, newAssigned)
-import Data.Bits (Bits(..))
-import qualified Prelude as P
+import qualified Data.Vector.Mutable as Mutable
+import Control.Monad.State
 
 type Size = 7
 
 -- | Foreign-field arithmetic based on https://cr.yp.to/papers/mmecrt.pdf
-newtype FFA0 (p :: Natural) c = FFA0 (c (Vector Size))
+newtype FFAOld (p :: Natural) c = FFAOld (c (Vector Size))
 
-deriving newtype instance Symbolic c => SymbolicData (FFA0 p c)
-deriving newtype instance NFData (c (Vector Size)) => NFData (FFA0 p c)
-deriving newtype instance Haskell.Show (c (Vector Size)) => Haskell.Show (FFA0 p c)
+deriving newtype instance Symbolic c => SymbolicData (FFAOld p c)
+deriving newtype instance NFData (c (Vector Size)) => NFData (FFAOld p c)
+deriving newtype instance Haskell.Show (c (Vector Size)) => Haskell.Show (FFAOld p c)
 
 coprimesDownFrom :: KnownNat n => Natural -> Vector n Natural
 coprimesDownFrom n = unfold (uncurry step) ([], [n,n-!1..0])
@@ -105,7 +108,7 @@ toZp = fromConstant . impl
        in vectorDotProduct gs (mis @a @p) -! mprod @a @p * residue
 
 fromZp :: forall p a. Arithmetic a => Zp p -> Vector Size a
-fromZp = (\(FFA0 (Interpreter xs) :: FFA0 p (Interpreter a)) -> xs) . fromConstant
+fromZp = (\(FFAOld (Interpreter xs) :: FFAOld p (Interpreter a)) -> xs) . fromConstant
 
 -- | Subtracts @m@ from @i@ if @i@ is not less than @m@
 --
@@ -156,8 +159,8 @@ cast xs = do
     newAssigned (($ dot) + fromConstant (m -! (mprod @a @p `mod` m)) * ($ residue))
         >>= bigSub m
 
-mul :: forall p i a w m. (KnownNat p, Arithmetic a, NFData i, MonadCircuit i a w m) => Vector Size i -> Vector Size i -> m (Vector Size i)
-mul xs ys = Haskell.fmap force $ zipWithM (\i j -> newAssigned (\w -> w i * w j)) xs ys >>= bigCut >>= cast @p
+mul0 :: forall p i a w m. (KnownNat p, Arithmetic a, NFData i, MonadCircuit i a w m) => Vector Size i -> Vector Size i -> m (Vector Size i)
+mul0 xs ys = Haskell.fmap force $ zipWithM (\i j -> newAssigned (\w -> w i * w j)) xs ys >>= bigCut >>= cast @p
 
 natPowM :: Monad m => (a -> a -> m a) -> m a -> Natural -> a -> m a
 natPowM _ z 0 _ = z
@@ -169,70 +172,70 @@ natPowM f z n x
 oneM :: MonadCircuit i a w m => m (Vector Size i)
 oneM = pure <$> newAssigned (const one)
 
-instance (KnownNat p, Arithmetic a) => ToConstant (FFA0 p (Interpreter a)) where
-  type Const (FFA0 p (Interpreter a)) = Zp p
-  toConstant (FFA0 (Interpreter rs)) = toZp rs
+instance (KnownNat p, Arithmetic a) => ToConstant (FFAOld p (Interpreter a)) where
+  type Const (FFAOld p (Interpreter a)) = Zp p
+  toConstant (FFAOld (Interpreter rs)) = toZp rs
 
-instance (FromConstant a (Zp p), Symbolic c) => FromConstant a (FFA0 p c) where
-  fromConstant = FFA0 . embed . impl . toConstant . (fromConstant :: a -> Zp p)
+instance (FromConstant a (Zp p), Symbolic c) => FromConstant a (FFAOld p c) where
+  fromConstant = FFAOld . embed . impl . toConstant . (fromConstant :: a -> Zp p)
     where
       impl :: Natural -> Vector Size (BaseField c)
       impl x = fromConstant . (x `mod`) <$> coprimes @(BaseField c)
 
-instance {-# OVERLAPPING #-} FromConstant (FFA0 p c) (FFA0 p c)
+instance {-# OVERLAPPING #-} FromConstant (FFAOld p c) (FFAOld p c)
 
-instance {-# OVERLAPPING #-} (KnownNat p, Symbolic c) => Scale (FFA0 p c) (FFA0 p c)
+instance {-# OVERLAPPING #-} (KnownNat p, Symbolic c) => Scale (FFAOld p c) (FFAOld p c)
 
-instance (KnownNat p, Symbolic c) => MultiplicativeSemigroup (FFA0 p c) where
-  FFA0 x * FFA0 y =
-    FFA0 $ symbolic2F x y (\u v -> fromZp (toZp u * toZp v :: Zp p)) (mul @p)
+instance (KnownNat p, Symbolic c) => MultiplicativeSemigroup (FFAOld p c) where
+  FFAOld x * FFAOld y =
+    FFAOld $ symbolic2F x y (\u v -> fromZp (toZp u * toZp v :: Zp p)) (mul0 @p)
 
-instance (KnownNat p, Symbolic c) => Exponent (FFA0 p c) Natural where
-  FFA0 x ^ a =
-    FFA0 $ symbolicF x (\v -> fromZp (toZp v ^ a :: Zp p)) $ natPowM (mul @p) oneM a
+instance (KnownNat p, Symbolic c) => Exponent (FFAOld p c) Natural where
+  FFAOld x ^ a =
+    FFAOld $ symbolicF x (\v -> fromZp (toZp v ^ a :: Zp p)) $ natPowM (mul0 @p) oneM a
 
-instance (KnownNat p, Symbolic c) => MultiplicativeMonoid (FFA0 p c) where
+instance (KnownNat p, Symbolic c) => MultiplicativeMonoid (FFAOld p c) where
   one = fromConstant (one :: Zp p)
 
-instance (KnownNat p, Symbolic c) => AdditiveSemigroup (FFA0 p c) where
-  FFA0 x + FFA0 y =
-    FFA0 $ symbolic2F x y (\u v -> fromZp (toZp u + toZp v :: Zp p)) $ \xs ys ->
+instance (KnownNat p, Symbolic c) => AdditiveSemigroup (FFAOld p c) where
+  FFAOld x + FFAOld y =
+    FFAOld $ symbolic2F x y (\u v -> fromZp (toZp u + toZp v :: Zp p)) $ \xs ys ->
       zipWithM (\i j -> newAssigned (\w -> w i + w j)) xs ys >>= smallCut >>= cast @p
 
-instance (KnownNat p, Scale a (Zp p), Symbolic c) => Scale a (FFA0 p c) where
+instance (KnownNat p, Scale a (Zp p), Symbolic c) => Scale a (FFAOld p c) where
   scale k x = fromConstant (scale k one :: Zp p) * x
 
-instance (KnownNat p, Symbolic c) => AdditiveMonoid (FFA0 p c) where
+instance (KnownNat p, Symbolic c) => AdditiveMonoid (FFAOld p c) where
   zero = fromConstant (zero :: Zp p)
 
-instance (KnownNat p, Symbolic c) => AdditiveGroup (FFA0 p c) where
-  negate (FFA0 x) = FFA0 $ symbolicF x (fromZp . negate . toZp @p) $ \xs -> do
+instance (KnownNat p, Symbolic c) => AdditiveGroup (FFAOld p c) where
+  negate (FFAOld x) = FFAOld $ symbolicF x (fromZp . negate . toZp @p) $ \xs -> do
     let cs = coprimes @(BaseField c)
     ys <- zipWithM (\i m -> newAssigned $ fromConstant m - ($ i)) xs cs
     cast @p ys
 
-instance (KnownNat p, Symbolic c) => Semiring (FFA0 p c)
+instance (KnownNat p, Symbolic c) => Semiring (FFAOld p c)
 
-instance (KnownNat p, Symbolic c) => Ring (FFA0 p c)
+instance (KnownNat p, Symbolic c) => Ring (FFAOld p c)
 
-instance (Prime p, Symbolic c) => Exponent (FFA0 p c) Integer where
+instance (Prime p, Symbolic c) => Exponent (FFAOld p c) Integer where
   x ^ a = x `intPowF` (a `mod` fromConstant (value @p -! 1))
 
-instance (Prime p, Symbolic c) => Field (FFA0 p c) where
-  finv (FFA0 x) =
-    FFA0 $ symbolicF x (fromZp . finv @(Zp p) . toZp)
-      $ natPowM (mul @p) oneM (value @p -! 2)
+instance (Prime p, Symbolic c) => Field (FFAOld p c) where
+  finv (FFAOld x) =
+    FFAOld $ symbolicF x (fromZp . finv @(Zp p) . toZp)
+      $ natPowM (mul0 @p) oneM (value @p -! 2)
 
-instance Finite (Zp p) => Finite (FFA0 p b) where
-  type Order (FFA0 p b) = p
+instance Finite (Zp p) => Finite (FFAOld p b) where
+  type Order (FFAOld p b) = p
 
 -- FIXME: This Eq instance is wrong
-deriving newtype instance Symbolic c => Eq (Bool c) (FFA0 p c)
+deriving newtype instance Symbolic c => Eq (Bool c) (FFAOld p c)
 
-deriving newtype instance Symbolic c => Conditional (Bool c) (FFA0 p c)
+deriving newtype instance Symbolic c => Conditional (Bool c) (FFAOld p c)
 
 -- | TODO: fix when rewrite is done
-instance (Symbolic c) => SymbolicInput (FFA0 p c) where
+instance (Symbolic c) => SymbolicInput (FFAOld p c) where
   isValid _ = true
 
 
@@ -271,85 +274,75 @@ residue = (`Haskell.mod` fromIntegral (value @p))
 toZp :: forall p . KnownNat p => Integer -> Zp p
 toZp = Zp . residue @p
 
-Natural -> Vector Size (BaseField c) -> c (Vector Size) -> FFA0 p c
+Natural -> Vector Size (BaseField c) -> c (Vector Size) -> FFAOld p c
 
 Par1 Fr ~ i (ScalarField c1)
 
 PlonkupRelation p i n l (ScalarField c1)
 
 -}
-{-
-Residue Numeral System
-Representation of an integer holding its values modulo several coprime integers.
-
-Contains all the necessary values to carry out operations such as
-multiplication and reduction in this representation.
-
-Representation of an integer.
-
-The integer is represented as a vector of [`Limb`]s with values in the
-native field plus a reference to the [`FFALimb`] used.
--}
---------------------------------- General FFA0 ----------------------------------
+--------------------------------- General FFALimbs ----------------------------------
 
 type LimbsMaxSize = 256
 type LimbMaxBits = 68
 
+-- Reduction witness contains all values that needs to be assigned in
+-- multiplication gate.
+data ReductionWitness (w :: Natural) (n :: Natural) (nlimbs :: Natural) (bits :: Natural) = ReductionWitness
+    { result       :: FFA w n nlimbs bits
+    , quotient     :: Quotient w n nlimbs bits
+    , intermediate :: Vector nlimbs (Zp n)
+    , residuesW    :: V.Vector (Zp n)
+    }
 
-{-
-a * b = r mod p
+-- Quotient term in [`ReductionWitness`].
+--
+-- There are two possible representations:
+-- Short: as an element of the native field.
+-- Long : as an [`FFA`].
+data Quotient (w :: Natural) (n :: Natural) (nlimbs :: Natural) (bits :: Natural) =
+      Short (Zp n)
+    | Long (FFA w n nlimbs bits)
 
-a_n -> nlimbs
-bits_length(r) ~ bits
-
-`t = BIT_LEN_LIMB * NUMBER_OF_LIMBS`
-`T = 2 ^ t` which we also name as `binary_modulus`
--}
-
-{-
-  -- Actual limbs FFA0 representation.
-  { limbs :: c (Vector nlimbs)
--}
-
-data FFA (w :: Natural) (n :: Natural) (nlimbs :: Natural) (bits :: Natural) = FFA {limbs :: (Vector nlimbs (Zp n)), ffalimb :: FFALimb w n nlimbs bits}
+data FFA (w :: Natural) (n :: Natural) (nlimbs :: Natural) (bits :: Natural) = FFA {limbs :: Vector nlimbs (Zp n), ffalimb :: FFALimb w n nlimbs bits}
 
 -- TODO: refactor the code to be able to use two different curves (native and non-native)
 data FFALimb (w :: Natural) (n :: Natural) (nlimbs :: Natural) (bits :: Natural) = FFALimb
   -- Order of the wrong field W. (In the article `p`).
-  { wrong_modulus  :: Natural
+  { wrong_modulus                          :: Natural
   -- Order of the native field N. (In the article `n`).
-  , native_modulus :: Natural
+  , native_modulus                         :: Natural
   -- In the article: 2^t
-  , binary_modulus :: Natural
+  , binary_modulus                         :: Natural
   -- In the article notation: M = n * 2^t
-  , crt_modulus    :: Natural
+  , crt_modulus                            :: Natural
 
   -- Native field elements representing `2^(i*-r)` with `bits_length(r) = bits`.
-  , right_shifters :: Vector nlimbs (Zp n)
+  , right_shifters                         :: Vector nlimbs (Zp n)
   -- Native field elements representing `2^(i*r)` with `bits_length(r) = bits`.
-  , left_shifters  :: Vector nlimbs (Zp n)
+  , left_shifters                          :: Vector nlimbs (Zp n)
   -- The value `base_aux` is a vector of auxiliary limbs representing the value `2p` with `p` the size of the wrong modulus.
-  , base_aux       :: Vector nlimbs Natural
+  , base_aux                               :: Vector nlimbs Natural
 
   -- Negative wrong modulus: `-p mod 2^t` as vector of limbs.
-  , negative_wrong_modulus_decomposed :: Vector nlimbs (Zp n)
+  , negative_wrong_modulus_decomposed      :: Vector nlimbs (Zp n)
   -- Wrong modulus `p` as vector of limbs.
-  , wrong_modulus_decomposed          :: Vector nlimbs (Zp n)
+  , wrong_modulus_decomposed               :: Vector nlimbs (Zp n)
   -- Wrong modulus -1  `p - 1` as vector of limbs.
-  , wrong_modulus_minus_one           :: Vector nlimbs (Zp n)
+  , wrong_modulus_minus_one                :: Vector nlimbs (Zp n)
   -- Wrong modulus as native field element: `p mod n`.
-  , wrong_modulus_in_native_modulus   :: Zp n
+  , wrong_modulus_in_native_modulus        :: Zp n
 
   -- Maximum value for a reduced limb.
-  , max_reduced_limb   :: Natural
+  , max_reduced_limb                       :: Natural
   -- Maximum value for an unreduced limb.
-  , max_unreduced_limb :: Natural
+  , max_unreduced_limb                     :: Natural
   -- Maximum value of the remainder.
-  , max_remainder      :: Natural
+  , max_remainder                          :: Natural
   -- Maximum value that can be safely multiplied (guaranteeing the result will be reducible).
-  , max_operand        :: Natural
+  , max_operand                            :: Natural
   -- Maximum value of the quotient `q` in a reduction.
-  , max_mul_quotient   :: Natural
+  , max_mul_quotient                       :: Natural
 
   -- Maximum value of most significant limb for `max_reduced_limb`.
   , max_most_significant_reduced_limb      :: Natural
@@ -492,10 +485,10 @@ constructFFALimb = do
       -- Calculate auxillary value for subtraction
       base_aux = calculateBaseAux @nlimbs @bits @w @n
 
-      wrong_modulus_in_native_modulus :: Zp n = PrimeField.toZp $ fromConstant $ wrong_modulus `P.mod` native_modulus
+      wrong_modulus_in_native_modulus :: Zp n = PrimeField.toZp $ fromConstant $ wrong_modulus `mod` native_modulus
 
       -- Calculate shifter elements
-      two     = PrimeField.toZp @n 2 
+      two     = PrimeField.toZp @n 2
       two_inv = finv two
 
       -- Right shifts field element by `u * BIT_LEN_LIMB` bits
@@ -508,58 +501,145 @@ constructFFALimb = do
 
   FFALimb{..}
 
+fromWrong :: forall nlimbs bits w n. (KnownNat nlimbs, KnownNat bits, Prime n) => Zp w -> FFALimb w n nlimbs bits -> FFA w n nlimbs bits
+fromWrong w = fromBig (toConstant w)
+
+fromBig :: forall nlimbs bits w n. (KnownNat nlimbs, KnownNat bits, Prime n) => Natural -> FFALimb w n nlimbs bits -> FFA w n nlimbs bits
+fromBig e = FFA (decomposeBig @nlimbs @bits @n e)
+
+-- Compute the represented value by a vector of values and a bit length.
+--
+-- This function is used to compute the value of an integer
+-- passing as input its limb values and the bit length used.
+-- Returns the sum of all limbs scaled by 2^(bit_len * i)
+compose :: forall nlimbs bits . KnownNat bits => Vector nlimbs Natural -> Natural
+compose limbs = F.foldl (\acc val -> (acc `shiftL` bit_len) + val) 0 (reverse limbs)
+  where
+    bit_len = P.fromIntegral $ value @bits
+
+-- Computes the inverse of the [`Integer`] as an element of the Wrong
+-- field. Returns `None` if the value cannot be inverted.
+invert :: forall nlimbs bits w n. (KnownNat nlimbs, KnownNat bits, Prime w, Prime n) => FFA w n nlimbs bits -> FFA w n nlimbs bits
+invert (FFA limbs ffalimb) = fromWrong @nlimbs @bits @w w ffalimb
+  where w = finv . PrimeField.toZp @w . fromConstant . compose @nlimbs @bits $ fmap toConstant limbs
+
+-- Computes the witness values for squaring operation
+square :: (KnownNat nlimbs, KnownNat bits, Prime n) => FFA w n nlimbs bits -> ReductionWitness w n nlimbs bits
+square a = mul a a
+
+-- Computes the witness values for multiplication operation
+mul :: forall nlimbs bits w n. (KnownNat nlimbs, KnownNat bits, Prime n) => FFA w n nlimbs bits -> FFA w n nlimbs bits -> ReductionWitness w n nlimbs bits
+mul s@(FFA limbs ffalimb) (FFA otherLimbs _) = ReductionWitness result (Long quotient) t residuesW
+  where
+    negative_modulus     = negative_wrong_modulus_decomposed ffalimb
+    self                 = compose @nlimbs @bits $ fmap toConstant limbs
+    other                = compose @nlimbs @bits $ fmap toConstant otherLimbs
+    (quotient', result') = (self * other) `divMod` wrong_modulus ffalimb
+    quotient             = fromBig quotient' ffalimb
+    result               = fromBig result' ffalimb
+    t                    = unsafeToVector $ repeat 0
+    {-
+    for k in 0..NUMBER_OF_LIMBS {
+        for i in 0..=k {
+            let j = k - i;
+            t[i + j] = t[i + j]
+                + self.limb(i).0 * other.limb(j).0
+                + negative_modulus[i] * quotient.limb(j).0;
+        }
+    }
+    -}
+    residuesW = residues s t
+
+-- Returns division witnesses
+div' :: forall nlimbs bits w n. (KnownNat nlimbs, KnownNat bits, Prime w, Prime n) => FFA w n nlimbs bits -> FFA w n nlimbs bits -> ReductionWitness w n nlimbs bits
+div' s@(FFA limbs' ffalimb) o@(FFA otherLimbs _) = ReductionWitness result (Long quotient) intermediate residuesW
+  where
+    modulus              = wrong_modulus ffalimb
+    self                 = compose @nlimbs @bits $ fmap toConstant limbs'
+    other_invert         = compose @nlimbs @bits $ fmap toConstant $ limbs $ invert o
+    result'              = (self * other_invert) `mod` modulus
+    other                = compose @nlimbs @bits $ fmap toConstant otherLimbs
+    negative_modulus     = negative_wrong_modulus_decomposed ffalimb
+    (quotient', reduced) = (other * result') `divMod` modulus
+    -- TODO: unsafe zero div
+    (k0, _must_be_zero)   = (self -! reduced) `divMod` modulus
+    quotient             = fromBig (quotient' -! k0) ffalimb
+    result               = fromBig result' ffalimb
+    intermediate         = Vector $ snd $ runState step (V.replicate (P.fromIntegral $ value @nlimbs) 0)
+    -- create :: (forall s. ST s (MVector s a)) -> Vector a
+
+    step :: State (V.Vector (Zp n)) ()
+    step = undefined {- do
+      for_ [0 .. value @nlimbs] $ \k -> do
+        for_ [0 .. k] $ \i -> do
+          let j = k -! i
+          vec <- get
+          let a = vec V.! P.fromIntegral (i + j)
+          Mutable.write vec (P.fromIntegral $ i + j) a -}
+    {-
+        for k in 0..NUMBER_OF_LIMBS {
+            for i in 0..=k {
+                let j = k - i;
+                intermediate[i + j] = intermediate[i + j]
+                    + result.limb(i).0 * other.limb(j).0
+                    + negative_modulus[i] * quotient.limb(j).0;
+            }
+        }
+    -}
+    residuesW = residues s intermediate
+
+-- Computes the witness values for reduction operation
+reduce :: forall nlimbs bits w n. (KnownNat nlimbs, KnownNat bits, Prime n) => FFA w n nlimbs bits -> ReductionWitness w n nlimbs bits
+reduce (FFA limbs ffalimb) = ReductionWitness result (Short quotient) t residuesW
+  where
+    modulus              = wrong_modulus ffalimb
+    negative_modulus     = negative_wrong_modulus_decomposed ffalimb
+    self                 = compose @nlimbs @bits $ fmap toConstant limbs
+    (quotient', result') = self `divMod` modulus
+    quotient             = PrimeField.toZp @n . fromConstant $ quotient'
+    t                    = (\(a, p) -> a + p * quotient) <$> zip limbs negative_modulus
+    result               = fromBig result' ffalimb
+    residuesW            = residues result t
+
+residues :: forall nlimbs bits w n. (KnownNat nlimbs, Prime n) => FFA w n nlimbs bits -> Vector nlimbs (Zp n) -> V.Vector (Zp n)
+residues (FFA limbs ffalimb) t = snd $ mapAccumL step zero (V.fromList $ repeat 0)
+  where
+    nlimbs       = value @nlimbs
+    u_len        = (nlimbs + 1) `div` 2
+    lsh1         = left_shifters ffalimb !! 1
+    (rsh1, rsh2) = (right_shifters ffalimb !! 1, right_shifters ffalimb !! 2)
+    -- TODO: use chunks
+    step :: Zp n -> Natural -> (Zp n, Zp n)
+    step carry i = (v, v)
+      where
+        j = 2 * i
+        v = if (i == u_len -! 1) && P.odd nlimbs
+            then (t !! j - limbs !! j) * rsh1
+            else let (r_0, r_1) = (limbs !! j, limbs !! (j + 1))
+                     (t_0, t_1) = (t !! j, t !! j + 1)
+                     u = t_0 + (t_1 * lsh1) - r_0 - (lsh1 * r_1) + carry
+                  in u * rsh2
+
+
+-- AssignedLimb is a limb of an non native integer
+data AssignedLimb (n :: Natural) = AssignedLimb
+    { -- witnessValue :: Witness value
+      witnessValue :: Zp n
+      -- max_val :: Maximum value to track overflow and reduction flow
+    , max_val      :: Natural
+    }
+
+data AssignedFFA (w :: Natural) (n :: Natural) (nlimbs :: Natural) (bits :: Natural) = AssignedFFA
+    { -- Limbs of the emulated integer
+      assignedLimbs   :: Vector nlimbs (AssignedLimb n)
+      -- Value in the scalar field
+    , assignedNative  :: Zp n
+      -- Share ffalimb across all `AssignedFFA`s
+    , assignedFfalimb :: FFALimb w n nlimbs bits
+    }
+
 -- toZp / fromZp, ToConstant (type Zp a) / FromConstant a
 
 -- (+), (-), (*), (negate), (^), (finv)
 
 -- cast, isValid
-
-
-
------------------------------------- Setup -------------------------------------
-
--- a, b \in [0, p)
-
--- a * b = r mod p, r \in [0, p)
-
--- a * b = q * p + r, a * b < p^2
-
--- a * b - r = q * p < p^2, q \in [0, p)
-
--- circumventing the computation of a * b or q * p
-
--- (a, b, q, p, r)
-
---------------------------- Native Field Constraint ----------------------------
-
--- a * b = r mod p => a * b = q * p + r
-
--- a * b - q * p - r = 0 mod n, prim n < p
--- min_n
-
--- v_a * n + a_n = a
--- v_b * n + b_n = b
--- v_q * n + q_n = q
--- v_p * n + p_n = p
--- v_r * n + r_n = r
-
--- v_overall * n = a_n * b_n - q_n * p_n - r_n
-
--- (a, b, q, p, r, v_a, v_b, v_q, v_p, v_r, v_overall)
-
----------- Constraint decomposition in modulo 2^𝑇 ring, where 𝑝 < 2^𝑇 ----------
-
--- T \in [4, 254]
-
--- p' = -p mod 2^T => p' = 2^T - p
-
--- a * b - q * p = a * b + q * p' mod 2^T
-
--- B = T/4
-
--- ...
-
---------------------------------------------------------------------------------
-
-
-

--- a/symbolic-base/src/ZkFold/Symbolic/Data/FFA.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/FFA.hs
@@ -10,6 +10,7 @@ module ZkFold.Symbolic.Data.FFA where
 import           Control.Applicative              (pure)
 import           Control.DeepSeq                  (NFData, force)
 import           Control.Monad                    (Monad, forM, return, (>>=))
+import           Control.Monad.State
 import           Data.Bits                        (Bits (..))
 import           Data.Foldable                    (any, foldlM, for_)
 import qualified Data.Foldable                    as F
@@ -21,6 +22,7 @@ import           Data.Semialign
 import           Data.Traversable                 (for, traverse)
 import           Data.Tuple                       (fst, snd, uncurry)
 import qualified Data.Vector                      as V
+import qualified Data.Vector.Mutable              as Mutable
 import           Data.Zip                         (zipWith)
 import           Prelude                          (Int, Integer, error, undefined)
 import qualified Prelude                          as Haskell
@@ -43,8 +45,6 @@ import           ZkFold.Symbolic.Data.Input
 import           ZkFold.Symbolic.Data.Ord         (blueprintGE)
 import           ZkFold.Symbolic.Interpreter
 import           ZkFold.Symbolic.MonadCircuit     (MonadCircuit, newAssigned)
-import qualified Data.Vector.Mutable as Mutable
-import Control.Monad.State
 
 type Size = 7
 

--- a/symbolic-base/src/ZkFold/Symbolic/Data/FFA.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/FFA.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE AllowAmbiguousTypes  #-}
 {-# LANGUAGE DerivingStrategies   #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
 
-module ZkFold.Symbolic.Data.FFA (FFA (..), Size, coprimesDownFrom, coprimes) where
+module ZkFold.Symbolic.Data.FFA0 where
+  -- (FFA0 (..), Size, coprimesDownFrom, coprimes)
 
 import           Control.Applicative              (pure)
 import           Control.DeepSeq                  (NFData, force)
@@ -15,11 +18,14 @@ import           Data.Ratio                       ((%))
 import           Data.Traversable                 (for, traverse)
 import           Data.Tuple                       (fst, snd, uncurry)
 import           Data.Zip                         (zipWith)
-import           Prelude                          (Integer, error)
+import           Prelude                          (Integer, error, undefined, Int)
 import qualified Prelude                          as Haskell
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Field  (Zp, inv)
+import qualified ZkFold.Base.Algebra.Basic.Field  as PrimeField
+import qualified Data.Vector                      as V
+import qualified Data.Foldable                    as F
 import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Base.Data.Utils           (zipWithM)
 import           ZkFold.Base.Data.Vector
@@ -34,15 +40,17 @@ import           ZkFold.Symbolic.Data.Input
 import           ZkFold.Symbolic.Data.Ord         (blueprintGE)
 import           ZkFold.Symbolic.Interpreter
 import           ZkFold.Symbolic.MonadCircuit     (MonadCircuit, newAssigned)
+import Data.Bits (Bits(..))
+import qualified Prelude as P
 
 type Size = 7
 
 -- | Foreign-field arithmetic based on https://cr.yp.to/papers/mmecrt.pdf
-newtype FFA (p :: Natural) c = FFA (c (Vector Size))
+newtype FFA0 (p :: Natural) c = FFA0 (c (Vector Size))
 
-deriving newtype instance Symbolic c => SymbolicData (FFA p c)
-deriving newtype instance NFData (c (Vector Size)) => NFData (FFA p c)
-deriving newtype instance Haskell.Show (c (Vector Size)) => Haskell.Show (FFA p c)
+deriving newtype instance Symbolic c => SymbolicData (FFA0 p c)
+deriving newtype instance NFData (c (Vector Size)) => NFData (FFA0 p c)
+deriving newtype instance Haskell.Show (c (Vector Size)) => Haskell.Show (FFA0 p c)
 
 coprimesDownFrom :: KnownNat n => Natural -> Vector n Natural
 coprimesDownFrom n = unfold (uncurry step) ([], [n,n-!1..0])
@@ -65,7 +73,7 @@ mprod :: forall a p . (Finite a, KnownNat p) => Natural
 mprod = mprod0 @a `mod` value @p
 
 mis0 :: forall a. Finite a => Vector Size Natural
-mis0 = let (c, m) = (coprimes @a, mprod0 @a) in (m `div`) <$> c
+mis0 = let m = mprod0 @a in (m `div`) <$> (coprimes @a)
 
 mis :: forall a p. (Finite a, KnownNat p) => Vector Size Natural
 mis = (`mod` value @p) <$> mis0 @a
@@ -77,13 +85,19 @@ wordExpansion :: forall r. KnownNat r => Natural -> [Natural]
 wordExpansion 0 = []
 wordExpansion x = (x `mod` wordSize) : wordExpansion @r (x `div` wordSize)
     where
+        wordSize :: Natural
         wordSize = 2 ^ value @r
 
 toZp :: forall p a. (Arithmetic a, KnownNat p) => Vector Size a -> Zp p
 toZp = fromConstant . impl
   where
+    mods :: Vector Size Natural
     mods = coprimes @a
+
+    binary :: Natural -> Natural -> Integer
     binary g m = (fromConstant g * 2 ^ sigma) `div` fromConstant m
+
+    impl :: Vector Size a -> Natural
     impl xs =
       let gs0 = zipWith (\x y -> toConstant x * y) xs $ minv @a
           gs = zipWith mod gs0 mods
@@ -91,7 +105,7 @@ toZp = fromConstant . impl
        in vectorDotProduct gs (mis @a @p) -! mprod @a @p * residue
 
 fromZp :: forall p a. Arithmetic a => Zp p -> Vector Size a
-fromZp = (\(FFA (Interpreter xs) :: FFA p (Interpreter a)) -> xs) . fromConstant
+fromZp = (\(FFA0 (Interpreter xs) :: FFA0 p (Interpreter a)) -> xs) . fromConstant
 
 -- | Subtracts @m@ from @i@ if @i@ is not less than @m@
 --
@@ -155,68 +169,397 @@ natPowM f z n x
 oneM :: MonadCircuit i a w m => m (Vector Size i)
 oneM = pure <$> newAssigned (const one)
 
-instance (KnownNat p, Arithmetic a) => ToConstant (FFA p (Interpreter a)) where
-  type Const (FFA p (Interpreter a)) = Zp p
-  toConstant (FFA (Interpreter rs)) = toZp rs
+instance (KnownNat p, Arithmetic a) => ToConstant (FFA0 p (Interpreter a)) where
+  type Const (FFA0 p (Interpreter a)) = Zp p
+  toConstant (FFA0 (Interpreter rs)) = toZp rs
 
-instance (FromConstant a (Zp p), Symbolic c) => FromConstant a (FFA p c) where
-  fromConstant = FFA . embed . impl . toConstant . (fromConstant :: a -> Zp p)
+instance (FromConstant a (Zp p), Symbolic c) => FromConstant a (FFA0 p c) where
+  fromConstant = FFA0 . embed . impl . toConstant . (fromConstant :: a -> Zp p)
     where
       impl :: Natural -> Vector Size (BaseField c)
       impl x = fromConstant . (x `mod`) <$> coprimes @(BaseField c)
 
-instance {-# OVERLAPPING #-} FromConstant (FFA p c) (FFA p c)
+instance {-# OVERLAPPING #-} FromConstant (FFA0 p c) (FFA0 p c)
 
-instance {-# OVERLAPPING #-} (KnownNat p, Symbolic c) => Scale (FFA p c) (FFA p c)
+instance {-# OVERLAPPING #-} (KnownNat p, Symbolic c) => Scale (FFA0 p c) (FFA0 p c)
 
-instance (KnownNat p, Symbolic c) => MultiplicativeSemigroup (FFA p c) where
-  FFA x * FFA y =
-    FFA $ symbolic2F x y (\u v -> fromZp (toZp u * toZp v :: Zp p)) (mul @p)
+instance (KnownNat p, Symbolic c) => MultiplicativeSemigroup (FFA0 p c) where
+  FFA0 x * FFA0 y =
+    FFA0 $ symbolic2F x y (\u v -> fromZp (toZp u * toZp v :: Zp p)) (mul @p)
 
-instance (KnownNat p, Symbolic c) => Exponent (FFA p c) Natural where
-  FFA x ^ a =
-    FFA $ symbolicF x (\v -> fromZp (toZp v ^ a :: Zp p)) $ natPowM (mul @p) oneM a
+instance (KnownNat p, Symbolic c) => Exponent (FFA0 p c) Natural where
+  FFA0 x ^ a =
+    FFA0 $ symbolicF x (\v -> fromZp (toZp v ^ a :: Zp p)) $ natPowM (mul @p) oneM a
 
-instance (KnownNat p, Symbolic c) => MultiplicativeMonoid (FFA p c) where
+instance (KnownNat p, Symbolic c) => MultiplicativeMonoid (FFA0 p c) where
   one = fromConstant (one :: Zp p)
 
-instance (KnownNat p, Symbolic c) => AdditiveSemigroup (FFA p c) where
-  FFA x + FFA y =
-    FFA $ symbolic2F x y (\u v -> fromZp (toZp u + toZp v :: Zp p)) $ \xs ys ->
+instance (KnownNat p, Symbolic c) => AdditiveSemigroup (FFA0 p c) where
+  FFA0 x + FFA0 y =
+    FFA0 $ symbolic2F x y (\u v -> fromZp (toZp u + toZp v :: Zp p)) $ \xs ys ->
       zipWithM (\i j -> newAssigned (\w -> w i + w j)) xs ys >>= smallCut >>= cast @p
 
-instance (KnownNat p, Scale a (Zp p), Symbolic c) => Scale a (FFA p c) where
+instance (KnownNat p, Scale a (Zp p), Symbolic c) => Scale a (FFA0 p c) where
   scale k x = fromConstant (scale k one :: Zp p) * x
 
-instance (KnownNat p, Symbolic c) => AdditiveMonoid (FFA p c) where
+instance (KnownNat p, Symbolic c) => AdditiveMonoid (FFA0 p c) where
   zero = fromConstant (zero :: Zp p)
 
-instance (KnownNat p, Symbolic c) => AdditiveGroup (FFA p c) where
-  negate (FFA x) = FFA $ symbolicF x (fromZp . negate . toZp @p) $ \xs -> do
+instance (KnownNat p, Symbolic c) => AdditiveGroup (FFA0 p c) where
+  negate (FFA0 x) = FFA0 $ symbolicF x (fromZp . negate . toZp @p) $ \xs -> do
     let cs = coprimes @(BaseField c)
     ys <- zipWithM (\i m -> newAssigned $ fromConstant m - ($ i)) xs cs
     cast @p ys
 
-instance (KnownNat p, Symbolic c) => Semiring (FFA p c)
+instance (KnownNat p, Symbolic c) => Semiring (FFA0 p c)
 
-instance (KnownNat p, Symbolic c) => Ring (FFA p c)
+instance (KnownNat p, Symbolic c) => Ring (FFA0 p c)
 
-instance (Prime p, Symbolic c) => Exponent (FFA p c) Integer where
+instance (Prime p, Symbolic c) => Exponent (FFA0 p c) Integer where
   x ^ a = x `intPowF` (a `mod` fromConstant (value @p -! 1))
 
-instance (Prime p, Symbolic c) => Field (FFA p c) where
-  finv (FFA x) =
-    FFA $ symbolicF x (fromZp . finv @(Zp p) . toZp)
+instance (Prime p, Symbolic c) => Field (FFA0 p c) where
+  finv (FFA0 x) =
+    FFA0 $ symbolicF x (fromZp . finv @(Zp p) . toZp)
       $ natPowM (mul @p) oneM (value @p -! 2)
 
-instance Finite (Zp p) => Finite (FFA p b) where
-  type Order (FFA p b) = p
+instance Finite (Zp p) => Finite (FFA0 p b) where
+  type Order (FFA0 p b) = p
 
 -- FIXME: This Eq instance is wrong
-deriving newtype instance Symbolic c => Eq (Bool c) (FFA p c)
+deriving newtype instance Symbolic c => Eq (Bool c) (FFA0 p c)
 
-deriving newtype instance Symbolic c => Conditional (Bool c) (FFA p c)
+deriving newtype instance Symbolic c => Conditional (Bool c) (FFA0 p c)
 
 -- | TODO: fix when rewrite is done
-instance (Symbolic c) => SymbolicInput (FFA p c) where
+instance (Symbolic c) => SymbolicInput (FFA0 p c) where
   isValid _ = true
+
+
+---------------------------------- Some staff ----------------------------------
+{-
+newtype FieldElement c = FieldElement { fromFieldElement :: c Par1 }
+
+k -> BaseField c -> Par1 (BaseField c) -> c Par1 -> FieldElement c
+
+data Point (curve :: Type) = Point
+  { _x     :: BaseField curve
+  , _y     :: BaseField curve
+  , _isInf :: BooleanOf curve
+  } deriving (Generic)
+
+type Fr = Zp BLS12_381_Scalar
+type Fq = Zp BLS12_381_Base
+
+instance EllipticCurve BLS12_381_G1 where
+    type ScalarField BLS12_381_G1 = Fr
+
+    type BaseField BLS12_381_G1 = Fq
+
+newtype Zp (p :: Natural) = Zp Integer
+    deriving (Generic, NFData)
+
+{-# INLINE fromZp #-}
+fromZp :: Zp p -> Natural
+fromZp (Zp a) = fromIntegral a
+
+{-# INLINE residue #-}
+residue :: forall p . KnownNat p => Integer -> Integer
+residue = (`Haskell.mod` fromIntegral (value @p))
+
+{-# INLINE toZp #-}
+toZp :: forall p . KnownNat p => Integer -> Zp p
+toZp = Zp . residue @p
+
+Natural -> Vector Size (BaseField c) -> c (Vector Size) -> FFA0 p c
+
+Par1 Fr ~ i (ScalarField c1)
+
+PlonkupRelation p i n l (ScalarField c1)
+
+-}
+{-
+Residue Numeral System
+Representation of an integer holding its values modulo several coprime integers.
+
+Contains all the necessary values to carry out operations such as
+multiplication and reduction in this representation.
+
+Representation of an integer.
+
+The integer is represented as a vector of [`Limb`]s with values in the
+native field plus a reference to the [`FFALimb`] used.
+-}
+--------------------------------- General FFA0 ----------------------------------
+
+type LimbsMaxSize = 256
+type LimbMaxBits = 68
+
+
+{-
+a * b = r mod p
+
+a_n -> nlimbs
+bits_length(r) ~ bits
+
+`t = BIT_LEN_LIMB * NUMBER_OF_LIMBS`
+`T = 2 ^ t` which we also name as `binary_modulus`
+-}
+
+{-
+  -- Actual limbs FFA0 representation.
+  { limbs :: c (Vector nlimbs)
+-}
+
+data FFA (w :: Natural) (n :: Natural) (nlimbs :: Natural) (bits :: Natural) = FFA {limbs :: (Vector nlimbs (Zp n)), ffalimb :: FFALimb w n nlimbs bits}
+
+-- TODO: refactor the code to be able to use two different curves (native and non-native)
+data FFALimb (w :: Natural) (n :: Natural) (nlimbs :: Natural) (bits :: Natural) = FFALimb
+  -- Order of the wrong field W. (In the article `p`).
+  { wrong_modulus  :: Natural
+  -- Order of the native field N. (In the article `n`).
+  , native_modulus :: Natural
+  -- In the article: 2^t
+  , binary_modulus :: Natural
+  -- In the article notation: M = n * 2^t
+  , crt_modulus    :: Natural
+
+  -- Native field elements representing `2^(i*-r)` with `bits_length(r) = bits`.
+  , right_shifters :: Vector nlimbs (Zp n)
+  -- Native field elements representing `2^(i*r)` with `bits_length(r) = bits`.
+  , left_shifters  :: Vector nlimbs (Zp n)
+  -- The value `base_aux` is a vector of auxiliary limbs representing the value `2p` with `p` the size of the wrong modulus.
+  , base_aux       :: Vector nlimbs Natural
+
+  -- Negative wrong modulus: `-p mod 2^t` as vector of limbs.
+  , negative_wrong_modulus_decomposed :: Vector nlimbs (Zp n)
+  -- Wrong modulus `p` as vector of limbs.
+  , wrong_modulus_decomposed          :: Vector nlimbs (Zp n)
+  -- Wrong modulus -1  `p - 1` as vector of limbs.
+  , wrong_modulus_minus_one           :: Vector nlimbs (Zp n)
+  -- Wrong modulus as native field element: `p mod n`.
+  , wrong_modulus_in_native_modulus   :: Zp n
+
+  -- Maximum value for a reduced limb.
+  , max_reduced_limb   :: Natural
+  -- Maximum value for an unreduced limb.
+  , max_unreduced_limb :: Natural
+  -- Maximum value of the remainder.
+  , max_remainder      :: Natural
+  -- Maximum value that can be safely multiplied (guaranteeing the result will be reducible).
+  , max_operand        :: Natural
+  -- Maximum value of the quotient `q` in a reduction.
+  , max_mul_quotient   :: Natural
+
+  -- Maximum value of most significant limb for `max_reduced_limb`.
+  , max_most_significant_reduced_limb      :: Natural
+  -- Maximum value of most significant limb for `max_operand_limb`.
+  , max_most_significant_operand_limb      :: Natural
+  -- Maximum value of most significant limb for `max_mul_quotient`.
+  , max_most_significant_mul_quotient_limb :: Natural
+
+  -- Bit length of the maximum value allowed for residues in multiplication.
+  -- TODO: implement , mul_v_bit_len :: Natural
+  -- Bit length of the maximum value allowed for residues in reduction circuit.
+  -- TODO: implement , red_v_bit_len :: Natural
+  }
+
+{-
+
+-}
+
+bitLenExpansion :: forall nlimbs bits. (KnownNat nlimbs, KnownNat bits) => Natural -> [Natural]
+bitLenExpansion e = expansion e nlimbs
+  where
+    nlimbs  = P.fromIntegral $ value @nlimbs
+    bit_len = P.fromIntegral $ value @bits
+    mask :: Natural = 1 `shiftL` bit_len
+
+    expansion :: Natural -> Int -> [Natural]
+    expansion 0 0 = []
+    expansion n i = (n .&. mask) : expansion (n `shiftR` bit_len) (i P.- 1)
+
+decomposeBig :: forall nlimbs bits f. (KnownNat nlimbs, KnownNat bits, KnownNat f) =>
+  Natural -> Vector nlimbs (Zp f)
+decomposeBig = unsafeToVector . fmap (PrimeField.toZp . fromConstant) . bitLenExpansion @nlimbs @bits
+
+calculateBaseAux :: forall nlimbs bits w n. (KnownNat nlimbs, KnownNat bits, Prime w, Prime n) => Vector nlimbs Natural
+calculateBaseAux = base_aux
+  where
+      two = PrimeField.toZp @n 2
+      r   = PrimeField.fromZp $ two ^ (value @bits)
+      w :: Natural = value @w
+      wrong_modulus = decomposeBig @nlimbs @bits @n w
+      -- `base_aux = 2 * wrong_modulus`
+      base_aux' = fmap PrimeField.fromZp wrong_modulus
+      aux = fromVector $ reverse base_aux'
+      last = P.head aux
+      base_aux = unsafeToVector $ P.reverse $ borrowNext last (P.tail aux)
+
+      bits = P.fromIntegral $ value @bits
+
+      -- If value of a limb is not above dense limb borrow from the next one
+      borrowNext :: Natural -> [Natural] -> [Natural]
+      borrowNext l [] = [l]
+      borrowNext l (l' : ls) = if countBits l' P.< bits P.+ 1 then
+        let new_l = l -! 1; new_l' = l' + r in new_l : borrowNext new_l' ls
+        else l : borrowNext l' ls
+
+countBits :: Natural -> Int
+countBits = undefined
+
+constructFFALimb :: forall nlimbs bits w n. (KnownNat nlimbs, KnownNat bits, Prime w, Prime n) => FFALimb w n nlimbs bits
+constructFFALimb = do
+  let nlimbs  :: Natural = value @nlimbs
+      bit_len :: Natural = value @bits
+
+      -- `t = BIT_LEN_LIMB * NUMBER_OF_LIMBS`
+      -- `T = 2 ^ t` which we also name as `binary_modulus`
+      binary_modulus_bit_len = P.fromIntegral $ bit_len * nlimbs
+      binary_modulus = one `shiftL` binary_modulus_bit_len
+
+      -- wrong field modulus: `w`
+      wrong_modulus :: Natural = value @w
+      -- native field modulus: `n`
+      native_modulus :: Natural = value @n
+      -- Multiplication is constrained as:
+      --
+      -- `a * b = w * quotient + remainder`
+      --
+      -- where `quotient` and `remainder` is witnesses, `a` and `b` are assigned
+      -- operands. Both sides of the equation must not wrap `crt_modulus`.
+      crt_modulus = binary_modulus * native_modulus
+
+      -- Witness remainder might overflow the wrong modulus but it is limited
+      -- to the next power of two of the wrong modulus.
+      max_remainder = (one `shiftL` P.fromIntegral wrong_modulus) -! one
+
+      -- Find maxium quotient that won't wrap `quotient * wrong + remainder` side of
+      -- the equation under `crt_modulus`.
+      pre_max_quotient = (crt_modulus -! max_remainder) `div` wrong_modulus
+
+      -- Lower this value to make this value suitable for bit range checks.
+      max_quotient = (one `shiftL` P.fromIntegral (pre_max_quotient -! one)) -! one
+
+      -- Find the maximum operand: in order to meet completeness maximum allowed
+      -- operand value is saturated as below:
+      --
+      -- `max_operand ^ 2 < max_quotient * wrong + max_remainder`
+      --
+      -- So that prover can find `quotient` and `remainder` witnesses for any
+      -- allowed input operands. And it also automativally ensures that:
+      --
+      -- `max_operand^2 < crt_modulus`
+      --
+      -- must hold.
+      max_operand_bit_len = (countBits (max_quotient * wrong_modulus + max_remainder) P.- 1) `P.div` 2;
+      max_operand = (one `shiftL` max_operand_bit_len) -! one
+
+      -- negative wrong field modulus moduli binary modulus `w'`
+      -- `w' = (T - w)`
+      -- `w' = [w'_0, w'_1, ... ]`
+      negative_wrong_modulus_decomposed = decomposeBig @nlimbs @bits @n $ binary_modulus -! wrong_modulus
+
+      --`w = [w_0, w_1, ... ]`
+      wrong_modulus_decomposed = decomposeBig @nlimbs @bits @n wrong_modulus
+
+      --`w-1 = [w_0-1 , w_1, ... ] `
+      wrong_modulus_minus_one = decomposeBig @nlimbs @bits @n $ wrong_modulus -! one
+
+      -- Full dense limb without overflow
+      max_reduced_limb = (one `shiftL` P.fromIntegral bit_len) -! one
+
+      -- Keep this much lower than what we can reduce with single limb quotient to
+      -- take extra measure for overflow issues
+      max_unreduced_limb = (one `shiftL` P.fromIntegral (bit_len + bit_len `P.div` 2)) -! one
+
+      -- Most significant limbs are subjected to different range checks which will be
+      -- probably less than full sized limbs.
+      max_most_significant_reduced_limb = max_remainder `shiftR` P.fromIntegral ((nlimbs -! 1) * bit_len)
+      max_most_significant_operand_limb = max_operand `shiftR` P.fromIntegral ((nlimbs -! 1) * bit_len)
+      max_most_significant_mul_quotient_limb = max_quotient `shiftR` P.fromIntegral ((nlimbs -! 1) * bit_len)
+
+      -- Emulate a multiplication to find out max residue overflows:
+      -- let mut mul_v_bit_len: usize = BIT_LEN_LIMB
+      -- TODO: implement mul_v_bit_len = bit_len
+
+      -- Emulate a multiplication to find out max residue overflows:
+      -- let mut red_v_bit_len: usize = BIT_LEN_LIMB;
+      -- TODO: implement red_v_bit_len = bit_len
+
+      -- let bit_len_lookup = BIT_LEN_LIMB / NUMBER_OF_LOOKUP_LIMBS;
+
+      -- Calculate auxillary value for subtraction
+      base_aux = calculateBaseAux @nlimbs @bits @w @n
+
+      wrong_modulus_in_native_modulus :: Zp n = PrimeField.toZp $ fromConstant $ wrong_modulus `P.mod` native_modulus
+
+      -- Calculate shifter elements
+      two     = PrimeField.toZp @n 2 
+      two_inv = finv two
+
+      -- Right shifts field element by `u * BIT_LEN_LIMB` bits
+      right_shifters = unsafeToVector $ fmap (\i -> two_inv ^ (i * bit_len)) [0..nlimbs]
+
+      -- Left shifts field element by `u * BIT_LEN_LIMB` bits
+      left_shifters = unsafeToVector $ fmap (\i -> two ^ (i * bit_len)) [0..nlimbs]
+
+      max_mul_quotient = max_quotient
+
+  FFALimb{..}
+
+-- toZp / fromZp, ToConstant (type Zp a) / FromConstant a
+
+-- (+), (-), (*), (negate), (^), (finv)
+
+-- cast, isValid
+
+
+
+------------------------------------ Setup -------------------------------------
+
+-- a, b \in [0, p)
+
+-- a * b = r mod p, r \in [0, p)
+
+-- a * b = q * p + r, a * b < p^2
+
+-- a * b - r = q * p < p^2, q \in [0, p)
+
+-- circumventing the computation of a * b or q * p
+
+-- (a, b, q, p, r)
+
+--------------------------- Native Field Constraint ----------------------------
+
+-- a * b = r mod p => a * b = q * p + r
+
+-- a * b - q * p - r = 0 mod n, prim n < p
+-- min_n
+
+-- v_a * n + a_n = a
+-- v_b * n + b_n = b
+-- v_q * n + q_n = q
+-- v_p * n + p_n = p
+-- v_r * n + r_n = r
+
+-- v_overall * n = a_n * b_n - q_n * p_n - r_n
+
+-- (a, b, q, p, r, v_a, v_b, v_q, v_p, v_r, v_overall)
+
+---------- Constraint decomposition in modulo 2^𝑇 ring, where 𝑝 < 2^𝑇 ----------
+
+-- T \in [4, 254]
+
+-- p' = -p mod 2^T => p' = 2^T - p
+
+-- a * b - q * p = a * b + q * p' mod 2^T
+
+-- B = T/4
+
+-- ...
+
+--------------------------------------------------------------------------------
+
+
+

--- a/symbolic-base/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/UInt.hs
@@ -10,12 +10,14 @@
 module ZkFold.Symbolic.Data.UInt (
     StrictConv(..),
     StrictNum(..),
-    UInt(..),
+    UInt,
     OrdWord,
     toConstant,
     asWords,
     expMod,
-    eea
+    eea,
+    testOnlyUInt,
+    testOnlyUIntInterpreter
 ) where
 
 import           Control.DeepSeq
@@ -56,8 +58,13 @@ import           ZkFold.Symbolic.Interpreter       (Interpreter (..))
 import           ZkFold.Symbolic.MonadCircuit      (MonadCircuit, constraint, newAssigned)
 
 
--- TODO (Issue #18): hide this constructor
 newtype UInt (n :: Natural) (r :: RegisterSize) (context :: (Type -> Type) -> Type) = UInt (context (Vector (NumberOfRegisters (BaseField context) n r)))
+
+testOnlyUInt :: UInt n r context -> context (Vector (NumberOfRegisters (BaseField context) n r))
+testOnlyUInt (UInt v) = v
+
+testOnlyUIntInterpreter :: UInt n r (Interpreter a) -> Vector (NumberOfRegisters a n r) a
+testOnlyUIntInterpreter (UInt (Interpreter v)) = v
 
 deriving instance Generic (UInt n r context)
 deriving instance (NFData (context (Vector (NumberOfRegisters (BaseField context) n r)))) => NFData (UInt n r context)

--- a/symbolic-base/test/Tests/FFA.hs
+++ b/symbolic-base/test/Tests/FFA.hs
@@ -18,7 +18,7 @@ import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.Basic.Number            (Prime, value)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
 import           ZkFold.Symbolic.Compiler                    (ArithmeticCircuit, exec)
-import           ZkFold.Symbolic.Data.FFA                    (FFA (FFA))
+import           ZkFold.Symbolic.Data.FFA                    (FFAOld (FFAOld))
 import           ZkFold.Symbolic.Interpreter                 (Interpreter (Interpreter))
 
 type Prime256_1 = 28948022309329048855892746252171976963363056481941560715954676764349967630337
@@ -35,10 +35,10 @@ specFFA = do
 specFFA' :: forall p q. (PrimeField (Zp p), PrimeField (Zp q)) => IO ()
 specFFA' = hspec $ do
   let q = value @q
-  describe ("FFA " ++ show q ++ " specification") $ do
-    it "FFA(Zp) embeds Zq" $ \(x :: Zp q) ->
-      toConstant (fromConstant x :: FFA q (Interpreter (Zp p))) === x
-    it "FFA(AC) embeds Zq" $ \(x :: Zp q) ->
+  describe ("FFAOld " ++ show q ++ " specification") $ do
+    it "FFAOld(Zp) embeds Zq" $ \(x :: Zp q) ->
+      toConstant (fromConstant x :: FFAOld q (Interpreter (Zp p))) === x
+    it "FFAOld(AC) embeds Zq" $ \(x :: Zp q) ->
       execAcFFA @p @q (fromConstant x) === x
     it "has zero" $ execAcFFA @p @q zero === execZpFFA @p @q zero
     it "has one" $ execAcFFA @p @q one === execZpFFA @p @q one
@@ -47,14 +47,14 @@ specFFA' = hspec $ do
       execAcFFA @p @q (negate $ fromConstant x) === execZpFFA @p @q (negate $ fromConstant x)
     it "multiplies correctly" $ isHom @p @q (*) (*)
 
-execAcFFA :: (PrimeField (Zp p), PrimeField (Zp q)) => FFA q (ArithmeticCircuit (Zp p) U1 U1) -> Zp q
-execAcFFA (FFA v) = execZpFFA $ FFA $ Interpreter (exec v)
+execAcFFA :: (PrimeField (Zp p), PrimeField (Zp q)) => FFAOld q (ArithmeticCircuit (Zp p) U1 U1) -> Zp q
+execAcFFA (FFAOld v) = execZpFFA $ FFAOld $ Interpreter (exec v)
 
-execZpFFA :: (PrimeField (Zp p), PrimeField (Zp q)) => FFA q (Interpreter (Zp p)) -> Zp q
+execZpFFA :: (PrimeField (Zp p), PrimeField (Zp q)) => FFAOld q (Interpreter (Zp p)) -> Zp q
 execZpFFA = toConstant
 
 type Binary a = a -> a -> a
 type Predicate a = a -> a -> Property
 
-isHom :: (PrimeField (Zp p), PrimeField (Zp q)) => Binary (FFA q (Interpreter (Zp p))) -> Binary (FFA q (ArithmeticCircuit (Zp p) U1 U1)) -> Predicate (Zp q)
+isHom :: (PrimeField (Zp p), PrimeField (Zp q)) => Binary (FFAOld q (Interpreter (Zp p))) -> Binary (FFAOld q (ArithmeticCircuit (Zp p) U1 U1)) -> Predicate (Zp q)
 isHom f g x y = execAcFFA (fromConstant x `g` fromConstant y) === execZpFFA (fromConstant x `f` fromConstant y)

--- a/symbolic-base/test/Tests/UInt.hs
+++ b/symbolic-base/test/Tests/UInt.hs
@@ -9,14 +9,14 @@ module Tests.UInt (specUInt) where
 import           Control.Applicative                         ((<*>))
 import           Control.Monad                               (return, when)
 import           Data.Aeson                                  (decode, encode)
-import           Data.Constraint
+import           Data.Constraint                             (Dict, withDict)
 import           Data.Constraint.Nat                         (timesNat)
-import           Data.Constraint.Unsafe
+import           Data.Constraint.Unsafe                      (unsafeAxiom)
 import           Data.Function                               (($))
 import           Data.Functor                                ((<$>))
 import           Data.List                                   ((++))
 import           GHC.Generics                                (Par1 (Par1), U1)
-import           Prelude                                     (show, type (~))
+import           Prelude                                     (show, type (~), (.))
 import qualified Prelude                                     as P
 import           System.IO                                   (IO)
 import           Test.Hspec                                  (describe, hspec)
@@ -55,10 +55,10 @@ evalBS :: forall a n . Arithmetic a => ByteString n (AC a) -> ByteString n (Inte
 evalBS (ByteString bits) = ByteString $ Interpreter (exec bits)
 
 execAcUint :: forall a n r . Arithmetic a => UInt n r (AC a) -> Vector (NumberOfRegisters a n r) a
-execAcUint (UInt v) = exec v
+execAcUint = exec . testOnlyUInt
 
 execZpUint :: forall a n r . UInt n r (Interpreter a) -> Vector (NumberOfRegisters a n r) a
-execZpUint (UInt (Interpreter v)) = v
+execZpUint = testOnlyUIntInterpreter
 
 overflowSub :: forall n . KnownNat n => Binary Natural
 overflowSub x y

--- a/symbolic-examples/src/Examples/FFA.hs
+++ b/symbolic-examples/src/Examples/FFA.hs
@@ -7,25 +7,25 @@ module Examples.FFA
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Symbolic.Class            (Symbolic)
-import           ZkFold.Symbolic.Data.FFA         (FFA)
+import           ZkFold.Symbolic.Data.FFA         (FFAOld)
 
 type Prime256_1 = 28948022309329048855892746252171976963363056481941560715954676764349967630337
 type Prime256_2 = 28948022309329048855892746252171976963363056481941647379679742748393362948097
 
-exampleFFAadd337 :: Symbolic c => FFA Prime256_1 c -> FFA Prime256_1 c -> FFA Prime256_1 c
+exampleFFAadd337 :: Symbolic c => FFAOld Prime256_1 c -> FFAOld Prime256_1 c -> FFAOld Prime256_1 c
 exampleFFAadd337 = exampleFFAadd
 
-exampleFFAadd097 :: Symbolic c => FFA Prime256_2 c -> FFA Prime256_2 c -> FFA Prime256_2 c
+exampleFFAadd097 :: Symbolic c => FFAOld Prime256_2 c -> FFAOld Prime256_2 c -> FFAOld Prime256_2 c
 exampleFFAadd097 = exampleFFAadd
 
-exampleFFAmul337 :: Symbolic c => FFA Prime256_1 c -> FFA Prime256_1 c -> FFA Prime256_1 c
+exampleFFAmul337 :: Symbolic c => FFAOld Prime256_1 c -> FFAOld Prime256_1 c -> FFAOld Prime256_1 c
 exampleFFAmul337 = exampleFFAmul
 
-exampleFFAmul097 :: Symbolic c => FFA Prime256_2 c -> FFA Prime256_2 c -> FFA Prime256_2 c
+exampleFFAmul097 :: Symbolic c => FFAOld Prime256_2 c -> FFAOld Prime256_2 c -> FFAOld Prime256_2 c
 exampleFFAmul097 = exampleFFAmul
 
-exampleFFAadd :: forall p c. (Symbolic c, KnownNat p) => FFA p c -> FFA p c -> FFA p c
+exampleFFAadd :: forall p c. (Symbolic c, KnownNat p) => FFAOld p c -> FFAOld p c -> FFAOld p c
 exampleFFAadd = (+)
 
-exampleFFAmul :: forall p c. (Symbolic c, KnownNat p) => FFA p c -> FFA p c -> FFA p c
+exampleFFAmul :: forall p c. (Symbolic c, KnownNat p) => FFAOld p c -> FFAOld p c -> FFAOld p c
 exampleFFAmul = (*)


### PR DESCRIPTION
## Motivation
In some circuits such as DSA, we are frequently interested in representing modulo arithmetic over a large prime field, equations of the sort 𝑎 ⋅ 𝑏 = 𝑟 mod 𝑝 where 𝑝 is a large prime. Typically, a witness (𝑎, 𝑏, 𝑟, 𝑞, 𝑝) is produced and the integer constraint 𝑎 ⋅ 𝑏 = 𝑞 ⋅𝑝 + 𝑟 is included as part of the polynomial commitment. Using non-native arithmetic discussed in this note, we can replace these types of constraints with (multiple) constraints over smaller numbers. Therefore, our goal in this note is to emulate certain expensive constraints in a different way.

## Description of what changes are proposed

- [ ] Trimming large `Point curve` type modules to `Zp BLS12_381_Scalar`
- [ ] Create a separate type `FFALimb` with pre-calculated constants so that all new numbers `FFA` refer to it
- [ ] Make a distinction between assigned and unassigned types (example create new data `AssignedFFA`)
- [ ] Replace the old `FFA` implementation with the new `AssignedFFA` 

## What will be done in the next pr

- [ ] Write a top-level `FFAChip` structure that knows about `RangeChip` and `MainGate`
- [ ] It might be a migration from `Zp` to `FFAChip` (For now I want to merge the bottom layer, which does not provide all the optimizations)