### PR TITLE
Elliptic Curve tests

### DIFF
--- a/symbolic-base/src/ZkFold/Base/Algebra/EllipticCurve/BLS12_381.hs
+++ b/symbolic-base/src/ZkFold/Base/Algebra/EllipticCurve/BLS12_381.hs
@@ -22,7 +22,6 @@ import           ZkFold.Base.Algebra.EllipticCurve.Class
 import           ZkFold.Base.Algebra.EllipticCurve.Pairing
 import           ZkFold.Base.Algebra.Polynomials.Univariate
 import           ZkFold.Base.Data.ByteString
-import qualified ZkFold.Symbolic.Data.Conditional           as Symbolic
 import qualified ZkFold.Symbolic.Data.Eq                    as Symbolic
 
 -------------------------------- Introducing Fields ----------------------------------
@@ -57,42 +56,31 @@ instance IrreduciblePoly Fq6 IP3 where
         in toPoly [e, zero, one]
 type Fq12 = Ext2 Fq6 IP3
 
-------------------------------------- BLS12-381 --------------------------------------
+------------------------------------- BLS12-381-G1 --------------------------------------
 
-instance Field field => WeierstrassCurve "BLS12-381" field where
+instance WeierstrassCurve "BLS12-381-G1" Fq where
   weierstrassB = fromConstant (4 :: Natural)
 
-type BLS12_381_Point baseField = Weierstrass "BLS12-381" (Point Bool baseField)
+type BLS12_381_G1_Point = Weierstrass "BLS12-381-G1" (Point Bool Fq)
 
-type BLS12_381_CompressedPoint baseField =
-  Weierstrass "BLS12-381" (CompressedPoint Bool baseField)
+type BLS12_381_G1_CompressedPoint =
+  Weierstrass "BLS12-381-G1" (CompressedPoint Bool Fq)
 
-instance
-  ( Symbolic.Conditional Bool field
-  , Symbolic.Eq Bool field
-  , FiniteField field
-  , Ord field
-  ) => Compressible Bool (BLS12_381_Point field) where
-    type Compressed (BLS12_381_Point field) = BLS12_381_CompressedPoint field
+instance Compressible Bool BLS12_381_G1_Point where
+    type Compressed BLS12_381_G1_Point = BLS12_381_G1_CompressedPoint
     pointCompressed x yBit = Weierstrass (CompressedPoint x yBit False)
     compress (Weierstrass (Point x y isInf)) =
       if isInf then pointInf
-      else pointCompressed @Bool @(BLS12_381_Point field) x (y > negate y)
+      else pointCompressed @Bool @BLS12_381_G1_Point x (y > negate y)
     decompress (Weierstrass (CompressedPoint x bigY isInf)) =
       if isInf then pointInf else
-        let b = weierstrassB @"BLS12-381"
-            q = order @field
+        let b = weierstrassB @"BLS12-381-G1"
+            q = order @Fq
             sqrt_ z = z ^ ((q + 1) `Prelude.div` 2)
             y' = sqrt_ (x * x * x + b)
             y'' = negate y'
             y = if bigY then max y' y'' else min y' y''
         in  pointXY x y
-
------------------------------------- BLS12-381 G1 ------------------------------------
-
-type BLS12_381_G1_Point = BLS12_381_Point Fq
-
-type BLS12_381_G1_CompressedPoint = BLS12_381_CompressedPoint Fq
 
 instance CyclicGroup BLS12_381_G1_Point where
   type ScalarFieldOf BLS12_381_G1_Point = Fr
@@ -105,9 +93,13 @@ instance Scale Fr BLS12_381_G1_Point where
 
 ------------------------------------ BLS12-381 G2 ------------------------------------
 
-type BLS12_381_G2_Point = BLS12_381_Point Fq2
+instance WeierstrassCurve "BLS12-381-G2" Fq2 where
+  weierstrassB = Ext2 4 4
 
