### PR TITLE
Clean up `symbolic-base`'s `.cabal` a bit

### DIFF
--- a/symbolic-base/symbolic-base.cabal
+++ b/symbolic-base/symbolic-base.cabal
@@ -35,7 +35,6 @@ custom-setup
     , filepath >= 1.3.0.2
     , process
 
-
 common options
     default-language: Haskell2010
     ghc-options:
@@ -296,105 +295,65 @@ library
     if arch(javascript) || arch(wasm32)
       js-sources:
         js-src/blake2b.js
-
     other-modules:
       Paths_symbolic_base
-
     autogen-modules:
       Paths_symbolic_base
-
+    build-depends:
+      base                          >= 4.9 && < 5,
+      adjunctions                           < 4.5,
+      aeson                               ^>= 2.2,
+      aeson-casing                          < 0.3,
+      base64-bytestring                          ,
+      binary                               < 0.11,
+      bifunctors                                 ,
+      bytestring                           < 0.13,
+      bytestring-aeson-orphans              < 0.2,
+      constraints                                ,
+      containers                                 ,
+      cryptohash-sha256                    < 0.12,
+      deepseq                          <= 1.6.0.0,
+      distributive                               ,
+      generic-random                        < 1.6,
+      hashtables                                 ,
+      infinite-list                              ,
+      lens                                       ,
+      monoidal-containers                        ,
+      mtl                                   < 2.4,
+      optics                                < 0.5,
+      pretty-simple                         < 4.2,
+      QuickCheck                           < 2.16,
+      random                                < 1.3,
+      scientific                            < 0.4,
+      semialign                             < 1.4,
+      semigroups                                 ,
+      split                               < 0.2.6,
+      text                                       ,
+      these                                 < 1.3,
+      transformers                               ,
+      type-errors                         < 0.2.1,
+      vector                               < 0.14,
+      vector-binary-instances               < 0.3,
+      vector-split                          < 1.1,
     if arch(wasm32)
       build-depends:
         ghc-experimental
-    if arch(javascript) || arch(wasm32)
+    if !arch(javascript) && !arch(wasm32)
       build-depends:
-        base                          >= 4.9 && < 5,
-        adjunctions                           < 4.5,
-        aeson                               ^>= 2.2,
-        aeson-casing                          < 0.3,
-        base64-bytestring                          ,
-        binary                               < 0.11,
-        bifunctors                                 ,
-        bytestring                           < 0.13,
-        containers                                 ,
-        constraints                                ,
-        cryptohash-sha256                    < 0.12,
-        deepseq                          <= 1.6.0.0,
-        distributive                               ,
-        generic-random                        < 1.6,
-        hashtables                                 ,
-        infinite-list                              ,
-        lens                                       ,
-        monoidal-containers                        ,
-        mtl                                   < 2.4,
-        optics                                < 0.5,
-        pretty-simple                         < 4.2,
-        QuickCheck                           < 2.16,
-        random                                < 1.3,
-        scientific                            < 0.4,
-        semialign                             < 1.4,
-        semigroups                                 ,
-        split                               < 0.2.6,
-        text                                       ,
-        these                                 < 1.3,
-        transformers                               ,
-        type-errors                         < 0.2.1,
-        vector                               < 0.14,
-        vector-binary-instances               < 0.3,
-        vector-split                          < 1.1,
-    else
-      build-depends:
-        base                          >= 4.9 && < 5,
-        adjunctions                           < 4.5,
-        aeson                               ^>= 2.2,
-        aeson-casing                          < 0.3,
-        base64-bytestring                          ,
-        binary                               < 0.11,
-        bifunctors                                 ,
-        bytestring-aeson-orphans             < 0.2,
         -- TODO: remove `blake2` after refactoring of ZK protocols
         blake2                                < 0.4,
-        bytestring                           < 0.13,
-        containers                                 ,
-        constraints                                ,
-        cryptohash-sha256                    < 0.12,
-        deepseq                          <= 1.6.0.0,
-        distributive                               ,
-        generic-random                        < 1.6,
-        hashtables                                 ,
-        infinite-list                              ,
-        lens                                       ,
-        monoidal-containers                        ,
-        mtl                                   < 2.4,
-        optics                                < 0.5,
-        pretty-simple                         < 4.2,
-        QuickCheck                           < 2.16,
-        random                                < 1.3,
-        scientific                            < 0.4,
-        semialign                             < 1.4,
-        semigroups                                 ,
-        split                               < 0.2.6,
-        text                                       ,
-        these                                 < 1.3,
-        transformers                               ,
-        type-errors                         < 0.2.1,
-        vector                               < 0.14,
-        vector-binary-instances               < 0.3,
-        vector-split                          < 1.1,
         openapi3                                   ,
     hs-source-dirs: src
     if arch(wasm32)
-        ghc-options: 
-            -no-hs-main 
-            -optl-mexec-model=reactor 
+        ghc-options:
+            -no-hs-main
+            -optl-mexec-model=reactor
             -optl-Wl,--export=hs_init,-Lrust-wrapper/target/wasm32-unknown-unknown/release/,-lrust_wrapper
-
-
 
 test-suite symbolic-base-test
     import: options-exe
     type: exitcode-stdio-1.0
-    ghc-options: 
+    ghc-options:
         -threaded
         "-with-rtsopts=-A128M -AL256m -qb0 -qn4 -N"
     main-is: Main.hs
@@ -478,7 +437,7 @@ benchmark bench-poly-mul
       tasty-bench,
       vector,
 
-benchmark bench-in-circuit-ec 
+benchmark bench-in-circuit-ec
     import:           options-exe
     main-is:          BenchEC.hs
     hs-source-dirs:   bench


### PR DESCRIPTION
Deduplicate dependencies in `symbolic-base.cabal` to make it simpler working with them.