-type BLS12_381_G2_CompressedPoint = BLS12_381_CompressedPoint Fq2
+type BLS12_381_G2_Point = Weierstrass "BLS12-381-G2" (Point Bool Fq2)
+
+type BLS12_381_G2_CompressedPoint =
+  Weierstrass "BLS12-381-G2" (CompressedPoint Bool Fq2)
 
 instance CyclicGroup BLS12_381_G2_Point where
   type ScalarFieldOf BLS12_381_G2_Point = Fr
@@ -121,6 +113,22 @@ instance CyclicGroup BLS12_381_G2_Point where
 
 instance Scale Fr BLS12_381_G2_Point where
   scale n x = scale (toConstant n) x
+
+instance Compressible Bool BLS12_381_G2_Point where
+    type Compressed BLS12_381_G2_Point = BLS12_381_G2_CompressedPoint
+    pointCompressed x yBit = Weierstrass (CompressedPoint x yBit False)
+    compress (Weierstrass (Point x y isInf)) =
+      if isInf then pointInf
+      else pointCompressed @Bool @BLS12_381_G2_Point x (y > negate y)
+    decompress (Weierstrass (CompressedPoint x bigY isInf)) =
+      if isInf then pointInf else
+        let b = weierstrassB @"BLS12-381-G2"
+            q = order @Fq2
+            sqrt_ z = z ^ ((q + 1) `Prelude.div` 2)
+            y' = sqrt_ (x * x * x + b)
+            y'' = negate y'
+            y = if bigY then max y' y'' else min y' y''
+        in  pointXY x y
 
 ------------------------------------ Encoding ------------------------------------
 

--- a/symbolic-base/src/ZkFold/Base/Algebra/EllipticCurve/BLS12_381.hs
+++ b/symbolic-base/src/ZkFold/Base/Algebra/EllipticCurve/BLS12_381.hs
@@ -59,7 +59,7 @@ type Fq12 = Ext2 Fq6 IP3
 ------------------------------------- BLS12-381-G1 --------------------------------------
 
 instance WeierstrassCurve "BLS12-381-G1" Fq where
-  weierstrassB = fromConstant (4 :: Natural)
+  weierstrassB = 4
 
 type BLS12_381_G1_Point = Weierstrass "BLS12-381-G1" (Point Bool Fq)
 

--- a/symbolic-base/src/ZkFold/Base/Algebra/EllipticCurve/Class.hs
+++ b/symbolic-base/src/ZkFold/Base/Algebra/EllipticCurve/Class.hs
@@ -262,6 +262,10 @@ instance
       let a = twistedEdwardsA @curve
           d = twistedEdwardsD @curve
       in a*x*x + y*y == one + d*x*x*y*y
+deriving newtype instance Prelude.Eq point
+  => Prelude.Eq (TwistedEdwards curve point)
+deriving newtype instance Prelude.Show point
+  => Prelude.Show (TwistedEdwards curve point)
 deriving newtype instance SymbolicOutput field
   => SymbolicData (TwistedEdwards curve (AffinePoint field))
 instance
@@ -311,6 +315,13 @@ instance
   , Field field
   ) => Scale Integer (TwistedEdwards curve (AffinePoint field)) where
   scale = intScale
+instance
+  ( Arbitrary (ScalarFieldOf (TwistedEdwards curve (AffinePoint field)))
+  , CyclicGroup (TwistedEdwards curve (AffinePoint field))
+  ) => Arbitrary (TwistedEdwards curve (AffinePoint field)) where
+    arbitrary = do
+      c <- arbitrary @(ScalarFieldOf (TwistedEdwards curve (AffinePoint field)))
+      return $ scale c pointGen
 
 {- | A type of points in the projective plane. -}
 data Point bool field = Point
@@ -364,7 +375,7 @@ instance (BoolType bool, AdditiveMonoid field)
 data AffinePoint field = AffinePoint
   { _x :: field
   , _y :: field
-  } deriving Generic
+  } deriving (Generic, Prelude.Eq)
 instance SymbolicOutput field => SymbolicData (AffinePoint field)
 instance Planar field (AffinePoint field) where pointXY = AffinePoint
 instance Conditional bool field => Conditional bool (AffinePoint field)
@@ -373,3 +384,6 @@ instance
   , Eq bool field
   , Field field
   ) => Eq bool (AffinePoint field)
+instance Prelude.Show field => Prelude.Show (AffinePoint field) where
+  show (AffinePoint x y) = Prelude.mconcat
+    ["(", Prelude.show x, ", ", Prelude.show y, ")"]

--- a/symbolic-base/test/Tests/EllipticCurve.hs
+++ b/symbolic-base/test/Tests/EllipticCurve.hs
@@ -48,7 +48,7 @@ specEllipticCurveGenerator
     ) => Spec
 specEllipticCurveGenerator = do
   let curve = symbolVal (Proxy @(CurveOf point))
-  describe (curve <> " curve specification EITANTEST") $ do
+  describe (curve <> " curve specification") $ do
     describe "cyclic group generator" $ do
       let g = pointGen @point
       it "should be on the curve" $

--- a/symbolic-base/test/Tests/EllipticCurve.hs
+++ b/symbolic-base/test/Tests/EllipticCurve.hs
@@ -42,6 +42,7 @@ specEllipticCurveGenerator
     ( EllipticCurve Prelude.Bool point
     , CyclicGroup point
     , Eq point
+    , Show point
     , Arbitrary (ScalarFieldOf point)
     , Show (ScalarFieldOf point)
     , KnownSymbol (CurveOf point)
@@ -52,9 +53,10 @@ specEllipticCurveGenerator = do
     describe "cyclic group generator" $ do
       let g = pointGen @point
       it "should be on the curve" $
-        property $ isOnCurve @Prelude.Bool g
-      it "should have the same order as the scalar field" $
-        property $ order @(ScalarFieldOf point) `scale` g == zero
+        g `shouldSatisfy` isOnCurve
+      it "should have the same order as the scalar field" $ do
+        let coef = order @(ScalarFieldOf point)
+        scale coef g `shouldBe` zero
       it "should be closed under scalar multiplication" $
         property $ \ (coef :: ScalarFieldOf point) ->
           isOnCurve @Prelude.Bool (coef `scale` g)

--- a/symbolic-base/test/Tests/EllipticCurve.hs
+++ b/symbolic-base/test/Tests/EllipticCurve.hs
@@ -5,14 +5,14 @@ module Tests.EllipticCurve (specEllipticCurve) where
 import           Data.Foldable
 import           Data.Proxy
 import           GHC.TypeLits
-import           Prelude hiding (Num(..))
+import           Prelude                                     hiding (Num (..))
 import           Test.Hspec
-import           Test.QuickCheck hiding (scale)
+import           Test.QuickCheck                             hiding (scale)
 
 import           ZkFold.Base.Algebra.Basic.Class
-import           ZkFold.Base.Algebra.EllipticCurve.Class
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381
 import           ZkFold.Base.Algebra.EllipticCurve.BN254
+import           ZkFold.Base.Algebra.EllipticCurve.Class
 import           ZkFold.Base.Algebra.EllipticCurve.Ed25519
 import           ZkFold.Base.Algebra.EllipticCurve.Pasta
 import           ZkFold.Base.Algebra.EllipticCurve.Secp256k1
@@ -27,7 +27,7 @@ specEllipticCurve = hspec $ do
             p = pointXY (fromConstant x) (fromConstant y)
             q = scale k pointGen
         p `shouldBe` q
-  
+
   specEllipticCurve' @Secp256k1_Point
   specEllipticCurve' @BLS12_381_G1_Point
   -- specEllipticCurve' @BLS12_381_G2_Point

--- a/symbolic-base/test/Tests/EllipticCurve.hs
+++ b/symbolic-base/test/Tests/EllipticCurve.hs
@@ -28,46 +28,36 @@ specEllipticCurve = hspec $ do
             q = scale k pointGen
         p `shouldBe` q
 
-  specEllipticCurve' @Secp256k1_Point
-  specEllipticCurve' @BLS12_381_G1_Point
-  -- specEllipticCurve' @BLS12_381_G2_Point
-  specEllipticCurve' @BN254_G1_Point
-  specEllipticCurve' @BN254_G2_Point
-  specEllipticCurve' @Ed25519_Point
-  specEllipticCurve' @Pallas_Point
-  specEllipticCurve' @Vesta_Point
+  specEllipticCurveGenerator @Secp256k1_Point
+  specEllipticCurveGenerator @BLS12_381_G1_Point
+  specEllipticCurveGenerator @BLS12_381_G2_Point
+  specEllipticCurveGenerator @BN254_G1_Point
+  specEllipticCurveGenerator @BN254_G2_Point
+  specEllipticCurveGenerator @Ed25519_Point
+  specEllipticCurveGenerator @Pallas_Point
+  specEllipticCurveGenerator @Vesta_Point
 
-specEllipticCurve'
+specEllipticCurveGenerator
   :: forall point .
     ( EllipticCurve Prelude.Bool point
     , CyclicGroup point
     , Eq point
-    , Show point
-    , Arbitrary point
     , Arbitrary (ScalarFieldOf point)
     , Show (ScalarFieldOf point)
     , KnownSymbol (CurveOf point)
     ) => Spec
-specEllipticCurve' = do
+specEllipticCurveGenerator = do
   let curve = symbolVal (Proxy @(CurveOf point))
   describe (curve <> " curve specification EITANTEST") $ do
-    describe "Cyclic Group generator" $ do
-      it "should be on the curve" $ do
-        property $ isOnCurve @Prelude.Bool (pointGen @point)
-      it "should be closed under scalar multiplication" $ do
-        property $ \ (coef :: ScalarFieldOf point) -> isOnCurve @Prelude.Bool (coef `scale` pointGen @point)
-      it "should have the same order as the scalar field" $ do
-        property $ order @(ScalarFieldOf point) `scale` pointGen @point == zero
-    describe "Points on the curve" $ do
-      it "should be on the curve" $ do
-        property $ \ (point :: point) ->
-          isOnCurve @Prelude.Bool point
-      it "should be closed under scalar multiplication" $ do
-        property $ \ (coef :: ScalarFieldOf point) (point :: point) ->
-          isOnCurve @Prelude.Bool (coef `scale` point)
-      it "should be closed under addition" $ do
-        property $ \ (point0 :: point) point1 ->
-          isOnCurve @Prelude.Bool (point0 + point1)
+    describe "cyclic group generator" $ do
+      let g = pointGen @point
+      it "should be on the curve" $
+        property $ isOnCurve @Prelude.Bool g
+      it "should have the same order as the scalar field" $
+        property $ order @(ScalarFieldOf point) `scale` g == zero
+      it "should be closed under scalar multiplication" $
+        property $ \ (coef :: ScalarFieldOf point) ->
+          isOnCurve @Prelude.Bool (coef `scale` g)
 
 data TestVector = TestVector
   { _k :: Natural -- scalar

--- a/symbolic-base/test/Tests/Group.hs
+++ b/symbolic-base/test/Tests/Group.hs
@@ -14,7 +14,9 @@ import           Test.QuickCheck
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381
 import           ZkFold.Base.Algebra.EllipticCurve.BN254
+import           ZkFold.Base.Algebra.EllipticCurve.Ed25519   (Ed25519_Point)
 import           ZkFold.Base.Algebra.EllipticCurve.Pasta     (Pallas_Point, Vesta_Point)
+import           ZkFold.Base.Algebra.EllipticCurve.Secp256k1 (Secp256k1_Point)
 
 specAdditiveGroup' :: forall a . (AdditiveGroup a, Eq a, Show a, Arbitrary a, Typeable a) => IO ()
 specAdditiveGroup' = hspec $ do
@@ -40,3 +42,7 @@ specAdditiveGroup = do
 
     specAdditiveGroup' @Pallas_Point
     specAdditiveGroup' @Vesta_Point
+
+    specAdditiveGroup' @Secp256k1_Point
+
+    specAdditiveGroup' @Ed25519_Point


### PR DESCRIPTION
Resolves #463 by adding a regression test which would have caught an earlier copy/paste bug.

Adds curve tests for
* cyclic generator properties of a (subgroup of an) elliptic curve
* additive group property tests for secp256k1 and ed25519

Adds fix for error that new tests provoked
* Fix the incorrect `weierstrassB` parameter for BLS12-381 G2